### PR TITLE
Removed hard-coded backgrounds

### DIFF
--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ChartSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ChartSettings.java
@@ -134,9 +134,6 @@ public class ChartSettings implements IChartSettings {
 		titleColor = display.getSystemColor(SWT.COLOR_TITLE_FOREGROUND);
 		titleFont = defaultFont;
 		//
-		background = display.getSystemColor(SWT.COLOR_LIST_BACKGROUND);
-		backgroundChart = display.getSystemColor(SWT.COLOR_LIST_BACKGROUND);
-		backgroundPlotArea = display.getSystemColor(SWT.COLOR_LIST_BACKGROUND);
 		rangeRestriction.setZeroX(true);
 		rangeRestriction.setZeroY(true);
 		rangeRestriction.setRestrictFrame(true);

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/ChartTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/ChartTest.java
@@ -43,7 +43,7 @@ public class ChartTest extends ChartTestCase {
 	 * Test for background.
 	 */
 	@Test
-	public void testBackground()  {
+	public void testBackground() {
 
 		// check the default color
 		showChart();
@@ -81,12 +81,12 @@ public class ChartTest extends ChartTestCase {
 	 * Test for background in plot area
 	 */
 	@Test
-	public void testBackgroundInPlotArea()  {
+	public void testBackgroundInPlotArea() {
 
 		// check the default color
 		showChart();
 		Color color = chart.getPlotArea().getBackground();
-		assertEquals(new RGB(255, 255, 255), color.getRGB());
+		assertEquals(new RGB(246, 245, 244), color.getRGB());
 		// set color
 		Color cyan = Display.getDefault().getSystemColor(SWT.COLOR_CYAN);
 		chart.getPlotArea().setBackground(cyan);
@@ -111,7 +111,7 @@ public class ChartTest extends ChartTestCase {
 			fail();
 		}
 		color = chart.getPlotArea().getBackground();
-		assertEquals(new RGB(255, 255, 255), color.getRGB());
+		assertEquals(new RGB(246, 245, 244), color.getRGB());
 		showChart();
 	}
 
@@ -119,7 +119,7 @@ public class ChartTest extends ChartTestCase {
 	 * Test for chart orientation with line series
 	 */
 	@Test
-	public void testOrientation1()  {
+	public void testOrientation1() {
 
 		// create line series
 		ILineSeries<?> lineSeries1 = (ILineSeries<?>)chart.getSeriesSet().createSeries(SeriesType.LINE, "line series 1");
@@ -234,7 +234,7 @@ public class ChartTest extends ChartTestCase {
 	 * Test for chart orientation with bar series
 	 */
 	@Test
-	public void testOrientation2()  {
+	public void testOrientation2() {
 
 		// create bar series
 		IBarSeries<?> barSeries1 = (IBarSeries<?>)chart.getSeriesSet().createSeries(SeriesType.BAR, "bar series 1");
@@ -348,7 +348,7 @@ public class ChartTest extends ChartTestCase {
 	 * Test for suspending update
 	 */
 	@Test
-	public void testSuspendUpdate()  {
+	public void testSuspendUpdate() {
 
 		ISeries<?> series1 = chart.getSeriesSet().createSeries(SeriesType.LINE, "series1");
 		series1.setYSeries(ySeries1);
@@ -378,7 +378,7 @@ public class ChartTest extends ChartTestCase {
 	 */
 	@Test
 	@Ignore("environment dependent")
-	public void testSaveToFile()  {
+	public void testSaveToFile() {
 
 		ISeries<?> series = chart.getSeriesSet().createSeries(SeriesType.LINE, "series1");
 		series.setYSeries(ySeries1);

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/PlotArea.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/PlotArea.java
@@ -31,7 +31,6 @@ import org.eclipse.swt.graphics.PaletteData;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swtchart.Chart;
 import org.eclipse.swtchart.IAxis;
 import org.eclipse.swtchart.IBarSeries;
@@ -53,8 +52,6 @@ public class PlotArea extends Composite implements PaintListener, IPlotArea {
 	private Chart chart;
 	/** the custom paint listeners */
 	private List<ICustomPaintListener> paintListeners;
-	/** the default background color */
-	private static final int DEFAULT_BACKGROUND = SWT.COLOR_WHITE;
 	private DisposeListener disposeListener;
 	private Image image = null;
 	private boolean buffered = false;
@@ -72,7 +69,6 @@ public class PlotArea extends Composite implements PaintListener, IPlotArea {
 		super(chart, style | SWT.NO_BACKGROUND | SWT.DOUBLE_BUFFERED);
 		this.chart = chart;
 		paintListeners = new ArrayList<ICustomPaintListener>();
-		setBackground(Display.getDefault().getSystemColor(DEFAULT_BACKGROUND));
 		addPaintListener(this);
 		disposeListener = new DisposeListener() {
 
@@ -123,16 +119,6 @@ public class PlotArea extends Composite implements PaintListener, IPlotArea {
 
 		super.setBounds(x, y, width, height);
 		((SeriesSet)getSeriesSet()).compressAllSeries();
-	}
-
-	@Override
-	public void setBackground(Color color) {
-
-		if(color == null) {
-			super.setBackground(Display.getDefault().getSystemColor(DEFAULT_BACKGROUND));
-		} else {
-			super.setBackground(color);
-		}
 	}
 
 	@Override


### PR DESCRIPTION
This resolves problems with Eclipse themes in dark mode on Windows 10. Followup on #300.