### PR TITLE
Issue #24 Improve Series Handling / Interface design

### DIFF
--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/barcharts/IBarSeriesData.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/barcharts/IBarSeriesData.java
@@ -15,5 +15,16 @@ import org.eclipse.swtchart.extensions.core.IChartSeriesData;
 
 public interface IBarSeriesData extends IChartSeriesData {
 
+	/**
+	 * @deprecated use {@link #getSettings()} instead
+	 * @return
+	 */
+	@Deprecated
 	IBarSeriesSettings getBarSeriesSettings();
+
+	@Override
+	default IBarSeriesSettings getSettings() {
+
+		return getBarSeriesSettings();
+	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/BaseChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/BaseChart.java
@@ -712,7 +712,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		}
 	}
 
-	private void applySeriesSettings(ISeries dataSeries, ISeriesSettings seriesSettings) {
+	public void applySeriesSettings(ISeries dataSeries, ISeriesSettings seriesSettings) {
 
 		if(dataSeries instanceof ILineSeries) {
 			ILineSeries lineSeries = (ILineSeries)dataSeries;

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/IChartSeriesData.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/IChartSeriesData.java
@@ -14,4 +14,6 @@ package org.eclipse.swtchart.extensions.core;
 public interface IChartSeriesData {
 
 	ISeriesData getSeriesData();
+
+	ISeriesSettings getSettings();
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/IExtendedChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/IExtendedChart.java
@@ -11,8 +11,8 @@
  *******************************************************************************/
 package org.eclipse.swtchart.extensions.core;
 
-import org.eclipse.swtchart.extensions.exceptions.SeriesException;
 import org.eclipse.swtchart.ISeries;
+import org.eclipse.swtchart.extensions.exceptions.SeriesException;
 
 public interface IExtendedChart {
 
@@ -38,11 +38,26 @@ public interface IExtendedChart {
 	void deleteSeries(String id);
 
 	/**
+	 * removes the given series from the chart
+	 * 
+	 * @param seriesData
+	 */
+	default void deleteSeries(IChartSeriesData seriesData) {
+
+		deleteSeries(seriesData.getSeriesData().getId());
+	}
+
+	/**
 	 * Append an existing series with the new arrays.
 	 * 
 	 * @param seriesData
 	 */
 	void appendSeries(ISeriesData seriesData);
+
+	default void appendSeries(IChartSeriesData seriesData) {
+
+		appendSeries(seriesData.getSeriesData());
+	}
 
 	/**
 	 * Sets the range, based on the start and stop coordinates.

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/IScrollableChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/IScrollableChart.java
@@ -11,7 +11,9 @@
  *******************************************************************************/
 package org.eclipse.swtchart.extensions.core;
 
+import org.eclipse.swtchart.ISeries;
 import org.eclipse.swtchart.Range;
+import org.eclipse.swtchart.extensions.exceptions.SeriesException;
 
 public interface IScrollableChart {
 
@@ -20,6 +22,16 @@ public interface IScrollableChart {
 	void applySettings(IChartSettings chartSettings);
 
 	BaseChart getBaseChart();
+
+	default ISeries addSeries(IChartSeriesData chartSeriesData) throws SeriesException {
+
+		ISeriesData seriesData = chartSeriesData.getSeriesData();
+		ISeriesSettings seriesSettings = chartSeriesData.getSettings();
+		BaseChart baseChart = getBaseChart();
+		ISeries series = baseChart.createSeries(seriesData, seriesSettings);
+		baseChart.applySeriesSettings(series, seriesSettings);
+		return series;
+	}
 
 	/**
 	 * Delete all series.

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/exceptions/SeriesException.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/exceptions/SeriesException.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.swtchart.extensions.exceptions;
 
-public class SeriesException extends Exception {
+public class SeriesException extends RuntimeException {
 
 	/**
 	 * Renew this UUID on change.

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/linecharts/ILineSeriesData.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/linecharts/ILineSeriesData.java
@@ -15,5 +15,16 @@ import org.eclipse.swtchart.extensions.core.IChartSeriesData;
 
 public interface ILineSeriesData extends IChartSeriesData {
 
+	/**
+	 * @deprecated use {@link #getSettings()} instead
+	 * @return
+	 */
+	@Deprecated
 	ILineSeriesSettings getLineSeriesSettings();
+
+	@Override
+	default ILineSeriesSettings getSettings() {
+
+		return getLineSeriesSettings();
+	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/scattercharts/IScatterSeriesData.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/scattercharts/IScatterSeriesData.java
@@ -15,5 +15,16 @@ import org.eclipse.swtchart.extensions.core.IChartSeriesData;
 
 public interface IScatterSeriesData extends IChartSeriesData {
 
+	/**
+	 * @deprecated use {@link #getSettings()} instead
+	 * @return
+	 */
+	@Deprecated
 	IScatterSeriesSettings getScatterSeriesSettings();
+
+	@Override
+	default IScatterSeriesSettings getSettings() {
+
+		return getScatterSeriesSettings();
+	}
 }


### PR DESCRIPTION
Signed-off-by: laeubi <laeubi@laeubi-soft.de>

Improves

    the generic handling of series instead of ids
    unify usage of series settings
    make SeriesException a runtime exception because it is more used as an IllegalArgumentException than a real exception one can handle
