### PR TITLE
Added CSS support

### DIFF
--- a/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/ChromatogramChart.java
+++ b/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/ChromatogramChart.java
@@ -61,6 +61,7 @@ public class ChromatogramChart extends LineChart {
 		setPrimaryAxisSet(chartSettings);
 		addSecondaryAxisSet(chartSettings);
 		applySettings(chartSettings);
+		setData("org.eclipse.e4.ui.css.CssClassName", "ChromatogramChart");
 	}
 
 	private void setPrimaryAxisSet(IChartSettings chartSettings) {

--- a/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/HighlightedStaticPie.java
+++ b/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/HighlightedStaticPie.java
@@ -26,11 +26,13 @@ public class HighlightedStaticPie extends PieChart {
 	public HighlightedStaticPie(Composite parent) {
 
 		super(parent, SWT.NONE);
+		setData("org.eclipse.e4.ui.css.CssClassName", "HighlightedStaticPie");
 	}
 
 	public HighlightedStaticPie(Composite parent, int style) {
 
 		super(parent, style);
+		setData("org.eclipse.e4.ui.css.CssClassName", "HighlightedStaticPie");
 	}
 
 	@Override

--- a/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/HighlightedStaticPie.java
+++ b/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/HighlightedStaticPie.java
@@ -33,9 +33,10 @@ public class HighlightedStaticPie extends PieChart {
 		super(parent, style);
 	}
 
+	@Override
 	public void addSeriesData(ICircularSeriesData model) {
 
-		ICircularSeriesSettings seriesSettings = (ICircularSeriesSettings)model.getSettings();
+		ICircularSeriesSettings seriesSettings = model.getSettings();
 		seriesSettings.setRedrawOnClick(false);
 		seriesSettings.setSliceColor(Display.getDefault().getSystemColor(SWT.COLOR_WHITE));
 		ISeriesSettings seriesSettingsHighlight = seriesSettings.getSeriesSettingsHighlight();

--- a/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/MassSpectrumChart.java
+++ b/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/MassSpectrumChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -114,6 +114,7 @@ public class MassSpectrumChart extends BarChart {
 		applySettings(chartSettings);
 		//
 		addSeriesLabelMarker();
+		setData("org.eclipse.e4.ui.css.CssClassName", "MassSpectrumChart");
 	}
 
 	private void setPrimaryAxisSet(IChartSettings chartSettings) {

--- a/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/PCAChart.java
+++ b/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/PCAChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,20 +33,21 @@ import org.eclipse.swtchart.extensions.scattercharts.ScatterChart;
 
 public class PCAChart extends ScatterChart {
 
-	private Color COLOR_BLACK = getDisplay().getSystemColor(SWT.COLOR_BLACK);
+	private Color colorBlack = getDisplay().getSystemColor(SWT.COLOR_BLACK);
 	//
-	private int symbolSize = 0;
 	private String chartTitle = ""; //$NON-NLS-1$
 	private String xAxisTitle = "PC1"; //$NON-NLS-1$
 	private String yAxisTitle = "PC2"; //$NON-NLS-1$
 	private DecimalFormat decimalFormat = new DecimalFormat(("0.0##"), new DecimalFormatSymbols(Locale.ENGLISH)); //$NON-NLS-1$
 
 	public PCAChart() {
+
 		super();
 		initialize();
 	}
 
 	public PCAChart(Composite parent, int style) {
+
 		super(parent, style);
 		initialize();
 	}
@@ -55,7 +56,7 @@ public class PCAChart extends ScatterChart {
 	public void addSeriesData(List<IScatterSeriesData> scatterSeriesDataList) {
 
 		super.addSeriesData(scatterSeriesDataList);
-		symbolSize = 0;
+		int symbolSize = 0;
 		for(IScatterSeriesData scatterSeriesData : scatterSeriesDataList) {
 			symbolSize = Math.max(symbolSize, scatterSeriesData.getSettings().getSymbolSize());
 		}
@@ -95,7 +96,7 @@ public class PCAChart extends ScatterChart {
 		IChartSettings chartSettings = getChartSettings();
 		chartSettings.setTitle(chartTitle);
 		chartSettings.setTitleVisible(true);
-		chartSettings.setTitleColor(COLOR_BLACK);
+		chartSettings.setTitleColor(colorBlack);
 		chartSettings.setOrientation(SWT.HORIZONTAL);
 		chartSettings.setHorizontalSliderVisible(false);
 		chartSettings.setVerticalSliderVisible(true);
@@ -107,9 +108,9 @@ public class PCAChart extends ScatterChart {
 		rangeRestriction.setExtendTypeY(RangeRestriction.ExtendType.RELATIVE);
 		rangeRestriction.setExtend(0.25d);
 		chartSettings.setShowAxisZeroMarker(true);
-		chartSettings.setColorAxisZeroMarker(COLOR_BLACK);
+		chartSettings.setColorAxisZeroMarker(colorBlack);
 		chartSettings.setShowSeriesLabelMarker(true);
-		chartSettings.setColorSeriesLabelMarker(COLOR_BLACK);
+		chartSettings.setColorSeriesLabelMarker(colorBlack);
 		//
 		setPrimaryAxisSet(chartSettings);
 		addSecondaryAxisSet(chartSettings);
@@ -122,12 +123,12 @@ public class PCAChart extends ScatterChart {
 		IPrimaryAxisSettings primaryAxisSettingsX = chartSettings.getPrimaryAxisSettingsX();
 		primaryAxisSettingsX.setTitle(xAxisTitle);
 		primaryAxisSettingsX.setDecimalFormat(decimalFormat);
-		primaryAxisSettingsX.setColor(COLOR_BLACK);
+		primaryAxisSettingsX.setColor(colorBlack);
 		//
 		IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
 		primaryAxisSettingsY.setTitle(yAxisTitle);
 		primaryAxisSettingsY.setDecimalFormat(decimalFormat);
-		primaryAxisSettingsY.setColor(COLOR_BLACK);
+		primaryAxisSettingsY.setColor(colorBlack);
 	}
 
 	private void addSecondaryAxisSet(IChartSettings chartSettings) {
@@ -136,13 +137,13 @@ public class PCAChart extends ScatterChart {
 		secondaryAxisSettingsX.setTitle(""); //$NON-NLS-1$
 		secondaryAxisSettingsX.setPosition(Position.Secondary);
 		secondaryAxisSettingsX.setDecimalFormat(decimalFormat);
-		secondaryAxisSettingsX.setColor(COLOR_BLACK);
+		secondaryAxisSettingsX.setColor(colorBlack);
 		chartSettings.getSecondaryAxisSettingsListX().add(secondaryAxisSettingsX);
 		//
 		ISecondaryAxisSettings secondaryAxisSettingsY = new SecondaryAxisSettings(yAxisTitle, new PassThroughConverter());
 		secondaryAxisSettingsY.setPosition(Position.Secondary);
 		secondaryAxisSettingsY.setDecimalFormat(decimalFormat);
-		secondaryAxisSettingsY.setColor(COLOR_BLACK);
+		secondaryAxisSettingsY.setColor(colorBlack);
 		chartSettings.getSecondaryAxisSettingsListY().add(secondaryAxisSettingsY);
 	}
 }

--- a/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/PCAChart.java
+++ b/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/PCAChart.java
@@ -116,6 +116,7 @@ public class PCAChart extends ScatterChart {
 		addSecondaryAxisSet(chartSettings);
 		//
 		applySettings(chartSettings);
+		setData("org.eclipse.e4.ui.css.CssClassName", "PCAChart");
 	}
 
 	private void setPrimaryAxisSet(IChartSettings chartSettings) {

--- a/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/ParallelPieCharts.java
+++ b/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/ParallelPieCharts.java
@@ -37,8 +37,6 @@ public class ParallelPieCharts {
 	private boolean redrawOnClick;
 	private SeriesType seriesType;
 	private int noOfCharts;
-	private int noOfSlices;
-	private String[] legendLabels;
 	// private String[] pieTitles; // It's not used yet.
 	private CircularSeriesData[] dataArray;
 
@@ -47,7 +45,7 @@ public class ParallelPieCharts {
 		composite = parent;
 		redrawOnClick = redraw;
 		seriesType = type;
-		linkedPieCharts = new ArrayList<PieChart>();
+		linkedPieCharts = new ArrayList<>();
 		parent.setLayout(new FillLayout());
 	}
 
@@ -64,18 +62,17 @@ public class ParallelPieCharts {
 	 * @param val
 	 *            New values.
 	 */
-	public void addPieChartSeries(String labels[], double val[][]) {
+	public void addPieChartSeries(String[] labels, double[][] val) {
 
 		noOfCharts = val[0].length;
-		legendLabels = labels;
-		noOfSlices = labels.length;
-		double[] values = new double[noOfSlices];
+		String[] legendLabels = labels;
+		int noOfSlices = labels.length;
 		dataArray = new CircularSeriesData[noOfCharts];
 		// create the charts independently
 		for(int i = 0; i != noOfCharts; i++) {
 			dataArray[i] = new CircularSeriesData();
 			dataArray[i].getSettings().setSeriesType(seriesType);
-			values = new double[noOfSlices];
+			double[] values = new double[noOfSlices];
 			for(int j = 0; j != noOfSlices; j++) {
 				values[j] = val[j][i];
 			}
@@ -89,8 +86,9 @@ public class ParallelPieCharts {
 		// add them to linked scrollable charts
 		for(int i = 0; i != noOfCharts; i++) {
 			for(int j = 0; j != noOfCharts; j++) {
-				if(i == j)
+				if(i == j) {
 					continue;
+				}
 				linkedPieCharts.get(i).addLinkedScrollableChart(linkedPieCharts.get(j));
 			}
 		}

--- a/org.eclipse.swtchart.export.test/src/org/eclipse/swtchart/export/menu/ImageFactory_1_UITest.java
+++ b/org.eclipse.swtchart.export.test/src/org/eclipse/swtchart/export/menu/ImageFactory_1_UITest.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swtchart.customcharts.core.ChromatogramChart;
+import org.eclipse.swtchart.export.PathResolver;
 import org.eclipse.swtchart.export.SeriesConverter;
 import org.eclipse.swtchart.export.TestPathHelper;
 import org.eclipse.swtchart.export.images.ImageFactory;
@@ -53,15 +54,15 @@ public class ImageFactory_1_UITest extends TestCase {
 			/*
 			 * Create the factory.
 			 */
-			ImageFactory<ChromatogramChart> imageFactory = new ImageFactory<ChromatogramChart>(ChromatogramChart.class, 800, 600);
+			ImageFactory<ChromatogramChart> imageFactory = new ImageFactory<>(ChromatogramChart.class, 800, 600);
 			/*
 			 * Modify the chart.
 			 */
 			ChromatogramChart chromatogramChart = imageFactory.getChart();
 			chromatogramChart.setBackground(chromatogramChart.getBaseChart().getDisplay().getSystemColor(SWT.COLOR_WHITE));
-			List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
+			List<ILineSeriesData> lineSeriesDataList = new ArrayList<>();
 			//
-			ISeriesData seriesData = SeriesConverter.getSeriesXY(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_LINE_SERIES_1));
+			ISeriesData seriesData = SeriesConverter.getSeriesXY(PathResolver.getAbsolutePath(TestPathHelper.TESTFILE_LINE_SERIES_1));
 			ILineSeriesData lineSeriesData = new LineSeriesData(seriesData);
 			ILineSeriesSettings lineSerieSettings = lineSeriesData.getSettings();
 			lineSerieSettings.setEnableArea(true);
@@ -70,7 +71,7 @@ public class ImageFactory_1_UITest extends TestCase {
 			/*
 			 * Export the images.
 			 */
-			String exportFolder = TestPathHelper.getAbsolutePath(TestPathHelper.TESTFOLDER_EXPORT);
+			String exportFolder = PathResolver.getAbsolutePath(TestPathHelper.TESTFOLDER_EXPORT);
 			String prefix = "LineSeries1";
 			//
 			String png = exportFolder + File.separator + prefix + ".png";

--- a/org.eclipse.swtchart.export.test/src/org/eclipse/swtchart/export/menu/ImageFactory_2_UITest.java
+++ b/org.eclipse.swtchart.export.test/src/org/eclipse/swtchart/export/menu/ImageFactory_2_UITest.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swtchart.customcharts.core.MassSpectrumChart;
+import org.eclipse.swtchart.export.PathResolver;
 import org.eclipse.swtchart.export.SeriesConverter;
 import org.eclipse.swtchart.export.TestPathHelper;
 import org.eclipse.swtchart.export.images.ImageFactory;
@@ -53,14 +54,14 @@ public class ImageFactory_2_UITest extends TestCase {
 			/*
 			 * Create the factory.
 			 */
-			ImageFactory<MassSpectrumChart> imageFactory = new ImageFactory<MassSpectrumChart>(MassSpectrumChart.class, 800, 600);
+			ImageFactory<MassSpectrumChart> imageFactory = new ImageFactory<>(MassSpectrumChart.class, 800, 600);
 			/*
 			 * Modify the chart.
 			 */
 			MassSpectrumChart massSpectrumChart = imageFactory.getChart();
 			massSpectrumChart.setBackground(massSpectrumChart.getBaseChart().getDisplay().getSystemColor(SWT.COLOR_WHITE));
-			List<IBarSeriesData> barSeriesDataList = new ArrayList<IBarSeriesData>();
-			ISeriesData seriesData = SeriesConverter.getSeriesXY(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_BAR_SERIES_1));
+			List<IBarSeriesData> barSeriesDataList = new ArrayList<>();
+			ISeriesData seriesData = SeriesConverter.getSeriesXY(PathResolver.getAbsolutePath(TestPathHelper.TESTFILE_BAR_SERIES_1));
 			//
 			IBarSeriesData barSeriesData = new BarSeriesData(seriesData);
 			IBarSeriesSettings barSeriesSettings = barSeriesData.getSettings();
@@ -70,7 +71,7 @@ public class ImageFactory_2_UITest extends TestCase {
 			/*
 			 * Export the images.
 			 */
-			String exportFolder = TestPathHelper.getAbsolutePath(TestPathHelper.TESTFOLDER_EXPORT);
+			String exportFolder = PathResolver.getAbsolutePath(TestPathHelper.TESTFOLDER_EXPORT);
 			String prefix = "BarSeries1";
 			//
 			String png = exportFolder + File.separator + prefix + ".png";

--- a/org.eclipse.swtchart.export.test/src/org/eclipse/swtchart/export/menu/ImageFactory_3_UITest.java
+++ b/org.eclipse.swtchart.export.test/src/org/eclipse/swtchart/export/menu/ImageFactory_3_UITest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.eclipse.swt.SWT;
 import org.eclipse.swtchart.ILineSeries.PlotSymbolType;
 import org.eclipse.swtchart.customcharts.core.PCAChart;
+import org.eclipse.swtchart.export.PathResolver;
 import org.eclipse.swtchart.export.SeriesConverter;
 import org.eclipse.swtchart.export.TestPathHelper;
 import org.eclipse.swtchart.export.images.ImageFactory;
@@ -57,15 +58,15 @@ public class ImageFactory_3_UITest extends TestCase {
 			/*
 			 * Create the factory.
 			 */
-			ImageFactory<PCAChart> imageFactory = new ImageFactory<PCAChart>(PCAChart.class, 800, 600);
+			ImageFactory<PCAChart> imageFactory = new ImageFactory<>(PCAChart.class, 800, 600);
 			/*
 			 * Modify the chart.
 			 */
 			PCAChart pcaChart = imageFactory.getChart();
 			BaseChart baseChart = pcaChart.getBaseChart();
 			pcaChart.setBackground(baseChart.getDisplay().getSystemColor(SWT.COLOR_WHITE));
-			List<ISeriesData> scatterSeriesList = SeriesConverter.getSeriesScatter(TestPathHelper.getAbsolutePath(TestPathHelper.TESTFILE_SCATTER_SERIES_1));
-			List<IScatterSeriesData> scatterSeriesDataList = new ArrayList<IScatterSeriesData>();
+			List<ISeriesData> scatterSeriesList = SeriesConverter.getSeriesScatter(PathResolver.getAbsolutePath(TestPathHelper.TESTFILE_SCATTER_SERIES_1));
+			List<IScatterSeriesData> scatterSeriesDataList = new ArrayList<>();
 			//
 			for(ISeriesData seriesData : scatterSeriesList) {
 				IScatterSeriesData scatterSeriesData = new ScatterSeriesData(seriesData);
@@ -100,7 +101,7 @@ public class ImageFactory_3_UITest extends TestCase {
 			/*
 			 * Export the images.
 			 */
-			String exportFolder = TestPathHelper.getAbsolutePath(TestPathHelper.TESTFOLDER_EXPORT);
+			String exportFolder = PathResolver.getAbsolutePath(TestPathHelper.TESTFOLDER_EXPORT);
 			String prefix = "ScatterSeries1";
 			//
 			String png = exportFolder + File.separator + prefix + ".png";

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/barcharts/BarChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/barcharts/BarChart.java
@@ -29,11 +29,13 @@ public class BarChart extends ScrollableChart {
 	public BarChart() {
 
 		super();
+		setData("org.eclipse.e4.ui.css.CssClassName", "BarChart");
 	}
 
 	public BarChart(Composite parent, int style) {
 
 		super(parent, style);
+		setData("org.eclipse.e4.ui.css.CssClassName", "BarChart");
 	}
 
 	public void addSeriesData(List<IBarSeriesData> barSeriesDataList) {

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/charts/InteractiveChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/charts/InteractiveChart.java
@@ -93,6 +93,7 @@ public class InteractiveChart extends Chart implements PaintListener {
 			plot.addPaintListener(this);
 			createMenuItems(plot);
 		}
+		setData("org.eclipse.e4.ui.css.CssClassName", "InteractiveChart");
 	}
 
 	/**

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/BaseChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/BaseChart.java
@@ -175,6 +175,8 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		redoSelection = null;
 		//
 		dataShiftHistory = new HashMap<>();
+		//
+		setData("org.eclipse.e4.ui.css.CssClassName", "BaseChart");
 	}
 
 	private void initializeEventProcessors() {

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ScrollableChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ScrollableChart.java
@@ -176,6 +176,10 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 	@Override
 	public void setBackground(Color color) {
 
+		// Use CSS styles instead.
+		if(color == null) {
+			return;
+		}
 		super.setBackground(color);
 		sashForm.setBackground(color);
 		chartSection.setBackground(color);
@@ -1347,6 +1351,8 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 		 * Legend is invisible by default.
 		 */
 		sashForm.setWeights(DEFAULT_WEIGHTS);
+		//
+		setData("org.eclipse.e4.ui.css.CssClassName", "ScrollableChart");
 	}
 
 	private Composite createChartSection(Composite parent) {

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ScrollableChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ScrollableChart.java
@@ -742,10 +742,8 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 
 		boolean isLegendVisible = false;
 		int[] weights = sashForm.getWeights();
-		if(weights.length > 0) {
-			if(weights[0] < MAX_WEIGHT) {
-				isLegendVisible = true;
-			}
+		if(weights.length > 0 && weights[0] < MAX_WEIGHT) {
+			isLegendVisible = true;
 		}
 		return isLegendVisible;
 	}

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/linecharts/StepChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/linecharts/StepChart.java
@@ -29,12 +29,14 @@ public class StepChart extends ScrollableChart implements ICompressionSupport {
 
 		super();
 		setChartType(ChartType.STEP);
+		setData("org.eclipse.e4.ui.css.CssClassName", "StepChart");
 	}
 
 	public StepChart(Composite parent, int style) {
 
 		super(parent, style);
 		setChartType(ChartType.STEP);
+		setData("org.eclipse.e4.ui.css.CssClassName", "StepChart");
 	}
 
 	public void addSeriesData(List<ILineSeriesData> lineSeriesDataList) {

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/PieChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/PieChart.java
@@ -32,12 +32,14 @@ public class PieChart extends ScrollableChart {
 
 		super();
 		setChartType(ChartType.PIE);
+		setData("org.eclipse.e4.ui.css.CssClassName", "BarChart");
 	}
 
 	public PieChart(Composite parent, int style) {
 
 		super(parent, style);
 		setChartType(ChartType.PIE);
+		setData("org.eclipse.e4.ui.css.CssClassName", "BarChart");
 	}
 
 	public void addSeriesData(ICircularSeriesData seriesData) {

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/scattercharts/BoxPlotChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/scattercharts/BoxPlotChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2023 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -44,6 +44,7 @@ public class BoxPlotChart extends ScatterChart {
 		IPlotArea plotArea = getBaseChart().getPlotArea();
 		BoxPlotMarker boxPlotMarker = new BoxPlotMarker(getBaseChart(), this);
 		plotArea.addCustomPaintListener(boxPlotMarker);
+		setData("org.eclipse.e4.ui.css.CssClassName", "BoxPlotChart");
 	}
 
 	@Override

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/scattercharts/ScatterChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/scattercharts/ScatterChart.java
@@ -26,11 +26,13 @@ public class ScatterChart extends ScrollableChart {
 	public ScatterChart() {
 
 		super();
+		setData("org.eclipse.e4.ui.css.CssClassName", "ScatterChart");
 	}
 
 	public ScatterChart(Composite parent, int style) {
 
 		super(parent, style);
+		setData("org.eclipse.e4.ui.css.CssClassName", "ScatterChart");
 	}
 
 	public void addSeriesData(List<IScatterSeriesData> scatterSeriesDataList) {

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/Chart.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/Chart.java
@@ -94,6 +94,7 @@ public class Chart extends Composite implements Listener {
 				redraw();
 			}
 		});
+		setData("org.eclipse.e4.ui.css.CssClassName", "Chart");
 	}
 
 	/**

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/Legend.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/Legend.java
@@ -85,7 +85,7 @@ public class Legend extends Composite implements ILegend, PaintListener {
 		this.chart = chart;
 		visible = true;
 		position = DEFAULT_POSITION;
-		cellBounds = new HashMap<String, Rectangle>();
+		cellBounds = new HashMap<>();
 		defaultFont = Resources.getFont("Tahoma", DEFAULT_FONT_SIZE, SWT.NORMAL); //$NON-NLS-1$
 		setFont(defaultFont);
 		setForeground(DEFAULT_FOREGROUND);

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/Legend.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/Legend.java
@@ -91,6 +91,7 @@ public class Legend extends Composite implements ILegend, PaintListener {
 		setForeground(DEFAULT_FOREGROUND);
 		setBackground(DEFAULT_BACKGROUND);
 		addPaintListener(this);
+		setData("org.eclipse.e4.ui.css.CssClassName", "Legend");
 	}
 
 	@Override

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/PlotArea.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/PlotArea.java
@@ -78,6 +78,7 @@ public class PlotArea extends Composite implements PaintListener, IPlotArea {
 				dispose();
 			}
 		};
+		setData("org.eclipse.e4.ui.css.CssClassName", "PlotArea");
 		chart.addDisposeListener(disposeListener);
 		chart.setPlotArea(this);
 	}

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/PlotArea.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/PlotArea.java
@@ -68,7 +68,7 @@ public class PlotArea extends Composite implements PaintListener, IPlotArea {
 
 		super(chart, style | SWT.NO_BACKGROUND | SWT.DOUBLE_BUFFERED);
 		this.chart = chart;
-		paintListeners = new ArrayList<ICustomPaintListener>();
+		paintListeners = new ArrayList<>();
 		addPaintListener(this);
 		disposeListener = new DisposeListener() {
 


### PR DESCRIPTION
This basically follows [styling based on CSS class or CSS ID](https://www.vogella.com/tutorials/Eclipse4CSS/article.html#styling-based-on-css-class-or-css-id) which clashes a bit with hard-coded colors in settings. I didn't rip that apart to avoid an API change. Instead, you can set the color to null to avoid clashes with CSS styling.