### PR TITLE
Arbitrary base logarithmic scale scale

### DIFF
--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/AxisTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/AxisTest.java
@@ -273,6 +273,58 @@ public class AxisTest extends ChartTestCase {
 	}
 
 	/**
+	 * Test for arbitrary base logarithmic scale
+	 */
+	@Test
+	public void testArbitraryLogScale() throws Exception {
+
+		ISeries<?> lineSeries = chart.getSeriesSet().createSeries(SeriesType.LINE, "line series");
+		// enable log scale without series
+		showChart();
+		xAxis.setLogScaleBase(2d);
+		xAxis.setRange(new Range(-1, 10));
+		xAxis.enableLogScale(true);
+		assertTrue(xAxis.isLogScaleEnabled());
+		assertEquals(0.1, xAxis.getRange().lower, 0.1);
+		showChart();
+		yAxis.setLogScaleBase(2d);
+		yAxis.setRange(new Range(-1, 10));
+		yAxis.enableLogScale(true);
+		assertTrue(yAxis.isLogScaleEnabled());
+		assertEquals(0.1, yAxis.getRange().lower, 0.1);
+		showChart();
+		// enable log scale for the axis whose range is negative
+		lineSeries = chart.getSeriesSet().createSeries(SeriesType.LINE, "line series");
+		lineSeries.setXSeries(xSeries1);
+		lineSeries.setYSeries(ySeries1);
+		chart.getAxisSet().adjustRange();
+		xAxis.enableLogScale(false);
+		yAxis.enableLogScale(false);
+		showChart();
+		xAxis.setRange(new Range(-1, 10));
+		xAxis.enableLogScale(true);
+		assertTrue(xAxis.isLogScaleEnabled());
+		assertEquals(1d, xAxis.getRange().lower, 0.1);
+		showChart();
+		yAxis.setRange(new Range(-1, 10));
+		yAxis.enableLogScale(true);
+		assertTrue(yAxis.isLogScaleEnabled());
+		assertEquals(0.1, yAxis.getRange().lower, 0.1);
+		showChart();
+		// enable log scale for category axis
+		xAxis.enableLogScale(false);
+		xAxis.setCategorySeries(categorySeries);
+		xAxis.enableCategory(true);
+		xAxis.setRange(new Range(0, 4));
+		showChart();
+		xAxis.enableLogScale(true);
+		xAxis.setRange(new Range(0, 10));
+		assertFalse(xAxis.isCategoryEnabled());
+		assertTrue(xAxis.isLogScaleEnabled());
+		showChart();
+	}
+
+	/**
 	 * Test for adjusting range.
 	 */
 	@Test

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/AxisTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/AxisTest.java
@@ -322,6 +322,21 @@ public class AxisTest extends ChartTestCase {
 		assertFalse(xAxis.isCategoryEnabled());
 		assertTrue(xAxis.isLogScaleEnabled());
 		showChart();
+		// change of scale
+		lineSeries = chart.getSeriesSet().createSeries(SeriesType.LINE, "line series");
+		lineSeries.setXSeries(xSeries1);
+		lineSeries.setYSeries(ySeries1);
+		chart.getAxisSet().adjustRange();
+		yAxis.setLogScaleBase(10d);
+		yAxis.enableLogScale(true);
+		xAxis.enableLogScale(false);
+		assertTrue(yAxis.isLogScaleEnabled());
+		assertEquals(10d, yAxis.getLogScaleBase(), 0.1d);
+		showChart();
+		yAxis.setLogScaleBase(2d);
+		assertEquals(2d, yAxis.getLogScaleBase(), 0.1d);
+		showChart();
+		yAxis.setLogScaleBase(10d);
 	}
 
 	/**

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/AxisTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/AxisTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 SWTChart project.
+ * Copyright (c) 2008, 2022 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
  * 
  * Contributors:
  * yoshitaka - initial API and implementation
+ * Sebastien Darche - Arbitrary base log scale test cases
  *******************************************************************************/
 package org.eclipse.swtchart;
 

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/AxisTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/AxisTest.java
@@ -336,6 +336,27 @@ public class AxisTest extends ChartTestCase {
 		yAxis.setLogScaleBase(2d);
 		assertEquals(2d, yAxis.getLogScaleBase(), 0.1d);
 		showChart();
+		// Test invalid logarithm base
+		try {
+			yAxis.setLogScaleBase(-1d);
+			fail();
+		} catch(IllegalStateException e) {
+		}
+		try {
+			yAxis.setLogScaleBase(0d);
+			fail();
+		} catch(IllegalStateException e) {
+		}
+		try {
+			yAxis.setLogScaleBase(Double.POSITIVE_INFINITY);
+			fail();
+		} catch(IllegalStateException e) {
+		}
+		try {
+			yAxis.setLogScaleBase(1d);
+			fail();
+		} catch(IllegalStateException e) {
+		}
 		yAxis.setLogScaleBase(10d);
 	}
 

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/IAxis.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/IAxis.java
@@ -124,6 +124,13 @@ public interface IAxis {
 	 *            the new base
 	 */
 	void setLogScaleBase(double base);
+	
+	/**
+	 * Returns the current base for the logarithmic scale
+	 *
+	 * @return Current base for the logarithmic scale
+	 */
+	public double getLogScaleBase();
 
 	/**
 	 * Gets the grid. The gird interval is identical with the position of axis

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/IAxis.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/IAxis.java
@@ -22,10 +22,10 @@ public interface IAxis {
 
 	/** An axis direction */
 	public enum Direction {
-	/** the constant to represent X axis */
-	X,
-	/** the constant to represent Y axis */
-	Y
+		/** the constant to represent X axis */
+		X,
+		/** the constant to represent Y axis */
+		Y
 	}
 
 	/** An axis position */
@@ -116,6 +116,14 @@ public interface IAxis {
 	 * @return true if log scale is enabled
 	 */
 	boolean isLogScaleEnabled();
+
+	/**
+	 * Sets the log scale base. It is set by default to 10.
+	 * 
+	 * @param base
+	 *            the new base
+	 */
+	void setLogScaleBase(double base);
 
 	/**
 	 * Gets the grid. The gird interval is identical with the position of axis

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/IAxis.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/IAxis.java
@@ -124,7 +124,7 @@ public interface IAxis {
 	 *            the new base
 	 */
 	void setLogScaleBase(double base);
-	
+
 	/**
 	 * Returns the current base for the logarithmic scale
 	 *

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/IAxis.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/IAxis.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 SWTChart project.
+ * Copyright (c) 2008, 2022 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  * Contributors:
  * yoshitaka - initial API and implementation
  * Philip Wenig - option to skip drawing the axis line
+ * Sebastien Darche - Implement arbitrary base log scale
  *******************************************************************************/
 package org.eclipse.swtchart;
 

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/Axis.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/Axis.java
@@ -291,11 +291,7 @@ public class Axis implements IAxis {
 		((SeriesSet)chart.getSeriesSet()).compressAllSeries();
 	}
 
-	/**
-	 * Returns the current base for the logarithmic scale
-	 *
-	 * @return Current base for the logaritmic scale
-	 */
+	@Override
 	public double getLogScaleBase() {
 
 		return logScaleBase;

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/Axis.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/Axis.java
@@ -283,7 +283,7 @@ public class Axis implements IAxis {
 	@Override
 	public void setLogScaleBase(double base) {
 
-		if(base <= 0) {
+		if(base <= 0 || base == 1d || !Double.isFinite(base)) {
 			throw new IllegalStateException(Messages.getString(Messages.LOGARITHM_BASE_IS_INVALID));
 		}
 		logScaleBase = base;

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/Axis.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/Axis.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 SWTChart project.
+ * Copyright (c) 2008, 2022 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  * Christoph Läubrich - use getSize instead of bounds since we are not interested in the location anyways, add support for datamodel
  * Frank Buloup - Internationalization
  * Philip Wenig - option to skip drawing the axis line
+ * Sebastien Darche - Implement arbitrary base log scale
  *******************************************************************************/
 package org.eclipse.swtchart.internal.axis;
 

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/AxisTickLabels.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/AxisTickLabels.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 SWTChart project.
+ * Copyright (c) 2008, 2022 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  * Christoph Läubrich - use getSize since we only want width/height, add support for datamodel
  * Frank Buloup - Internationalization
  * Philip Wenig - x/y axis position marker
+ * Sebastien Darche - Implement arbitrary base log scale
  *******************************************************************************/
 package org.eclipse.swtchart.internal.axis;
 

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/AxisTickLabels.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/AxisTickLabels.java
@@ -208,10 +208,12 @@ public class AxisTickLabels implements PaintListener {
 
 		double min = axis.getRange().lower;
 		double max = axis.getRange().upper;
-		int digitMin = (int)Math.ceil(Math.log10(min));
-		int digitMax = (int)Math.ceil(Math.log10(max));
+
+		double base = axis.getLogScaleBase();
+		int digitMin = (int)Math.ceil(axis.logBase(min));
+		int digitMax = (int)Math.ceil(axis.logBase(max));
 		final BigDecimal MIN = BigDecimal.valueOf(min);
-		BigDecimal tickStep = pow(10, digitMin - 1);
+		BigDecimal tickStep = pow(base, digitMin - 1);
 		BigDecimal firstPosition;
 		if(MIN.remainder(tickStep).doubleValue() <= 0) {
 			firstPosition = MIN.subtract(MIN.remainder(tickStep));
@@ -219,20 +221,20 @@ public class AxisTickLabels implements PaintListener {
 			firstPosition = MIN.subtract(MIN.remainder(tickStep)).add(tickStep);
 		}
 		for(int i = digitMin; i <= digitMax; i++) {
-			for(BigDecimal j = firstPosition; j.doubleValue() <= pow(10, i).doubleValue(); j = j.add(tickStep)) {
+			for(BigDecimal j = firstPosition; j.doubleValue() <= pow(base, i).doubleValue(); j = j.add(tickStep)) {
 				if(j.doubleValue() > max) {
 					break;
 				}
 				tickLabels.add(format(j.doubleValue()));
 				tickLabelValues.add(j.doubleValue());
-				int tickLabelPosition = (int)((Math.log10(j.doubleValue()) - Math.log10(min)) / (Math.log10(max) - Math.log10(min)) * length);
+				int tickLabelPosition = (int)((axis.logBase(j.doubleValue()) - axis.logBase(min)) / (axis.logBase(max) - axis.logBase(min)) * length);
 				if(axis.isReversed()) {
 					tickLabelPosition = correctPositionInReversedAxis(tickLabelPosition);
 				}
 				tickLabelPositions.add(tickLabelPosition);
 			}
-			tickStep = tickStep.multiply(pow(10, 1));
-			firstPosition = tickStep.add(pow(10, i));
+			tickStep = tickStep.multiply(pow(base, 1));
+			firstPosition = tickStep.add(pow(base, i));
 		}
 	}
 

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/Messages.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 SWT Chart Project
+ * Copyright (c) 2020, 2022 SWT Chart Project
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
  * 
  * Contributors:
  * Frank Buloup - initial API and implementation
+ * Sebastien Darche - Implement arbitrary base log scale
  *******************************************************************************/
 package org.eclipse.swtchart.internal.axis;
 

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/Messages.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/Messages.java
@@ -10,7 +10,6 @@
  * Contributors:
  * Frank Buloup - initial API and implementation
  *******************************************************************************/
-
 package org.eclipse.swtchart.internal.axis;
 
 import java.util.MissingResourceException;
@@ -20,7 +19,6 @@ public class Messages {
 
 	private static final String BUNDLE_NAME = "org.eclipse.swtchart.internal.axis.messages"; //$NON-NLS-1$
 	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
-	
 	public static final String AXIS_ID_DONT_EXIST = "AXIS_ID_DONT_EXIST";
 	public static final String GIVEN_RANGE_INVALID = "GIVEN_RANGE_INVALID";
 	public static final String ILLEGAL_RANGE = "ILLEGAL_RANGE";
@@ -31,6 +29,7 @@ public class Messages {
 	public static final String X_AXIS = "X_AXIS";
 	public static final String Y_AXIS = "Y_AXIS";
 	public static final String Y_AXIS_CANNOT_BE_CATEGORY = "Y_AXIS_CANNOT_BE_CATEGORY";
+	public static final String LOGARITHM_BASE_IS_INVALID = "LOGARITHM_BASE_IS_INVALID";
 
 	private Messages() {
 

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/messages.properties
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/messages.properties
@@ -10,4 +10,4 @@ X_AXIS = X Axis
 Y_AXIS = Y axis
 Y_AXIS = Y Axis
 Y_AXIS_CANNOT_BE_CATEGORY = Y axis cannot be category axis.
-LOGARITHM_BASE_IS_INVALID = Logarithm base is invalid (must be positive)
+LOGARITHM_BASE_IS_INVALID = Logarithm base is invalid (must be positive and different from 1)

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/messages.properties
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/messages.properties
@@ -10,3 +10,4 @@ X_AXIS = X Axis
 Y_AXIS = Y axis
 Y_AXIS = Y Axis
 Y_AXIS_CANNOT_BE_CATEGORY = Y axis cannot be category axis.
+LOGARITHM_BASE_IS_INVALID = Logarithm base is invalid (must be positive)

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/messages_fr.properties
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/messages_fr.properties
@@ -8,4 +8,4 @@ UNKNOWN_AXIS_POSITION = position de l'axe inconnu
 X_AXIS = Axe X
 Y_AXIS = Axe Y
 Y_AXIS_CANNOT_BE_CATEGORY = L'axe Y ne peut être un axe de catégorie.
-LOGARITHM_BASE_IS_INVALID = La base du logarithme est invalide (doit être positif)
+LOGARITHM_BASE_IS_INVALID = La base du logarithme est invalide (doit être positive et différente de 1)

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/messages_fr.properties
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/messages_fr.properties
@@ -8,3 +8,4 @@ UNKNOWN_AXIS_POSITION = position de l'axe inconnu
 X_AXIS = Axe X
 Y_AXIS = Axe Y
 Y_AXIS_CANNOT_BE_CATEGORY = L'axe Y ne peut être un axe de catégorie.
+LOGARITHM_BASE_IS_INVALID = La base du logarithme est invalide (doit être positif)


### PR DESCRIPTION
Hello! I am currently using SWTChart in a different Eclipse project and needed to use a base-2 logarithmic scale on both axes.

I added two new public methods to the `IAxis` interface : 
- `void setLogScaleBase(double base)` to set a new base
- `double getLogScaleBase()` to get the current base

The default behaviour is unchanged, the axis will use a decimal logarithm by default. I added some test cases as well for potential invalid bases.
I would love to get some feedback on this (short) pull request.

Thank you!