### PR TITLE
Removed a redundant if-else statement

### DIFF
--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/Axis.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/Axis.java
@@ -111,13 +111,6 @@ public class Axis implements IAxis {
 		position = Position.Primary;
 		min = DEFAULT_MIN;
 		max = DEFAULT_MAX;
-		//The following if-else is present in the AxisTitle,java file, and is hence redundant.
-		//It shall be removed in the next commit.
-		if(direction == Direction.X) {
-			title.setText(Messages.getString(Messages.X_AXIS)); 
-		} else if(direction == Direction.Y) {
-			title.setText(Messages.getString(Messages.Y_AXIS)); 
-		}
 		logScaleEnabled = false;
 		categoryAxisEnabled = false;
 		reversed = false;

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/Axis.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/Axis.java
@@ -111,6 +111,8 @@ public class Axis implements IAxis {
 		position = Position.Primary;
 		min = DEFAULT_MIN;
 		max = DEFAULT_MAX;
+		//The following if-else is present in the AxisTitle,java file, and is hence redundant.
+		//It shall be removed in the next commit.
 		if(direction == Direction.X) {
 			title.setText(Messages.getString(Messages.X_AXIS)); 
 		} else if(direction == Direction.Y) {


### PR DESCRIPTION
The Axis class constructs an AxisTitle object in it's Constructor. This sets the title to the default text as in Messages class. In Axis constructor furthur, the same code is written again. It is not just redundant but also isn't proper decoupling between the two Classes.