### PR TITLE
Remove dependency to org.eclipse.ui by org.eclipse.swtchart.extensions

### DIFF
--- a/org.eclipse.swtchart.cbi/pom.xml
+++ b/org.eclipse.swtchart.cbi/pom.xml
@@ -237,6 +237,9 @@
         <groupId>${tycho.groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <version>${tycho.version}</version>
+        <configuration>
+          <useUIHarness>true</useUIHarness>
+        </configuration> 
       </plugin>
       <plugin>
         <groupId>${maven.groupid}</groupId>

--- a/org.eclipse.swtchart.extensions/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.extensions/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.swtchart.extensions;singleton:=true
 Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.eclipse.swtchart.extensions.Activator
 Bundle-Vendor: Eclipse SWTChart
-Require-Bundle: org.eclipse.ui,
+Require-Bundle: org.eclipse.jface,
  org.eclipse.core.runtime,
  org.eclipse.swtchart;bundle-version="0.8.0",
  org.eclipse.e4.ui.model.workbench;bundle-version="1.1.100",

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/Activator.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/Activator.java
@@ -22,21 +22,27 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
 /**
  * The activator class controls the plug-in life cycle
  */
-public class Activator extends AbstractUIPlugin {
+public class Activator implements BundleActivator {
 
 	public static final String ICON_SET_RANGE = "ICON_SET_RANGE"; // $NON-NLS-1$
 	public static final String ICON_HIDE = "ICON_HIDE"; // $NON-NLS-1$
 	public static final String ICON_RESET = "ICON_RESET"; // $NON-NLS-1$
 	//
 	private static Activator plugin;
+	
+	private ImageRegistry imageRegistry = new ImageRegistry();
+
+	/**
+	 * The bundle associated this plug-in
+	 */
+	private Bundle bundle;
 
 	/**
 	 * The constructor
@@ -50,11 +56,9 @@ public class Activator extends AbstractUIPlugin {
 	 */
 	public void start(BundleContext context) throws Exception {
 
-		super.start(context);
 		plugin = this;
-		if(PlatformUI.isWorkbenchRunning()) {
-			initializeImageRegistry();
-		}
+		this.bundle = context.getBundle();
+		initializeImageRegistry();
 	}
 
 	/*
@@ -64,12 +68,21 @@ public class Activator extends AbstractUIPlugin {
 	public void stop(BundleContext context) throws Exception {
 
 		plugin = null;
-		super.stop(context);
 	}
 
 	public Image getImage(String key) {
 
-		return getImageRegistry().get(key);
+		return imageRegistry.get(key);
+	}
+
+	/**
+	 * Returns the bundle associated with this plug-in.
+	 *
+	 * @return the associated bundle
+	 */
+	public final Bundle getBundle() {
+
+		return bundle;
 	}
 
 	/**
@@ -89,14 +102,8 @@ public class Activator extends AbstractUIPlugin {
 		imageHashMap.put(ICON_HIDE, "icons/16x16/hide.gif"); // $NON-NLS-1$
 		imageHashMap.put(ICON_RESET, "icons/16x16/reset.gif"); // $NON-NLS-1$
 		//
-		ImageRegistry imageRegistry = getImageRegistry();
-		if(imageRegistry != null) {
-			/*
-			 * Set the image/icon values.
-			 */
-			for(Map.Entry<String, String> entry : imageHashMap.entrySet()) {
-				imageRegistry.put(entry.getKey(), createImageDescriptor(getBundle(), entry.getValue()));
-			}
+		for(Map.Entry<String, String> entry : imageHashMap.entrySet()) {
+			imageRegistry.put(entry.getKey(), createImageDescriptor(getBundle(), entry.getValue()));
 		}
 	}
 


### PR DESCRIPTION
Similarly to #51, the extensions bundle has a dependency to
org.eclipse.ui which prevents it from being used in pure e4 RCP
applications. This change removes the dependency.

I am happy to discuss whether the Activator should still have the #getBundle method as it is exposed by the AbstractUIPlugin, but as far as I can see not used in the code base (beside the usage inside the Activator).

To run the tests from the command line, I had to add the ```<useUIHarness>true</useUIHarness>``` to the Tycho Surefire Plugin configuration.