### PR TITLE
Fix #154 Don't init colors in constructor for series-settings

### DIFF
--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/AbstractPointSeriesSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/AbstractPointSeriesSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Lablicate GmbH.
+ * Copyright (c) 2017, 2020 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
  * 
  * Contributors:
  * Dr. Philip Wenig - initial API and implementation
+ * Christoph Läubrich - don't initialize colors in constructor
  *******************************************************************************/
 package org.eclipse.swtchart.extensions.core;
 
@@ -24,9 +25,9 @@ public abstract class AbstractPointSeriesSettings extends AbstractSeriesSettings
 	private Color symbolColor;
 
 	public AbstractPointSeriesSettings() {
+
 		symbolType = PlotSymbolType.NONE;
 		symbolSize = 8;
-		symbolColor = Display.getDefault().getSystemColor(SWT.COLOR_BLACK);
 	}
 
 	@Override
@@ -56,6 +57,9 @@ public abstract class AbstractPointSeriesSettings extends AbstractSeriesSettings
 	@Override
 	public Color getSymbolColor() {
 
+		if(symbolColor == null) {
+			return Display.getDefault().getSystemColor(SWT.COLOR_BLACK);
+		}
 		return symbolColor;
 	}
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/linecharts/LineSeriesSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/linecharts/LineSeriesSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Lablicate GmbH.
+ * Copyright (c) 2017, 2020 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
  * 
  * Contributors:
  * Dr. Philip Wenig - initial API and implementation
+ * Christoph Läubrich - don't fetch default color in constructor
  *******************************************************************************/
 package org.eclipse.swtchart.extensions.linecharts;
 
@@ -23,7 +24,7 @@ public class LineSeriesSettings extends AbstractPointSeriesSettings implements I
 
 	private int antialias = SWT.DEFAULT;
 	private boolean enableArea = true;
-	private Color lineColor = Display.getDefault().getSystemColor(SWT.COLOR_RED);
+	private Color lineColor;
 	private int lineWidth = 1;
 	private boolean enableStack = false;
 	private boolean enableStep = false;
@@ -57,6 +58,9 @@ public class LineSeriesSettings extends AbstractPointSeriesSettings implements I
 	@Override
 	public Color getLineColor() {
 
+		if(lineColor == null) {
+			return Display.getDefault().getSystemColor(SWT.COLOR_RED);
+		}
 		return lineColor;
 	}
 


### PR DESCRIPTION
This allows to create new instances outside the Event-Thread, it allows allows to reset the color to the default by calling set with a null argument

Signed-off-by: Christoph Läubrich <laeubi@laeubi-soft.de>