### PR TITLE
Allow tick labels to display even with lossy formatters

### DIFF
--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/AxisTickLabels.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/AxisTickLabels.java
@@ -413,9 +413,12 @@ public class AxisTickLabels implements PaintListener {
 				String currentLabel = tickLabels.get(i);
 				try {
 					double value = parse(currentLabel);
-					if(value != tickLabelValues.get(i)) {
-						isMajorTick = false;
-					}
+					/*
+					 * Check if the value is close to the tick label, then it is a major tick
+					 */
+					double diff = Math.abs((value - tickLabelValues.get(i)) / value);
+					double maximumDelta = 0.01;
+					isMajorTick = (diff <= maximumDelta);
 				} catch(ParseException e) {
 					// label is not decimal value but string
 				}


### PR DESCRIPTION
Handle significant digits, assume that if a value is within 1% (arbitrary)

Fixes https://github.com/eclipse/swtchart/issues/214

Signed-off-by: Matthew Khouzam <matthew.khouzam@ericsson.com>