### PR TITLE
Added settings to highlight a node when clicked instead of redrawing it

### DIFF
--- a/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/HighlightedStaticPie.java
+++ b/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/HighlightedStaticPie.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2020 SWTChart project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Himanshu Balasamanta - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.swtchart.customcharts.core;
 
 import org.eclipse.swt.SWT;

--- a/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/HighlightedStaticPie.java
+++ b/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/HighlightedStaticPie.java
@@ -1,0 +1,27 @@
+package org.eclipse.swtchart.customcharts.core;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swtchart.extensions.piecharts.ICircularSeriesData;
+import org.eclipse.swtchart.extensions.piecharts.ICircularSeriesSettings;
+import org.eclipse.swtchart.extensions.piecharts.PieChart;
+
+public class HighlightedStaticPie extends PieChart {
+
+	public HighlightedStaticPie(Composite parent) {
+		super(parent, SWT.NONE);
+	}
+
+	public HighlightedStaticPie(Composite parent, int none) {
+		super(parent, none);
+	}
+
+	public void addSeriesData(ICircularSeriesData model) {
+		ICircularSeriesSettings pieSeriesSettings = (ICircularSeriesSettings) model.getSettings();
+		pieSeriesSettings.setRedrawOnClick(false);
+		pieSeriesSettings.setBorderColor(Display.getDefault().getSystemColor(SWT.COLOR_WHITE));
+		pieSeriesSettings.setHighlightLineWidth(3);
+		super.addSeriesData(model);
+	}
+}

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/HighlightMultiLevelPie.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/HighlightMultiLevelPie.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2020 SWTChart project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Himanshu Balasamanta - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swtchart.examples.advanced;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.ICircularSeries;
+import org.eclipse.swtchart.ISeries.SeriesType;
+
+/**
+ * An example for MultiLevel pie chart.
+ */
+public class HighlightMultiLevelPie {
+
+	private static final String[] continentLabels = {"Asia", "Africa", "North America", "South America", "Antarctica", "Europe", "Australia"};
+	private static final double[] continentValues = {17212000, 11608000, 9365000, 6880000, 5100000, 3837000, 2968000};
+	private static final String[] AsianCountriesLabels = {"China", "Russia", "India"};
+	private static final double[] AsianCountriesValues = {3746887, 5083540, 1269219};
+	private static final String[] AfricanCountriesLabels = {"Algeria", "Congo"};
+	private static final double[] AfricanCountriesValues = {919595, 905355};
+	private static final String[] NorthAmericanCountriesLabels = {"Canada", "USA"};
+	private static final double[] NorthAmericanCountriesValues = {3900261, 3761363};
+	private static final String[] IndianStatesLabels = {"Maharashtra", "Rajasthan", "Uttar Pradesh", "Madhya Pradesh"};
+	private static final double[] IndianStateValues = {92320, 213900, 150580, 192718};
+
+	/**
+	 * The main method.
+	 * 
+	 * @param args
+	 *            the arguments
+	 */
+	public static void main(String[] args) {
+
+		Display display = new Display();
+		Shell shell = new Shell(display);
+		shell.setText("Multi Level Pie Chart");
+		shell.setSize(800, 500);
+		shell.setLayout(new FillLayout());
+		createChart(shell);
+		shell.open();
+		while(!shell.isDisposed()) {
+			if(!display.readAndDispatch()) {
+				display.sleep();
+			}
+		}
+		display.dispose();
+	}
+
+	/**
+	 * create the chart.
+	 * 
+	 * @param parent
+	 *            The parent composite
+	 * @return The created chart
+	 */
+	static public Chart createChart(Composite parent) {
+
+		// create a chart
+		Chart chart = new Chart(parent, SWT.NONE);
+		// set titles
+		chart.getTitle().setText("Multi Level Pie Chart");
+		// create pie series
+		// Doughnut multiLevelPie = (Doughnut)chart.getSeriesSet().createSeries(SeriesType.DOUGHNUT, "countries");
+		ICircularSeries multiLevelPie = (ICircularSeries)chart.getSeriesSet().createSeries(SeriesType.PIE, "countries");
+		// sets the series.
+		multiLevelPie.setSeries(continentLabels, continentValues);
+		// adding Asian countries. These go in as second level
+		multiLevelPie.getNodeById("Asia").addChildren(AsianCountriesLabels, AsianCountriesValues);
+		//
+		multiLevelPie.getNodeById("Africa").addChildren(AfricanCountriesLabels, AfricanCountriesValues);
+		//
+		multiLevelPie.getNodeById("North America").addChildren(NorthAmericanCountriesLabels, NorthAmericanCountriesValues);
+		/*
+		 * Adding Indian states. These go as third level.
+		 * Added to show that those too small for 1 degree, are also made visible
+		 */
+		multiLevelPie.getNodeById("India").addChildren(IndianStatesLabels, IndianStateValues);
+		// Another API
+		multiLevelPie.getNodeById("Europe").addChild("Germany", 137847);
+		// setting the border color
+		multiLevelPie.setBorderColor(Display.getDefault().getSystemColor(SWT.COLOR_WHITE));
+		// setting the Highlight Color
+		multiLevelPie.setHighlightColor(Display.getDefault().getSystemColor(SWT.COLOR_BLACK));
+		// highlighting the node
+		multiLevelPie.setHighlightedNode(multiLevelPie.getNodeById("Russia"));
+		//
+		return chart;
+	}
+}

--- a/org.eclipse.swtchart.extensions.examples/fragment.e4xmi
+++ b/org.eclipse.swtchart.extensions.examples/fragment.e4xmi
@@ -8,7 +8,6 @@
             <children xsi:type="basic:Part" xmi:id="_e5PlkFKeEee9KdU-PVJmHw" elementId="org.eclipse.swtchart.extensions.examples.part.lineseries2" contributionURI="bundleclass://org.eclipse.swtchart.extensions.examples/org.eclipse.swtchart.extensions.examples.parts.LineSeries_2_Part" label="Line Series 2" iconURI="platform:/plugin/org.eclipse.swtchart.extensions.examples/icons/swtchart.gif"/>
             <children xsi:type="basic:Part" xmi:id="_RY_QkFvpEeefC5_PD_lHmw" elementId="org.eclipse.swtchart.extensions.examples.part.lineseries5" contributionURI="bundleclass://org.eclipse.swtchart.extensions.examples/org.eclipse.swtchart.extensions.examples.parts.LineSeries_5_Part" label="Line Series 5" iconURI="platform:/plugin/org.eclipse.swtchart.extensions.examples/icons/swtchart.gif"/>
             <children xsi:type="basic:Part" xmi:id="_TUFgYGViEee3gaHlavhwaA" elementId="org.eclipse.swtchart.extensions.examples.part.lineseries6" contributionURI="bundleclass://org.eclipse.swtchart.extensions.examples/org.eclipse.swtchart.extensions.examples.parts.LineSeries_6_Part" label="Line Series 6" iconURI="platform:/plugin/org.eclipse.swtchart.extensions.examples/icons/swtchart.gif"/>
-            <children xsi:type="basic:Part" xmi:id="_GI2wIMG9EeqpR6SLV6NH5A" elementId="org.eclipse.swtchart.extensions.examples.part.simple" contributionURI="bundleclass://org.eclipse.swtchart.extensions.examples/org.eclipse.swtchart.extensions.examples.parts.SimplePieChart" label="Pie Chart" iconURI="platform:/plugin/org.eclipse.swtchart.extensions.examples/icons/swtchart.gif"/>
           </children>
           <children xsi:type="basic:PartStack" xmi:id="_2Z6CoLzoEeq8Z5UVJV3IcA" elementId="org.eclipse.swtchart.extensions.examples.partstack.18">
             <children xsi:type="basic:Part" xmi:id="_9lgGoLzoEeq8Z5UVJV3IcA" elementId="org.eclipse.swtchart.extensions.examples.part.lineseries1" contributionURI="bundleclass://org.eclipse.swtchart.extensions.examples/org.eclipse.swtchart.extensions.examples.parts.LineSeries_1_Part" label="Line Series 1" iconURI="platform:/plugin/org.eclipse.swtchart.extensions.examples/icons/swtchart.gif"/>
@@ -121,6 +120,18 @@
       <children xsi:type="basic:PartSashContainer" xmi:id="_qk9jYJeKEee0UIXngt5SPA" elementId="org.eclipse.swtchart.extensions.examples.partsashcontainer.14">
         <children xsi:type="basic:PartStack" xmi:id="_w7rN0JeKEee0UIXngt5SPA" elementId="org.eclipse.swtchart.extensions.examples.partstack.17">
           <children xsi:type="basic:Part" xmi:id="_CqarAJeMEee0UIXngt5SPA" elementId="org.eclipse.swtchart.extensions.examples.part.lineseriesselection" contributionURI="bundleclass://org.eclipse.swtchart.extensions.examples/org.eclipse.swtchart.extensions.examples.parts.LineSeries_Selection_Part" label="LineSeries Selection" iconURI="platform:/plugin/org.eclipse.swtchart.extensions.examples/icons/swtchart.gif"/>
+        </children>
+      </children>
+    </elements>
+    <elements xsi:type="advanced:Perspective" xmi:id="_XfAK4NDXEeqhDPrxlDyw8w" elementId="org.eclipse.swtchart.extensions.examples.perspective.demo-swtchartextensionscircularcharts" label="Demo-SWTChart Extensions (Circular Charts)">
+      <children xsi:type="basic:PartSashContainer" xmi:id="_oSxqENDXEeqhDPrxlDyw8w" elementId="org.eclipse.swtchart.extensions.examples.partsashcontainer.15">
+        <children xsi:type="basic:PartSashContainer" xmi:id="_rk9zkNDXEeqhDPrxlDyw8w" elementId="org.eclipse.swtchart.extensions.examples.partsashcontainer.16" horizontal="true">
+          <children xsi:type="basic:PartStack" xmi:id="_sSAfwNDXEeqhDPrxlDyw8w" elementId="org.eclipse.swtchart.extensions.examples.partstack.19">
+            <children xsi:type="basic:Part" xmi:id="_tOA1ANDXEeqhDPrxlDyw8w" elementId="org.eclipse.swtchart.extensions.examples.part.simplepiechart" contributionURI="bundleclass://org.eclipse.swtchart.extensions.examples/org.eclipse.swtchart.extensions.examples.parts.SimplePieChart" label="Simple Pie Chart"/>
+          </children>
+          <children xsi:type="basic:PartStack" xmi:id="_J4ChwNDeEeqhDPrxlDyw8w" elementId="org.eclipse.swtchart.extensions.examples.partstack.20">
+            <children xsi:type="basic:Part" xmi:id="_DO_RgNDbEeqhDPrxlDyw8w" elementId="org.eclipse.swtchart.extensions.examples.part.highlightedpiechart" contributionURI="bundleclass://org.eclipse.swtchart.extensions.examples/org.eclipse.swtchart.extensions.examples.parts.HighlightedPieChart_Part" label="HighLighted Pie Chart"/>
+          </children>
         </children>
       </children>
     </elements>

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/InteractivePieChart.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/InteractivePieChart.java
@@ -27,6 +27,7 @@ public class InteractivePieChart {
 		shell.setSize(700, 600);
 		shell.setLayout(new FillLayout());
 		//
+		// new HighlightedPieChart_Part(shell);
 		new SimplePieChart(shell);
 		shell.open();
 		//

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/HighlightedPieChart_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/HighlightedPieChart_Part.java
@@ -1,5 +1,3 @@
-package org.eclipse.swtchart.extensions.examples.parts;
-
 /*******************************************************************************
  * Copyright (c) 2020 SWTChart project.
  *
@@ -12,6 +10,8 @@ package org.eclipse.swtchart.extensions.examples.parts;
  * Contributors:
  * Himanshu Balasamanta Orignal API and implementation
  *******************************************************************************/
+package org.eclipse.swtchart.extensions.examples.parts;
+
 import javax.inject.Inject;
 
 import org.eclipse.swt.SWT;

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/HighlightedPieChart_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/HighlightedPieChart_Part.java
@@ -1,0 +1,88 @@
+package org.eclipse.swtchart.extensions.examples.parts;
+
+/*******************************************************************************
+ * Copyright (c) 2020 SWTChart project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Himanshu Balasamanta Orignal API and implementation
+ *******************************************************************************/
+import javax.inject.Inject;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swtchart.ISeries.SeriesType;
+import org.eclipse.swtchart.customcharts.core.HighlightedStaticPie;
+import org.eclipse.swtchart.extensions.piecharts.CircularSeriesData;
+import org.eclipse.swtchart.extensions.piecharts.ICircularSeriesData;
+import org.eclipse.swtchart.extensions.piecharts.ICircularSeriesSettings;
+
+public class HighlightedPieChart_Part extends HighlightedStaticPie {
+
+	private static final String[] continentLabels = {"Asia", "Africa", "North America", "South America", "Antarctica", "Europe", "Australia"};
+	private static final double[] continentValues = {17212000, 11608000, 9365000, 6880000, 5100000, 3837000, 2968000};
+	private static final String[] AsianCountriesLabels = {"China", "Russia", "India"};
+	private static final double[] AsianCountriesValues = {3746887, 5083540, 1269219};
+	private static final String[] AfricanCountriesLabels = {"Algeria", "Congo"};
+	private static final double[] AfricanCountriesValues = {919595, 905355};
+	private static final String[] NorthAmericanCountriesLabels = {"Canada", "USA"};
+	private static final double[] NorthAmericanCountriesValues = {3900261, 3761363};
+	private static final String[] IndianStatesLabels = {"Maharashtra", "Rajasthan", "Uttar Pradesh", "Madhya Pradesh"};
+	private static final double[] IndianStateValues = {92320, 213900, 150580, 192718};
+
+	@Inject
+	public HighlightedPieChart_Part(Composite parent) {
+
+		super(parent, SWT.NONE);
+		setBackground(getDisplay().getSystemColor(SWT.COLOR_WHITE));
+		try {
+			initialize();
+		} catch(Exception e) {
+			System.out.println(e);
+		}
+	}
+
+	private void initialize() throws Exception {
+
+		/*
+		 * Create series.
+		 */
+		ICircularSeriesData multiLevelDoughnut = new CircularSeriesData();
+		//
+		multiLevelDoughnut.setId("World");
+		multiLevelDoughnut.setNodeClass("Landmass Name");
+		multiLevelDoughnut.setValueClass("Area in sq miles");
+		//
+		multiLevelDoughnut.setSeries(continentLabels, continentValues);
+		// adding Asian countries. These go in as second level
+		multiLevelDoughnut.getNodeById("Asia").addChildren(AsianCountriesLabels, AsianCountriesValues);
+		//
+		multiLevelDoughnut.getNodeById("Africa").addChildren(AfricanCountriesLabels, AfricanCountriesValues);
+		//
+		multiLevelDoughnut.getNodeById("North America").addChildren(NorthAmericanCountriesLabels, NorthAmericanCountriesValues);
+		/*
+		 * Adding Indian states. These go as third level.
+		 * Added to show that those too small for 1 degree, are also made visible
+		 */
+		multiLevelDoughnut.getNodeById("India").addChildren(IndianStatesLabels, IndianStateValues);
+		// Another API
+		multiLevelDoughnut.getNodeById("Europe").addChild("Germany", 137847);
+		//
+		//
+		ICircularSeriesSettings settings = multiLevelDoughnut.getSettings();
+		settings.setDescription("Landmass Distribultion");
+		settings.setBorderStyle(SWT.LINE_SOLID);
+		//
+		multiLevelDoughnut.getSettings().setSeriesType(SeriesType.DOUGHNUT);
+		/*
+		 * Set series.
+		 * ICircularSeriesData
+		 */
+		addSeriesData(multiLevelDoughnut);
+	}
+}

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/BaseChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/BaseChart.java
@@ -45,6 +45,7 @@ import org.eclipse.swtchart.Range;
 import org.eclipse.swtchart.extensions.barcharts.IBarSeriesSettings;
 import org.eclipse.swtchart.extensions.events.IEventProcessor;
 import org.eclipse.swtchart.extensions.events.IHandledEventProcessor;
+import org.eclipse.swtchart.extensions.events.MouseDownEvent;
 import org.eclipse.swtchart.extensions.exceptions.SeriesException;
 import org.eclipse.swtchart.extensions.linecharts.ILineSeriesSettings;
 import org.eclipse.swtchart.extensions.piecharts.ICircularSeriesSettings;
@@ -736,6 +737,8 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		pieSeries.setBorderWidth(pieSeriesSettings.getBorderWidth());
 		pieSeries.setBorderStyle(pieSeriesSettings.getBorderStyle());
 		this.getTitle().setText(pieSeriesSettings.getDescription());
+		pieSeries.setHighlightLineWidth(pieSeriesSettings.getHighlightLineWidth());
+		((MouseDownEvent)registeredEvents.get(EVENT_MOUSE_DOWN).get(1).get(SWT.NONE).get(0)).setRedrawOnClick(pieSeriesSettings.isRedrawOnClick());
 		// add one for doughnut chart.
 		/*
 		 * MORE TO COME!!! STAY TUNED:)

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseDownEvent.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseDownEvent.java
@@ -14,15 +14,17 @@ package org.eclipse.swtchart.extensions.events;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Event;
+import org.eclipse.swtchart.ICircularSeries;
 import org.eclipse.swtchart.ISeries;
 import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.swtchart.extensions.core.IExtendedChart;
 import org.eclipse.swtchart.extensions.core.IMouseSupport;
 import org.eclipse.swtchart.internal.series.CircularSeries;
-import org.eclipse.swtchart.internal.series.Pie;
 import org.eclipse.swtchart.model.Node;
 
 public class MouseDownEvent extends AbstractHandledEventProcessor implements IHandledEventProcessor {
+
+	private boolean redrawOnClick = true;
 
 	@Override
 	public int getEvent() {
@@ -42,40 +44,40 @@ public class MouseDownEvent extends AbstractHandledEventProcessor implements IHa
 		return SWT.NONE;
 	}
 
+	public void setRedrawOnClick(boolean redraw) {
+
+		this.redrawOnClick = redraw;
+	}
+
+	public boolean isRedrawOnClick() {
+
+		return redrawOnClick;
+	}
+
 	@Override
 	public void handleEvent(BaseChart baseChart, Event event) {
 
 		/*
-		 * To recognise the node where the click event occured, and redraw.
+		 * To recognise the node where the click event occurred, and redraw.
 		 */
 		if(baseChart.isCircularChart()) {
 			for(ISeries series : baseChart.getSeriesSet().getSeries()) {
 				if(series instanceof CircularSeries) {
 					double primaryValueX = baseChart.getSelectedPrimaryAxisValue(event.x, IExtendedChart.X_AXIS);
 					double primaryValueY = baseChart.getSelectedPrimaryAxisValue(event.y, IExtendedChart.Y_AXIS);
-					double radius = Math.sqrt(primaryValueX * primaryValueX + primaryValueY * primaryValueY);
-					int level = ((int)radius) + 1 - (series instanceof Pie ? 0 : 1);
-					Node node = null;
-					double angleOfInspection = Math.atan2(primaryValueY, primaryValueX);
-					if(angleOfInspection < 0.0)
-						angleOfInspection += 2 * Math.PI;
-					if(level < ((CircularSeries)series).getModel().getNodes().length)
-						for(Node noda : ((CircularSeries)series).getModel().getNodes()[level]) {
-							double lowerBound = (noda.getAngleBounds().x * Math.PI) / (double)180.0;
-							double upperBound = ((noda.getAngleBounds().x + noda.getAngleBounds().y) * Math.PI) / (double)180.0;
-							if((lowerBound <= angleOfInspection) && (upperBound >= angleOfInspection)) {
-								node = noda;
-								break;
-							}
-						}
+					Node node = ((ICircularSeries)series).getPieSliceFromPosition(primaryValueX, primaryValueY);
+					if(!redrawOnClick) {
+						((CircularSeries)series).setHighlightedNode(node);
+						break;
+					}
 					if(node != null) {
 						// redraw from parent node, if clicked on the center of the Doughnut Chart.
-						if(((CircularSeries)series).getModel().getRootPointer() == node) {
-							((CircularSeries)series).getModel().setRootPointer(node.getParent());
+						if(((CircularSeries)series).getRootPointer() == node) {
+							((CircularSeries)series).setRootPointer(node.getParent());
 						}
 						// redraw form the node where it is clicked on.
 						else {
-							((CircularSeries)series).getModel().setRootPointer(node);
+							((CircularSeries)series).setRootPointer(node);
 						}
 					}
 					/*
@@ -84,7 +86,7 @@ public class MouseDownEvent extends AbstractHandledEventProcessor implements IHa
 					 * Works for Doughnut chart as well.
 					 */
 					else {
-						((CircularSeries)series).getModel().setRootPointer(((CircularSeries)series).getRootNode());
+						((CircularSeries)series).setRootPointer(((CircularSeries)series).getRootNode());
 					}
 				}
 			}

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/marker/LegendMarker.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/marker/LegendMarker.java
@@ -25,7 +25,6 @@ import org.eclipse.swtchart.extensions.core.IExtendedChart;
 import org.eclipse.swtchart.extensions.marker.AbstractPositionPaintListener;
 import org.eclipse.swtchart.extensions.marker.IPositionPaintListener;
 import org.eclipse.swtchart.internal.series.CircularSeries;
-import org.eclipse.swtchart.internal.series.Pie;
 import org.eclipse.swtchart.model.Node;
 
 public class LegendMarker extends AbstractPositionPaintListener implements IPositionPaintListener {
@@ -76,21 +75,7 @@ public class LegendMarker extends AbstractPositionPaintListener implements IPosi
 
 	private void drawNodes(double primaryValueX, double primaryValueY, CircularSeries series) {
 
-		double radius = Math.sqrt(primaryValueX * primaryValueX + primaryValueY * primaryValueY);
-		int level = ((int)radius) + 1 - (series instanceof Pie ? 0 : 1);
-		Node node = null;
-		double angleOfInspection = Math.atan2(primaryValueY, primaryValueX);
-		if(angleOfInspection < 0.0)
-			angleOfInspection += 2 * Math.PI;
-		if(level < series.getModel().getNodes().length)
-			for(Node noda : series.getModel().getNodes()[level]) {
-				double lowerBound = (noda.getAngleBounds().x * Math.PI) / (double)180.0;
-				double upperBound = ((noda.getAngleBounds().x + noda.getAngleBounds().y) * Math.PI) / (double)180.0;
-				if((lowerBound <= angleOfInspection) && (upperBound >= angleOfInspection)) {
-					node = noda;
-					break;
-				}
-			}
+		Node node = series.getPieSliceFromPosition(primaryValueX, primaryValueY);
 		String id = "---", val = "---", percentage = "---";
 		if(node != null) {
 			id = node.getId();

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/CircularSeriesSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/CircularSeriesSettings.java
@@ -23,14 +23,18 @@ public class CircularSeriesSettings extends AbstractSeriesSettings implements IC
 
 	private Color borderColor;
 	private int borderWidth;
+	private int highlightLineWidth;
 	private int borderStyle;
 	private SeriesType type;
+	private boolean redrawOnClick;
 
 	public CircularSeriesSettings() {
 
 		borderColor = Display.getDefault().getSystemColor(SWT.COLOR_BLACK);
 		borderWidth = 1;
+		highlightLineWidth = 2;
 		borderStyle = SWT.LINE_SOLID;
+		redrawOnClick = true;
 		type = SeriesType.PIE;
 	}
 
@@ -86,5 +90,29 @@ public class CircularSeriesSettings extends AbstractSeriesSettings implements IC
 	public SeriesType getSeriesType() {
 
 		return type;
+	}
+
+	@Override
+	public void setRedrawOnClick(boolean redraw) {
+
+		this.redrawOnClick = redraw;
+	}
+
+	@Override
+	public boolean isRedrawOnClick() {
+
+		return redrawOnClick;
+	}
+
+	@Override
+	public void setHighlightLineWidth(int width) {
+
+		this.highlightLineWidth = width;
+	}
+
+	@Override
+	public int getHighlightLineWidth() {
+
+		return highlightLineWidth;
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/ICircularSeriesSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/ICircularSeriesSettings.java
@@ -36,4 +36,12 @@ public interface ICircularSeriesSettings {
 	public void setDescription(String id);
 
 	public String getDescription();
+
+	public void setRedrawOnClick(boolean redraw);
+
+	public boolean isRedrawOnClick();
+
+	public void setHighlightLineWidth(int width);
+
+	public int getHighlightLineWidth();
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/PieChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/PieChart.java
@@ -21,8 +21,13 @@ import org.eclipse.swtchart.extensions.core.IChartSettings;
 import org.eclipse.swtchart.extensions.core.IPrimaryAxisSettings;
 import org.eclipse.swtchart.extensions.core.ScrollableChart;
 import org.eclipse.swtchart.extensions.exceptions.SeriesException;
+import org.eclipse.swtchart.model.Node;
 
 public class PieChart extends ScrollableChart {
+
+	private Node rootNode;
+	private Node rootPointer;
+	private ICircularSeriesData data;
 
 	public PieChart() {
 
@@ -39,14 +44,18 @@ public class PieChart extends ScrollableChart {
 		/*
 		 * Suspend the update when adding new data to improve the performance.
 		 */
+		this.data = model;
 		if(model != null && model.getRootNode() != null) {
 			BaseChart baseChart = getBaseChart();
+			this.rootNode = model.getRootNode();
+			this.rootPointer = rootNode;
 			baseChart.suspendUpdate(true);
 			/*
 			 * Get the series data and apply the settings.
 			 */
 			try {
 				ICircularSeriesSettings pieSeriesSettings = (ICircularSeriesSettings)model.getSettings();
+				//
 				IChartSettings chartSettings = getChartSettings();
 				//
 				chartSettings.setHorizontalSliderVisible(false);

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/ICircularSeries.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/ICircularSeries.java
@@ -154,4 +154,46 @@ public interface ICircularSeries extends ISeries {
 	 * @return the number of levels the data model has.
 	 */
 	public int getMaxTreeDepth();
+
+	/**
+	 * Call to this function happens when the node where an
+	 * event fired does not have to redraw the entire chart.
+	 */
+	public void setHighlightedNode(Node highlightedNode);
+
+	/** gets the node to highlight */
+	public Node getHighlightedNode();
+
+	/**
+	 * sets the border color for the node to be highlighted.
+	 * 
+	 * @param color
+	 */
+	public void setHighlightColor(Color color);
+
+	/**
+	 * 
+	 * @param primaryValueX
+	 * @param primaryValueY
+	 * @return
+	 */
+	public Node getPieSliceFromPosition(double primaryValueX, double primaryValueY);
+
+	/**
+	 * 
+	 * @param id
+	 * @return the percent that the pie slice is compared to the rootPointer
+	 */
+	public double getSlicePercent(String id);
+
+	/**
+	 * x and y are in pixels
+	 * 
+	 * @param x
+	 * @param y
+	 * @return
+	 */
+	public Node getPieSliceFromPosition(int x, int y);
+
+	void setHighlightLineWidth(int width);
 }

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/series/Doughnut.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/series/Doughnut.java
@@ -126,4 +126,24 @@ public class Doughnut extends CircularSeries {
 		maxTreeDepth = rootNode.getMaxSubTreeDepth() - 1;
 		return new Range(-maxTreeDepth - 1, maxTreeDepth + 1);
 	}
+
+	public Node getPieSliceFromPosition(double primaryValueX, double primaryValueY) {
+
+		double radius = Math.sqrt(primaryValueX * primaryValueX + primaryValueY * primaryValueY);
+		int level = ((int)radius);
+		Node node = null;
+		double angleOfInspection = Math.atan2(primaryValueY, primaryValueX);
+		if(angleOfInspection < 0.0)
+			angleOfInspection += 2 * Math.PI;
+		if(level < getModel().getNodes().length)
+			for(Node noda : getModel().getNodes()[level]) {
+				double lowerBound = (noda.getAngleBounds().x * Math.PI) / (double)180.0;
+				double upperBound = ((noda.getAngleBounds().x + noda.getAngleBounds().y) * Math.PI) / (double)180.0;
+				if((lowerBound <= angleOfInspection) && (upperBound >= angleOfInspection)) {
+					node = noda;
+					break;
+				}
+			}
+		return node;
+	}
 }

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/series/Pie.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/series/Pie.java
@@ -124,4 +124,24 @@ public class Pie extends CircularSeries {
 		maxTreeDepth = rootPointer.getMaxSubTreeDepth() - 1;
 		return new Range(-maxTreeDepth, maxTreeDepth);
 	}
+
+	public Node getPieSliceFromPosition(double primaryValueX, double primaryValueY) {
+
+		double radius = Math.sqrt(primaryValueX * primaryValueX + primaryValueY * primaryValueY);
+		int level = ((int)radius) + 1;
+		Node node = null;
+		double angleOfInspection = Math.atan2(primaryValueY, primaryValueX);
+		if(angleOfInspection < 0.0)
+			angleOfInspection += 2 * Math.PI;
+		if(level < getModel().getNodes().length)
+			for(Node noda : getModel().getNodes()[level]) {
+				double lowerBound = (noda.getAngleBounds().x * Math.PI) / (double)180.0;
+				double upperBound = ((noda.getAngleBounds().x + noda.getAngleBounds().y) * Math.PI) / (double)180.0;
+				if((lowerBound <= angleOfInspection) && (upperBound >= angleOfInspection)) {
+					node = noda;
+					break;
+				}
+			}
+		return node;
+	}
 }


### PR DESCRIPTION
- The API to allow the user set a node to highlight is provided through `ICircularSeries.setHighlightedNode(Node node);`
- The API to retrieve the highlighted node can be accessed through `ICircularSeries.getHighlightedNode();`
- The customisation of highlighted node's boundary line colour and boundary line width can be customised though ICircularChartSettings or ICircularSeries
- User has the option to set what happens when a node is clicked on.. Highlight or redraw from it, by setting `ICircularSeriesSettings.setRedrawOnClick(boolean);` to false or true.
- API to get the Pie Slice (Node) from a given position is implemented by both `ICircularSeries.getPieSliceFromPosition(double x, double y)` , and `ICircularSeries.getPieSliceFromPosition(int x, int y)`.
- API to get the percentage that a particular PieSlice is of the rootPointer node is available at `ICircularSeries.getSlicePercent(String id);`
- Custom chart was created to highlight nodes when clicked upon. (May be changed or even removed if anyone has any issues with it.)
- Example part was created for the custom chart.
- The circular series now makes most use of the space available to it... (This may look weird, so maybe we should allow a setting for it.)