### PR TITLE
Update to Eclipse 2023-06

### DIFF
--- a/org.eclipse.swtchart.targetplatform/org.eclipse.swtchart.targetplatform.target
+++ b/org.eclipse.swtchart.targetplatform/org.eclipse.swtchart.targetplatform.target
@@ -10,7 +10,7 @@
 <unit id="org.apache.batik.dom" version="0.0.0"/>
 <unit id="org.w3c.dom.events" version="0.0.0"/>
 <unit id="org.apache.batik.ext" version="0.0.0"/>
-<repository location="https://download.eclipse.org/releases/2023-03/"/>
+<repository location="https://download.eclipse.org/releases/2023-06/"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
Update swtchart dependencies to 2023-06.

And is it possible also to create a release? The strange thing is: after updating PP to 2023-06, I get a lot of dependencies via swtchart and, interestingly, it results in a different resolution of the target platform on macOS and Windows.