### PR TITLE
Fixed a number format exception when there is no column order set

### DIFF
--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/SeriesListUI.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/SeriesListUI.java
@@ -215,8 +215,10 @@ public class SeriesListUI extends TableViewer {
 		if(preferenceStore != null) {
 			try {
 				String columnOrder = preferenceStore.getString(PreferenceConstants.P_LEGEND_COLUMN_ORDER);
-				int[] columns = convertColumnOrder(columnOrder);
-				table.setColumnOrder(columns);
+				if(!columnOrder.isEmpty()) {
+					int[] columns = convertColumnOrder(columnOrder);
+					table.setColumnOrder(columns);
+				}
 			} catch(SWTException | IllegalArgumentException e) {
 				/*
 				 * On exception, default order will be used.


### PR DESCRIPTION
This changes nothing except that it silences a common exception which spams the log files.