### PR TITLE
Fixed tick label not shown if formatted in non-US locale

### DIFF
--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/AxisTickLabels.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/AxisTickLabels.java
@@ -17,6 +17,7 @@ package org.eclipse.swtchart.internal.axis;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.text.Format;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -411,11 +412,11 @@ public class AxisTickLabels implements PaintListener {
 				// check if the same tick label is repeated
 				String currentLabel = tickLabels.get(i);
 				try {
-					double value = Double.parseDouble(currentLabel);
+					double value = parse(currentLabel);
 					if(value != tickLabelValues.get(i)) {
 						isMajorTick = false;
 					}
-				} catch(NumberFormatException e) {
+				} catch(ParseException e) {
 					// label is not decimal value but string
 				}
 			}
@@ -477,6 +478,17 @@ public class AxisTickLabels implements PaintListener {
 			return new DecimalFormat(DEFAULT_DECIMAL_FORMAT).format(obj);
 		}
 		return format.format(obj);
+	}
+
+	private double parse(String label) throws ParseException {
+
+		if (format == null) {
+			return new DecimalFormat(DEFAULT_DECIMAL_FORMAT).parse(label).doubleValue();
+		}
+		Object parsed = format.parseObject(label);
+		if(!(parsed instanceof Number))
+			throw new ParseException(label, 0);
+		return ((Number)parsed).doubleValue();
 	}
 
 	/**


### PR DESCRIPTION
While updating the tick visibility, AxisTickLabels converts the label
back to a double value. Previously it used Double#parseDouble which is
only parsing values in the Java standard format (local independent).
With this change AxisTickLabels uses the same Format objects that was
used to create the label in the first place.

**Remark:** I have to admit I do not fully understand why the existing code converts the label back to a double to compare with the original. The code comment seems to indicate that it is about *"checking whether the same label repeats"*. But I do not see how the existing code achieves this. Let me know if you prefer a PR that is removing this conversion from label back to double value.