### PR TITLE
Fixed Y-axis backgrounds

### DIFF
--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/AbstractAxisSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/AbstractAxisSettings.java
@@ -45,9 +45,9 @@ public abstract class AbstractAxisSettings implements IAxisSettings {
 	/*
 	 * The default font is only used if no font is set.
 	 */
-	private final Font defaultFont = ResourceSupport.getFont("Tahoma", Resources.MEDIUM_FONT_SIZE, SWT.BOLD); //$NON-NLS-1$
+	private final Font defaultFont = Resources.getFont("Tahoma", Resources.MEDIUM_FONT_SIZE, SWT.BOLD); //$NON-NLS-1$
 
-	public AbstractAxisSettings(String title) {
+	protected AbstractAxisSettings(String title) {
 
 		/*
 		 * In this case, the title is used also as
@@ -56,7 +56,7 @@ public abstract class AbstractAxisSettings implements IAxisSettings {
 		this(title, title);
 	}
 
-	public AbstractAxisSettings(String title, String description) {
+	protected AbstractAxisSettings(String title, String description) {
 
 		this.title = title;
 		this.description = description;

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/Title.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/Title.java
@@ -24,6 +24,8 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.PaletteData;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.graphics.TextLayout;
@@ -357,21 +359,29 @@ public class Title implements ITitle, PaintListener {
 			int margin = textHeight / 10;
 			textWidth += margin;
 		}
-		//
+		/*
+		 * Create image to draw text. If drawing text on rotated graphics
+		 * context instead of drawing rotated image, the text shape becomes a
+		 * bit ugly especially with small font with bold.
+		 */
 		if(textWidth > 0 && textHeight > 0) {
 			/*
-			 * Create image to draw text. If drawing text on rotated graphics
-			 * context instead of drawing rotated image, the text shape becomes a
-			 * bit ugly especially with small font with bold.
+			 * Set transparent background
 			 */
-			Image image = new Image(Display.getCurrent(), textWidth, textHeight);
+			ImageData imageData = new ImageData(textWidth, textHeight, 32, new PaletteData(0xFF0000, 0xFF00, 0xFF));
+			for(int x = 0; x < textWidth; x++) {
+				for(int y = 0; y < textHeight; y++) {
+					int pixelValue = imageData.getPixel(x, y);
+					imageData.setAlpha(x, y, pixelValue == 0 ? 0 : 255);
+				}
+			}
+			Image image = new Image(Display.getCurrent(), imageData);
 			GC tmpGc = new GC(image);
 			//
 			if(useTextLayout()) {
 				TextLayout textLayout = Resources.getTextLayout(textLayoutUUID);
 				textLayout.draw(tmpGc, 0, 0);
 			} else {
-				tmpGc.setBackground(chart.getBackground());
 				tmpGc.setForeground(getForeground());
 				tmpGc.setFont(getFont());
 				tmpGc.fillRectangle(image.getBounds());


### PR DESCRIPTION
In https://github.com/eclipse/swtchart/pull/349 I forgot about the special cases Y axis which is a rotated image. Proper transparency fixes polish issues with backgrounds other than white.