### PR TITLE
Disabled .jar signing to fix the build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
 			steps {
 				wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
 					sh '''
-						mvn -f org.eclipse.swtchart.cbi/pom.xml -Peclipse-sign clean install
+						mvn -f org.eclipse.swtchart.cbi/pom.xml clean install
 					'''
 				}
 			}

--- a/org.eclipse.swtchart.cbi/pom.xml
+++ b/org.eclipse.swtchart.cbi/pom.xml
@@ -212,7 +212,7 @@
             <plugin>
               <groupId>org.eclipse.cbi.maven.plugins</groupId>
               <artifactId>eclipse-jarsigner-plugin</artifactId>
-              <version>1.1.7</version>
+              <version>1.3.2</version>
               <executions>
                 <execution>
                   <id>sign</id>


### PR DESCRIPTION
https://ci.eclipse.org/swtchart/job/build/job/develop/1939/ currently fails due to https://bugs.eclipse.org/bugs/show_bug.cgi?id=565644 but I think the new infrastructure isn't up and running yet. I couldn't fully verify locally as some tests fail and that cancels the build.