### PR TITLE
Added a help dialog for mouse and keyboard combinations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,11 @@ jobs:
     steps:
     - name: Checkout SWTChart
       uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '17'
         cache: 'maven'
     - name: Build with Maven
       uses: coactions/setup-xvfb@v1

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/BaseChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/BaseChart.java
@@ -45,6 +45,7 @@ import org.eclipse.swtchart.LineStyle;
 import org.eclipse.swtchart.Range;
 import org.eclipse.swtchart.extensions.barcharts.IBarSeriesSettings;
 import org.eclipse.swtchart.extensions.clipboard.IImageClipboardSupplier;
+import org.eclipse.swtchart.extensions.dialogs.ClickBindingHelpDialog;
 import org.eclipse.swtchart.extensions.events.CircularMouseDownEvent;
 import org.eclipse.swtchart.extensions.events.IEventProcessor;
 import org.eclipse.swtchart.extensions.events.IHandledEventProcessor;
@@ -136,6 +137,8 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 	private List<ICustomSeries> customSeriesList = new ArrayList<>();
 	//
 	private IPreferenceStore preferenceStore = ResourceSupport.getPreferenceStore();
+	//
+	private ClickBindingHelpDialog clickBindingPopup;
 
 	public BaseChart(Composite parent, int style) {
 
@@ -698,6 +701,26 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		}
 	}
 
+	public void openShortcutPopup(String shortcut, String name, String description) {
+
+		if(!preferenceStore.getBoolean(PreferenceConstants.P_SHOW_HELP_FOR_EVENTS)) {
+			return;
+		}
+		closeShortcutPopup();
+		int timeToClose = preferenceStore.getInt(PreferenceConstants.P_HELP_POPUP_TIME_TO_CLOSE);
+		clickBindingPopup = new ClickBindingHelpDialog(getShell(), timeToClose);
+		clickBindingPopup.setShortcut(shortcut, name, description);
+		clickBindingPopup.open();
+	}
+
+	private void closeShortcutPopup() {
+
+		if(clickBindingPopup != null) {
+			clickBindingPopup.close();
+			clickBindingPopup = null;
+		}
+	}
+
 	public void selectSeries(String selectedSeriesId) {
 
 		selectSeries(selectedSeriesId, true);
@@ -830,35 +853,31 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		 */
 		if(series instanceof ILineSeries) {
 			ILineSeries<?> lineSeries = (ILineSeries<?>)series;
-			if(seriesSettings instanceof ILineSeriesSettings) {
+			if(seriesSettings instanceof ILineSeriesSettings lineSeriesSettings) {
 				/*
 				 * Line Series
 				 */
-				ILineSeriesSettings lineSeriesSettings = (ILineSeriesSettings)seriesSettings;
 				applyLineSeriesSettings(lineSeries, lineSeriesSettings);
-			} else if(seriesSettings instanceof IScatterSeriesSettings) {
+			} else if(seriesSettings instanceof IScatterSeriesSettings scatterSeriesSettings) {
 				/*
 				 * Scatter Series
 				 */
-				IScatterSeriesSettings scatterSeriesSettings = (IScatterSeriesSettings)seriesSettings;
 				applyScatterSeriesSettings(lineSeries, scatterSeriesSettings);
 			}
 		} else if(series instanceof IBarSeries) {
 			IBarSeries<?> barSeries = (IBarSeries<?>)series;
-			if(seriesSettings instanceof IBarSeriesSettings) {
+			if(seriesSettings instanceof IBarSeriesSettings barSeriesSettings) {
 				/*
 				 * Bar Series
 				 */
-				IBarSeriesSettings barSeriesSettings = (IBarSeriesSettings)seriesSettings;
 				applyBarSeriesSettings(barSeries, barSeriesSettings);
 			}
 		} else if(series instanceof ICircularSeries) {
 			ICircularSeries<?> circularSeries = (ICircularSeries<?>)series;
-			if(seriesSettings instanceof ICircularSeriesSettings) {
+			if(seriesSettings instanceof ICircularSeriesSettings circularSeriesSettings) {
 				/*
 				 * Pie Series
 				 */
-				ICircularSeriesSettings circularSeriesSettings = (ICircularSeriesSettings)seriesSettings;
 				applyCircularSeriesSettings(circularSeries, circularSeriesSettings);
 				//
 				String id = circularSeries.getId();
@@ -931,8 +950,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		circularSeries.setBorderStyle(circularSeriesSettings.getBorderStyle().value());
 		//
 		ISeriesSettings seriesSettingsHighlight = circularSeriesSettings.getSeriesSettingsHighlight();
-		if(seriesSettingsHighlight instanceof ICircularSeriesSettings) {
-			ICircularSeriesSettings circularSeriesSettingsHighlight = (ICircularSeriesSettings)seriesSettingsHighlight;
+		if(seriesSettingsHighlight instanceof ICircularSeriesSettings circularSeriesSettingsHighlight) {
 			circularSeries.setSliceColorHighlight(circularSeriesSettingsHighlight.getSliceColor());
 			circularSeries.setBorderColorHighlight(circularSeriesSettingsHighlight.getBorderColor());
 			circularSeries.setBorderWidthHighlight(circularSeriesSettingsHighlight.getBorderWidth());

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/dialogs/ClickBindingHelpDialog.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/dialogs/ClickBindingHelpDialog.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2023 SAP SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Christian Georgi (SAP SE) - Bug 540440
+ * Matthias Mailänder - adapted for SWT Chart
+ *******************************************************************************/
+package org.eclipse.swtchart.extensions.dialogs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.util.Geometry;
+import org.eclipse.jface.window.Window;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.graphics.Resource;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Monitor;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swtchart.Resources;
+
+public class ClickBindingHelpDialog extends Window {
+
+	private static final int POPUP_FONT_SIZEFACTOR_KEY_LABEL = 2;
+	private static final int POPUP_FONT_SIZEFACTOR_KEY = POPUP_FONT_SIZEFACTOR_KEY_LABEL + 1;
+	private static final int MARGIN_BOTTOM = 25;
+	private final List<Resource> resources = new ArrayList<>(3);
+	private final int timeToClose;
+	private String shortcut;
+	private String name;
+	private String description;
+	private boolean readyToClose = true;
+
+	public ClickBindingHelpDialog(Shell parentShell, int timeToClose) {
+
+		super(parentShell);
+		this.timeToClose = timeToClose;
+		setShellStyle((SWT.NO_TRIM | SWT.ON_TOP | SWT.TOOL) & ~SWT.APPLICATION_MODAL);
+	}
+
+	public void setShortcut(String shortcut, String shortcutText, String shortcutDescription) {
+
+		this.shortcut = shortcut;
+		this.name = shortcutText;
+		this.description = shortcutDescription;
+	}
+
+	@Override
+	public int open() {
+
+		scheduleClose();
+		Shell shell = getShell();
+		if(shell == null || shell.isDisposed()) {
+			create();
+			shell = getShell();
+		}
+		constrainShellSize();
+		shell.setVisible(true);
+		return OK;
+	}
+
+	private void scheduleClose() {
+
+		this.readyToClose = true;
+		Display.getDefault().timerExec(this.timeToClose, () -> {
+			if(ClickBindingHelpDialog.this.readyToClose && getShell() != null && !getShell().isDisposed()) {
+				close();
+			}
+		});
+	}
+
+	@Override
+	public boolean close() {
+
+		boolean closed = super.close();
+		for(Resource resource : this.resources) {
+			resource.dispose();
+		}
+		this.resources.clear();
+		return closed;
+	}
+
+	@Override
+	protected void configureShell(Shell newShell) {
+
+		super.configureShell(newShell);
+		Color color = Resources.getColor("66,66,66");
+		newShell.setBackground(color);
+		newShell.setAlpha(170);
+	}
+
+	@Override
+	protected Control createContents(Composite parent) {
+
+		Font font = JFaceResources.getDialogFont();
+		FontData[] defaultFontData = font.getFontData();
+		Color foregroundColor = parent.getDisplay().getSystemColor(SWT.COLOR_WHITE);
+		Composite contents = new Composite(parent, SWT.NONE);
+		GridLayoutFactory.swtDefaults().applyTo(contents);
+		contents.setBackground(parent.getBackground());
+		String primaryText = null;
+		if(shortcut != null && name != null) {
+			primaryText = shortcut + " – " + name; //$NON-NLS-1$
+		} else if(shortcut != null) {
+			primaryText = shortcut;
+		} else if(name != null) {
+			primaryText = name;
+		}
+		if(primaryText != null) {
+			Label shortcutLabel = new Label(contents, SWT.CENTER);
+			GridDataFactory.fillDefaults().align(SWT.CENTER, SWT.CENTER).applyTo(shortcutLabel);
+			FontData fontData = new FontData(defaultFontData[0].getName(), defaultFontData[0].getHeight() * POPUP_FONT_SIZEFACTOR_KEY, SWT.BOLD);
+			Font shortcutFont = new Font(getShell().getDisplay(), fontData);
+			this.resources.add(shortcutFont);
+			shortcutLabel.setBackground(parent.getBackground());
+			shortcutLabel.setForeground(foregroundColor);
+			shortcutLabel.setFont(shortcutFont);
+			shortcutLabel.setText(primaryText);
+		}
+		if(description != null) {
+			Label shortcutDescriptionLabel = new Label(contents, SWT.CENTER);
+			GridDataFactory.fillDefaults().align(SWT.CENTER, SWT.CENTER).applyTo(shortcutDescriptionLabel);
+			FontData fontData = new FontData(defaultFontData[0].getName(), (int)(defaultFontData[0].getHeight() * 1.3), SWT.NORMAL);
+			Font shortcutFont = new Font(getShell().getDisplay(), fontData);
+			this.resources.add(shortcutFont);
+			shortcutDescriptionLabel.setFont(shortcutFont);
+			shortcutDescriptionLabel.setBackground(parent.getBackground());
+			shortcutDescriptionLabel.setForeground(foregroundColor);
+			shortcutDescriptionLabel.setText(description);
+		}
+		return contents;
+	}
+
+	@Override
+	protected Point getInitialLocation(Point initialSize) {
+
+		Composite parent = getShell().getParent();
+		Rectangle parentBounds = parent.getBounds();
+		Monitor monitor = parent.getMonitor();
+		Rectangle monitorBounds = monitor.getClientArea();
+		Point centerPoint = Geometry.centerPoint(parent.getBounds());
+		return new Point(centerPoint.x - (initialSize.x / 2), //
+				Math.max(monitorBounds.y, parentBounds.y + parentBounds.height - (initialSize.y) - MARGIN_BOTTOM));
+	}
+}

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/AbstractHandledEventProcessor.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/AbstractHandledEventProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package org.eclipse.swtchart.extensions.events;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Event;
+import org.eclipse.swtchart.extensions.core.BaseChart;
 import org.eclipse.swtchart.extensions.core.IMouseSupport;
 
 public abstract class AbstractHandledEventProcessor implements IHandledEventProcessor {
@@ -26,5 +28,71 @@ public abstract class AbstractHandledEventProcessor implements IHandledEventProc
 	protected boolean isSingleClick(Event event) {
 
 		return event.count == 1;
+	}
+
+	public void showClickbindingHelp(BaseChart chart, String name, String description) {
+
+		chart.openShortcutPopup(getFormattedShortcut(), name, description);
+	}
+
+	private String getFormattedShortcut() {
+
+		String modifier = "";
+		if((getStateMask() & SWT.MOD1) == SWT.MOD1) {
+			modifier = isMac() ? "CMD" : "CTRL";
+		} else if((getStateMask() & SWT.MOD2) == SWT.MOD2) {
+			modifier = "SHIFT";
+		} else if((getStateMask() & SWT.MOD3) == SWT.MOD3) {
+			modifier = "ALT";
+		}
+		//
+		String button = "";
+		switch(getButton()) {
+			case IMouseSupport.MOUSE_BUTTON_LEFT:
+				button = "Left";
+				break;
+			case IMouseSupport.MOUSE_BUTTON_MIDDLE:
+				button = "Middle";
+				break;
+			case IMouseSupport.MOUSE_BUTTON_RIGHT:
+				button = "Right";
+				break;
+		}
+		//
+		String event = "";
+		switch(getEvent()) {
+			case IMouseSupport.EVENT_MOUSE_DOUBLE_CLICK:
+				event = "Double Click";
+				break;
+			case IMouseSupport.EVENT_MOUSE_DOWN:
+			case IMouseSupport.EVENT_MOUSE_UP:
+				event = "Click";
+				break;
+		}
+		StringBuilder builder = new StringBuilder();
+		if(!modifier.isEmpty()) {
+			builder.append(modifier);
+		}
+		if(!button.isEmpty()) {
+			if(!modifier.isEmpty()) {
+				builder.append(" + " + button);
+			} else {
+				builder.append(button);
+			}
+		}
+		if(!event.isEmpty()) {
+			builder.append(" " + event);
+		}
+		return builder.toString();
+	}
+
+	private static boolean isMac() {
+
+		return (getOperatingSystem().indexOf("mac") >= 0);
+	}
+
+	private static String getOperatingSystem() {
+
+		return System.getProperty("os.name").toLowerCase();
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseMoveShiftEvent.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseMoveShiftEvent.java
@@ -64,6 +64,7 @@ public class MouseMoveShiftEvent extends AbstractHandledEventProcessor implement
 						/*
 						 * Shift
 						 */
+						showClickbindingHelp(baseChart, "Shift series", "Shift the selected series.");
 						baseChart.setMoveStartTime(System.currentTimeMillis());
 						//
 						double shiftX = baseChart.getShiftValue(baseChart.getXMoveStart(), event.x, IExtendedChart.X_AXIS);

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseWheelEvent.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseWheelEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -64,14 +64,17 @@ public class MouseWheelEvent extends AbstractHandledEventProcessor implements IH
 			 */
 			baseChart.zoomX(xAxis, event);
 			baseChart.zoomY(yAxis, event);
+			showClickbindingHelp(baseChart, "Zoom", "Zoom the X and Y axis.");
 		} else {
 			/*
 			 * X or Y zoom.
 			 */
 			if(rangeRestriction.isRestrictZoomX()) {
 				baseChart.zoomX(xAxis, event);
+				showClickbindingHelp(baseChart, "Zoom", "Zoom the X axis.");
 			} else if(rangeRestriction.isRestrictZoomY()) {
 				baseChart.zoomY(yAxis, event);
+				showClickbindingHelp(baseChart, "Zoom", "Zoom the Y axis.");
 			}
 		}
 	}

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/ResetSeriesEvent.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/ResetSeriesEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -40,6 +40,7 @@ public class ResetSeriesEvent extends AbstractHandledEventProcessor implements I
 	@Override
 	public void handleEvent(BaseChart baseChart, Event event) {
 
+		showClickbindingHelp(baseChart, "Reset", "Unzoom to cover complete range.");
 		baseChart.adjustRange(true);
 		baseChart.fireUpdateCustomRangeSelectionHandlers(event);
 		baseChart.redraw();

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/SelectDataPointEvent.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/SelectDataPointEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -46,5 +46,6 @@ public class SelectDataPointEvent extends AbstractHandledEventProcessor implemen
 		 * double y = getSelectedPrimaryAxisValue(event.y, IExtendedChart.Y_AXIS);
 		 */
 		baseChart.fireUpdateCustomPointSelectionHandlers(event);
+		showClickbindingHelp(baseChart, "Select", "Select a data point.");
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/SelectHideSeriesEvent.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/SelectHideSeriesEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -49,8 +49,10 @@ public class SelectHideSeriesEvent extends AbstractHandledEventProcessor impleme
 			 */
 			String selectedSeriesId = baseChart.getSelectedseriesId(event);
 			if(selectedSeriesId.equals("")) { //$NON-NLS-1$
+				showClickbindingHelp(baseChart, "Unhide", "Display all series again.");
 				baseChart.resetSeriesSettings();
 			} else {
+				showClickbindingHelp(baseChart, "Hide", "Hide the selected series.");
 				baseChart.hideSeries(selectedSeriesId);
 				baseChart.redraw();
 			}
@@ -60,8 +62,10 @@ public class SelectHideSeriesEvent extends AbstractHandledEventProcessor impleme
 			 */
 			String selectedSeriesId = baseChart.getSelectedseriesId(event);
 			if(selectedSeriesId.equals("")) { //$NON-NLS-1$
+				showClickbindingHelp(baseChart, "Unselect", "Deselect a series.");
 				baseChart.resetSeriesSettings();
 			} else {
+				showClickbindingHelp(baseChart, "Select", "Select series.");
 				baseChart.selectSeries(selectedSeriesId);
 				baseChart.redraw();
 			}

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/UndoRedoEvent.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/UndoRedoEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Lablicate GmbH.
+ * Copyright (c) 2017, 2023 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -47,6 +47,7 @@ public class UndoRedoEvent extends AbstractHandledEventProcessor implements IHan
 			 * Redo
 			 */
 			baseChart.redoSelection();
+			showClickbindingHelp(baseChart, "Select", "Select series.");
 		} else {
 			/*
 			 * Undo

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/preferences/PreferenceConstants.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/preferences/PreferenceConstants.java
@@ -60,4 +60,9 @@ public class PreferenceConstants {
 	public static final int DEF_BITMAP_EXPORT_WIDTH = 512;
 	public static final String P_BITMAP_EXPORT_HEIGHT = "bitmapExportHeight";
 	public static final int DEF_BITMAP_EXPORT_HEIGHT = 512;
+	//
+	public static final String P_SHOW_HELP_FOR_EVENTS = "showHelpForEvents";
+	public static final boolean DEF_SHOW_HELP_FOR_EVENTS = false;
+	public static final String P_HELP_POPUP_TIME_TO_CLOSE = "showHelpForEvents_timeToClose";
+	public static final int DEF_HELP_POPUP_TIME_TO_CLOSE = 6000;
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/preferences/PreferenceInitializer.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/preferences/PreferenceInitializer.java
@@ -38,6 +38,8 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 			preferenceStore.setDefault(PreferenceConstants.P_BITMAP_EXPORT_CUSTOM_SIZE, PreferenceConstants.DEF_BITMAP_EXPORT_CUSTOM_SIZE);
 			preferenceStore.setDefault(PreferenceConstants.P_BITMAP_EXPORT_WIDTH, PreferenceConstants.DEF_BITMAP_EXPORT_WIDTH);
 			preferenceStore.setDefault(PreferenceConstants.P_BITMAP_EXPORT_HEIGHT, PreferenceConstants.DEF_BITMAP_EXPORT_HEIGHT);
+			preferenceStore.setDefault(PreferenceConstants.P_SHOW_HELP_FOR_EVENTS, PreferenceConstants.DEF_SHOW_HELP_FOR_EVENTS);
+			preferenceStore.setDefault(PreferenceConstants.P_HELP_POPUP_TIME_TO_CLOSE, PreferenceConstants.DEF_HELP_POPUP_TIME_TO_CLOSE);
 		}
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/preferences/PreferencePage.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/preferences/PreferencePage.java
@@ -47,5 +47,7 @@ public class PreferencePage extends FieldEditorPreferencePage {
 		addField(new BooleanFieldEditor(PreferenceConstants.P_BITMAP_EXPORT_CUSTOM_SIZE, "Bitmap Export Custom Size", getFieldEditorParent()));
 		addField(new IntegerFieldEditor(PreferenceConstants.P_BITMAP_EXPORT_WIDTH, "Bitmap Export Width", getFieldEditorParent()));
 		addField(new IntegerFieldEditor(PreferenceConstants.P_BITMAP_EXPORT_HEIGHT, "Bitmap Export Height", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(PreferenceConstants.P_SHOW_HELP_FOR_EVENTS, "Show pop-up on clickbinding", getFieldEditorParent()));
+		addField(new IntegerFieldEditor(PreferenceConstants.P_HELP_POPUP_TIME_TO_CLOSE, "Time to close popup [ms]", getFieldEditorParent()));
 	}
 }


### PR DESCRIPTION
[Show Key Bindings When Command is Invoked](https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.user%2Fconcepts%2Faccessibility%2Fkeyboardshortcuts.htm) is a cool feature for seminars or training videos. However, it only covers hotkeys registered to Eclipse commands and everything is internal API. I recreated it here to also cover click bindings where mouse and keyboard are involved. You can turn this feature on in the SWT Chart settings.