### PR TITLE
Added missing extension to plugin.xml file

### DIFF
--- a/org.eclipse.swtchart.extensions.examples/plugin.xml
+++ b/org.eclipse.swtchart.extensions.examples/plugin.xml
@@ -106,5 +106,19 @@
             MenuEntry="org.eclipse.swtchart.extensions.examples.menu.ResetYAxisHandler">
       </MenuItemSupplier>
    </extension>
-
+	<extension
+         point="org.eclipse.ui.views">
+      <category
+            name="Interactive Chart"
+            id="org.eclipse.swtchart.extensions.examples">
+      </category>
+      <view
+            id="org.eclipse.swtchart.extensions.examples.charts.InteractiveChartExample"
+            name="Interactive Chart"
+            icon="icons/sample.png"
+            class="org.eclipse.swtchart.extensions.examples.charts.InteractiveChartExample"
+            category="org.eclipse.swtchart.extensions.examples"
+            inject="true">
+      </view>
+   </extension>
 </plugin>


### PR DESCRIPTION
InteractiveChartExample from org.eclipse.swtchart.extensions.examples.charts is a ViewPart sub class, but the plug-in's XML markup did not contain the extension point to org.eclipse.ui.views.

Signed-off-by: Himanshu Balasamanta <himanshubb.eee18@itbhu.ac.in>