### PR TITLE
Added new Mouse Down Event Listener for CircularCharts

### DIFF
--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/BaseChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/BaseChart.java
@@ -739,6 +739,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		this.getTitle().setText(pieSeriesSettings.getDescription());
 		pieSeries.setHighlightLineWidth(pieSeriesSettings.getHighlightLineWidth());
 		((MouseDownEvent)registeredEvents.get(EVENT_MOUSE_DOWN).get(1).get(SWT.NONE).get(0)).setRedrawOnClick(pieSeriesSettings.isRedrawOnClick());
+		((MouseDownEvent)registeredEvents.get(EVENT_MOUSE_DOWN).get(1).get(SWT.NONE).get(0)).setFillEntireSpace(pieSeriesSettings.isEntireSpaceFilled());
 		// add one for doughnut chart.
 		/*
 		 * MORE TO COME!!! STAY TUNED:)

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/BaseChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/BaseChart.java
@@ -738,12 +738,12 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		pieSeries.setBorderStyle(pieSeriesSettings.getBorderStyle());
 		this.getTitle().setText(pieSeriesSettings.getDescription());
 		pieSeries.setHighlightLineWidth(pieSeriesSettings.getHighlightLineWidth());
-		((CircularMouseDownEvent)registeredEvents.get(EVENT_MOUSE_DOWN).get(1).get(SWT.NONE).get(0)).setRedrawOnClick(pieSeriesSettings.isRedrawOnClick());
-		((CircularMouseDownEvent)registeredEvents.get(EVENT_MOUSE_DOWN).get(1).get(SWT.NONE).get(0)).setFillEntireSpace(pieSeriesSettings.isEntireSpaceFilled());
-		// add one for doughnut chart.
-		/*
-		 * MORE TO COME!!! STAY TUNED:)
-		 */
+		IHandledEventProcessor processor = (IHandledEventProcessor)registeredEvents.get(EVENT_MOUSE_DOWN).get(1).get(SWT.NONE).get(0);
+		if(processor instanceof CircularMouseDownEvent) {
+			CircularMouseDownEvent mouseDownEvent = ((CircularMouseDownEvent)registeredEvents.get(EVENT_MOUSE_DOWN).get(1).get(SWT.NONE).get(0));
+			mouseDownEvent.setRedrawOnClick(pieSeriesSettings.isRedrawOnClick());
+			mouseDownEvent.setFillEntireSpace(pieSeriesSettings.isEntireSpaceFilled());
+		}
 	}
 
 	public List<double[]> getDataShiftHistory(String selectedSeriesId) {

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/BaseChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/BaseChart.java
@@ -43,9 +43,9 @@ import org.eclipse.swtchart.ITitle;
 import org.eclipse.swtchart.LineStyle;
 import org.eclipse.swtchart.Range;
 import org.eclipse.swtchart.extensions.barcharts.IBarSeriesSettings;
+import org.eclipse.swtchart.extensions.events.CircularMouseDownEvent;
 import org.eclipse.swtchart.extensions.events.IEventProcessor;
 import org.eclipse.swtchart.extensions.events.IHandledEventProcessor;
-import org.eclipse.swtchart.extensions.events.MouseDownEvent;
 import org.eclipse.swtchart.extensions.exceptions.SeriesException;
 import org.eclipse.swtchart.extensions.linecharts.ILineSeriesSettings;
 import org.eclipse.swtchart.extensions.piecharts.ICircularSeriesSettings;
@@ -738,8 +738,8 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		pieSeries.setBorderStyle(pieSeriesSettings.getBorderStyle());
 		this.getTitle().setText(pieSeriesSettings.getDescription());
 		pieSeries.setHighlightLineWidth(pieSeriesSettings.getHighlightLineWidth());
-		((MouseDownEvent)registeredEvents.get(EVENT_MOUSE_DOWN).get(1).get(SWT.NONE).get(0)).setRedrawOnClick(pieSeriesSettings.isRedrawOnClick());
-		((MouseDownEvent)registeredEvents.get(EVENT_MOUSE_DOWN).get(1).get(SWT.NONE).get(0)).setFillEntireSpace(pieSeriesSettings.isEntireSpaceFilled());
+		((CircularMouseDownEvent)registeredEvents.get(EVENT_MOUSE_DOWN).get(1).get(SWT.NONE).get(0)).setRedrawOnClick(pieSeriesSettings.isRedrawOnClick());
+		((CircularMouseDownEvent)registeredEvents.get(EVENT_MOUSE_DOWN).get(1).get(SWT.NONE).get(0)).setFillEntireSpace(pieSeriesSettings.isEntireSpaceFilled());
 		// add one for doughnut chart.
 		/*
 		 * MORE TO COME!!! STAY TUNED:)

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/CircularMouseDownEvent.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/CircularMouseDownEvent.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2020 SWTChart project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Himanshu Balasamanta: Orignal API and implementation
+ *******************************************************************************/
 package org.eclipse.swtchart.extensions.events;
 
 import org.eclipse.swt.SWT;

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseDownEvent.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseDownEvent.java
@@ -25,6 +25,7 @@ import org.eclipse.swtchart.model.Node;
 public class MouseDownEvent extends AbstractHandledEventProcessor implements IHandledEventProcessor {
 
 	private boolean redrawOnClick = true;
+	private boolean fillEntireSpace = false;
 
 	@Override
 	public int getEvent() {
@@ -46,12 +47,12 @@ public class MouseDownEvent extends AbstractHandledEventProcessor implements IHa
 
 	public void setRedrawOnClick(boolean redraw) {
 
-		this.redrawOnClick = redraw;
+		redrawOnClick = redraw;
 	}
 
-	public boolean isRedrawOnClick() {
+	public void setFillEntireSpace(boolean fillEntireSpace) {
 
-		return redrawOnClick;
+		this.fillEntireSpace = fillEntireSpace;
 	}
 
 	@Override
@@ -73,11 +74,17 @@ public class MouseDownEvent extends AbstractHandledEventProcessor implements IHa
 					if(node != null) {
 						// redraw from parent node, if clicked on the center of the Doughnut Chart.
 						if(((CircularSeries)series).getRootPointer() == node) {
-							((CircularSeries)series).setRootPointer(node.getParent());
+							if(!fillEntireSpace)
+								((CircularSeries)series).getModel().setRootPointer(node.getParent());
+							else
+								((CircularSeries)series).setRootPointer(node.getParent());
 						}
 						// redraw form the node where it is clicked on.
 						else {
-							((CircularSeries)series).setRootPointer(node);
+							if(!fillEntireSpace)
+								((CircularSeries)series).getModel().setRootPointer(node);
+							else
+								((CircularSeries)series).setRootPointer(node);
 						}
 					}
 					/*

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseDownEvent.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseDownEvent.java
@@ -41,43 +41,6 @@ public class MouseDownEvent extends AbstractHandledEventProcessor implements IHa
 	public void handleEvent(BaseChart baseChart, Event event) {
 
 		/*
-<<<<<<< HEAD
-=======
-		 * To recognise the node where the click event occurred, and redraw.
-		 */
-		if(baseChart.isCircularChart()) {
-			for(ISeries<?> series : baseChart.getSeriesSet().getSeries()) {
-				if(series instanceof CircularSeries) {
-					double primaryValueX = baseChart.getSelectedPrimaryAxisValue(event.x, IExtendedChart.X_AXIS);
-					double primaryValueY = baseChart.getSelectedPrimaryAxisValue(event.y, IExtendedChart.Y_AXIS);
-					Node node = ((ICircularSeries<?>)series).getPieSliceFromPosition(primaryValueX, primaryValueY);
-					if(!redrawOnClick) {
-						((CircularSeries)series).setHighlightedNode(node);
-						break;
-					}
-					if(node != null) {
-						// redraw from parent node, if clicked on the center of the Doughnut Chart.
-						if(((CircularSeries)series).getRootPointer() == node) {
-							((CircularSeries)series).setRootPointer(node.getParent());
-						}
-						// redraw form the node where it is clicked on.
-						else {
-							((CircularSeries)series).setRootPointer(node);
-						}
-					}
-					/*
-					 * redraw from rootNode if clicked elsewhere.
-					 * (The only way to redraw a pieChart from an ancestor node.)
-					 * Works for Doughnut chart as well.
-					 */
-					else {
-						((CircularSeries)series).setRootPointer(((CircularSeries)series).getRootNode());
-					}
-				}
-			}
-		}
-		/*
->>>>>>> upstream/develop
 		 * Activate the selection if the user made a single click.
 		 */
 		if(isSingleClick(event)) {

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseDownEvent.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseDownEvent.java
@@ -14,18 +14,10 @@ package org.eclipse.swtchart.extensions.events;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Event;
-import org.eclipse.swtchart.ICircularSeries;
-import org.eclipse.swtchart.ISeries;
 import org.eclipse.swtchart.extensions.core.BaseChart;
-import org.eclipse.swtchart.extensions.core.IExtendedChart;
 import org.eclipse.swtchart.extensions.core.IMouseSupport;
-import org.eclipse.swtchart.internal.series.CircularSeries;
-import org.eclipse.swtchart.model.Node;
 
 public class MouseDownEvent extends AbstractHandledEventProcessor implements IHandledEventProcessor {
-
-	private boolean redrawOnClick = true;
-	private boolean fillEntireSpace = false;
 
 	@Override
 	public int getEvent() {
@@ -45,63 +37,13 @@ public class MouseDownEvent extends AbstractHandledEventProcessor implements IHa
 		return SWT.NONE;
 	}
 
-	public void setRedrawOnClick(boolean redraw) {
-
-		redrawOnClick = redraw;
-	}
-
-	public void setFillEntireSpace(boolean fillEntireSpace) {
-
-		this.fillEntireSpace = fillEntireSpace;
-	}
-
 	@Override
 	public void handleEvent(BaseChart baseChart, Event event) {
 
 		/*
-		 * To recognise the node where the click event occurred, and redraw.
-		 */
-		if(baseChart.isCircularChart()) {
-			for(ISeries series : baseChart.getSeriesSet().getSeries()) {
-				if(series instanceof CircularSeries) {
-					double primaryValueX = baseChart.getSelectedPrimaryAxisValue(event.x, IExtendedChart.X_AXIS);
-					double primaryValueY = baseChart.getSelectedPrimaryAxisValue(event.y, IExtendedChart.Y_AXIS);
-					Node node = ((ICircularSeries)series).getPieSliceFromPosition(primaryValueX, primaryValueY);
-					if(!redrawOnClick) {
-						((CircularSeries)series).setHighlightedNode(node);
-						break;
-					}
-					if(node != null) {
-						// redraw from parent node, if clicked on the center of the Doughnut Chart.
-						if(((CircularSeries)series).getRootPointer() == node) {
-							if(!fillEntireSpace)
-								((CircularSeries)series).getModel().setRootPointer(node.getParent());
-							else
-								((CircularSeries)series).setRootPointer(node.getParent());
-						}
-						// redraw form the node where it is clicked on.
-						else {
-							if(!fillEntireSpace)
-								((CircularSeries)series).getModel().setRootPointer(node);
-							else
-								((CircularSeries)series).setRootPointer(node);
-						}
-					}
-					/*
-					 * redraw from rootNode if clicked elsewhere.
-					 * (The only way to redraw a pieChart from an ancestor node.)
-					 * Works for Doughnut chart as well.
-					 */
-					else {
-						((CircularSeries)series).setRootPointer(((CircularSeries)series).getRootNode());
-					}
-				}
-			}
-		}
-		/*
 		 * Activate the selection if the user made a single click.
 		 */
-		else if(isSingleClick(event)) {
+		if(isSingleClick(event)) {
 			baseChart.getUserSelection().setStartCoordinate(event.x, event.y);
 			baseChart.setClickStartTime(System.currentTimeMillis());
 		} else {

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/CircularSeriesSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/CircularSeriesSettings.java
@@ -27,6 +27,7 @@ public class CircularSeriesSettings extends AbstractSeriesSettings implements IC
 	private int borderStyle;
 	private SeriesType type;
 	private boolean redrawOnClick;
+	private boolean fillEntireSpace;
 
 	public CircularSeriesSettings() {
 
@@ -35,6 +36,7 @@ public class CircularSeriesSettings extends AbstractSeriesSettings implements IC
 		highlightLineWidth = 2;
 		borderStyle = SWT.LINE_SOLID;
 		redrawOnClick = true;
+		fillEntireSpace = false;
 		type = SeriesType.PIE;
 	}
 
@@ -114,5 +116,17 @@ public class CircularSeriesSettings extends AbstractSeriesSettings implements IC
 	public int getHighlightLineWidth() {
 
 		return highlightLineWidth;
+	}
+
+	@Override
+	public void setFillEntireSpace(boolean fillEntireSpace) {
+
+		this.fillEntireSpace = fillEntireSpace;
+	}
+
+	@Override
+	public boolean isEntireSpaceFilled() {
+
+		return fillEntireSpace;
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/ICircularSeriesSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/ICircularSeriesSettings.java
@@ -41,6 +41,10 @@ public interface ICircularSeriesSettings {
 
 	public boolean isRedrawOnClick();
 
+	public void setFillEntireSpace(boolean fillEntireSpace);
+
+	public boolean isEntireSpaceFilled();
+
 	public void setHighlightLineWidth(int width);
 
 	public int getHighlightLineWidth();

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/PieChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/PieChart.java
@@ -20,6 +20,9 @@ import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.swtchart.extensions.core.IChartSettings;
 import org.eclipse.swtchart.extensions.core.IPrimaryAxisSettings;
 import org.eclipse.swtchart.extensions.core.ScrollableChart;
+import org.eclipse.swtchart.extensions.events.CircularMouseDownEvent;
+import org.eclipse.swtchart.extensions.events.IHandledEventProcessor;
+import org.eclipse.swtchart.extensions.events.MouseDownEvent;
 import org.eclipse.swtchart.extensions.exceptions.SeriesException;
 import org.eclipse.swtchart.model.Node;
 
@@ -76,6 +79,19 @@ public class PieChart extends ScrollableChart {
 				chartSettings.setShowLegendMarker(true);
 				chartSettings.setColorLegendMarker(Display.getDefault().getSystemColor(SWT.COLOR_BLACK));
 				//
+				IHandledEventProcessor handledEventProcessor = null;
+				//
+				for(IHandledEventProcessor processor : chartSettings.getHandledEventProcessors()) {
+					if(processor instanceof MouseDownEvent) {
+						handledEventProcessor = processor;
+						break;
+					}
+				}
+				if(handledEventProcessor != null)
+					chartSettings.removeHandledEventProcessor(handledEventProcessor);
+				//
+				IHandledEventProcessor circularHandledEventProcessor = new CircularMouseDownEvent();
+				chartSettings.addHandledEventProcessor(circularHandledEventProcessor);
 				applySettings(chartSettings);
 				ICircularSeries pieSeries = (ICircularSeries)createCircularSeries(model, pieSeriesSettings);
 				//

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/PieChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/PieChart.java
@@ -80,8 +80,9 @@ public class PieChart extends ScrollableChart {
 						break;
 					}
 				}
-				if(handledEventProcessor != null)
+				if(handledEventProcessor != null) {
 					chartSettings.removeHandledEventProcessor(handledEventProcessor);
+				}
 				//
 				IHandledEventProcessor circularHandledEventProcessor = new CircularMouseDownEvent();
 				chartSettings.addHandledEventProcessor(circularHandledEventProcessor);


### PR DESCRIPTION
code is cleaner, and user has the choice to set the setting if or not he wants the redrawn charts to use the entire space available.

`circularSeriesSettings.setFillEntireSpace(boolean fillEntireSpace);` is false by default, setting it to true leads to filling up the entire space available.