### PR TITLE
Update to Eclipse 2022-12

### DIFF
--- a/org.eclipse.swtchart.targetplatform/org.eclipse.swtchart.targetplatform.basic.target
+++ b/org.eclipse.swtchart.targetplatform/org.eclipse.swtchart.targetplatform.basic.target
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="Eclipse SWTChart (Basic - without Batik)" sequenceNumber="3">
-<locations>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.sdk.ide" version="4.24.0.I20220607-0700"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.24/R-4.24-202206070700/"/>
-</location>
-</locations>
-</target>

--- a/org.eclipse.swtchart.targetplatform/org.eclipse.swtchart.targetplatform.target
+++ b/org.eclipse.swtchart.targetplatform/org.eclipse.swtchart.targetplatform.target
@@ -1,18 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="Eclipse SWTChart (Developers)" sequenceNumber="3">
+<target name="Eclipse SWTChart" sequenceNumber="3">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.sdk.ide" version="4.24.0.I20220607-0700"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.24/R-4.24-202206070700/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.sdk.ide" version="0.0.0"/>
 <unit id="org.apache.batik.anim" version="0.0.0"/>
 <unit id="org.apache.batik.svggen" version="0.0.0"/>
-<unit id="org.apache.batik.ext.awt" version="0.0.0"/>
+<unit id="org.apache.batik.awt.util" version="0.0.0"/>
 <unit id="org.apache.batik.dom" version="0.0.0"/>
 <unit id="org.w3c.dom.events" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220302172233/repository"/>
+<repository location="https://download.eclipse.org/releases/2022-12/"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
to prepare for #312. I merged the target platforms because Orbit is now shipped together with Eclipse anyway.