### PR TITLE
Polished the title and the example background colors

### DIFF
--- a/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/PCAChart.java
+++ b/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/PCAChart.java
@@ -70,6 +70,7 @@ public class PCAChart extends ScatterChart {
 		//
 		IChartSettings chartSettings = getChartSettings();
 		chartSettings.setTitle(chartTitle);
+		chartSettings.setTitleVisible(true);
 		chartSettings.getPrimaryAxisSettingsX().setTitle(xAxisTitle);
 		chartSettings.getPrimaryAxisSettingsY().setTitle(yAxisTitle);
 		applySettings(chartSettings);

--- a/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/ParallelPieCharts.java
+++ b/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/ParallelPieCharts.java
@@ -151,6 +151,7 @@ public class ParallelPieCharts {
 			linkedPieCharts.get(i).getChartSettings().setTitle(titles[i]);
 			PieChart pieChart = linkedPieCharts.get(i);
 			ChartSettings chartSettings = (ChartSettings)pieChart.getChartSettings();
+			chartSettings.setTitleVisible(true);
 			chartSettings.setTitleColor(Display.getDefault().getSystemColor(SWT.COLOR_BLACK));
 			pieChart.applySettings(chartSettings);
 		}
@@ -182,6 +183,7 @@ public class ParallelPieCharts {
 		}
 		ChartSettings chartSettings = (ChartSettings)pieChart.getChartSettings();
 		chartSettings.setLegendVisible(false);
+		chartSettings.setTitleVisible(true);
 		chartSettings.setTitleColor(Display.getDefault().getSystemColor(SWT.COLOR_BLACK));
 		chartSettings.setLegendExtendedVisible(false);
 		chartSettings.setShowLegendMarker(false);

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/AxisTickBoundsExample.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/AxisTickBoundsExample.java
@@ -61,7 +61,7 @@ public class AxisTickBoundsExample {
 	 *            The parent composite
 	 * @return The created chart
 	 */
-	static public Chart createChart(Composite parent) {
+	public static Chart createChart(Composite parent) {
 
 		// create a chart
 		final Chart chart = new Chart(parent, SWT.NONE);

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/AxisTickBoundsExample.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/AxisTickBoundsExample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 SWTChart project.
+ * Copyright (c) 2008, 2023 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -66,6 +66,8 @@ public class AxisTickBoundsExample {
 		// create a chart
 		final Chart chart = new Chart(parent, SWT.NONE);
 		chart.getTitle().setText("Axis Tick Bounds");
+		chart.getPlotArea().setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_WHITE));
+		chart.setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_WHITE));
 		// create bar series
 		IBarSeries<?> series1 = (IBarSeries<?>)chart.getSeriesSet().createSeries(SeriesType.BAR, "series");
 		series1.setYSeries(ySeries);

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/BarBoundsExample.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/BarBoundsExample.java
@@ -63,7 +63,7 @@ public class BarBoundsExample {
 	 *            The parent composite
 	 * @return The created chart
 	 */
-	static public Chart createChart(Composite parent) {
+	public static Chart createChart(Composite parent) {
 
 		// create a chart
 		final Chart chart = new Chart(parent, SWT.NONE);

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/BarBoundsExample.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/BarBoundsExample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 SWTChart project.
+ * Copyright (c) 2008, 2023 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -68,6 +68,8 @@ public class BarBoundsExample {
 		// create a chart
 		final Chart chart = new Chart(parent, SWT.NONE);
 		chart.getTitle().setText("Bar Bounds");
+		chart.getPlotArea().setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_WHITE));
+		chart.setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_WHITE));
 		// create bar series
 		IBarSeries<?> series1 = (IBarSeries<?>)chart.getSeriesSet().createSeries(SeriesType.BAR, "series 1");
 		series1.setYSeries(ySeries1);

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/CustomPaintListenerExample.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/CustomPaintListenerExample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 SWTChart project.
+ * Copyright (c) 2008, 2023 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -66,6 +66,8 @@ public class CustomPaintListenerExample {
 		// create a chart
 		Chart chart = new Chart(parent, SWT.NONE);
 		chart.getTitle().setText("Custom Paint Listener");
+		chart.getPlotArea().setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_WHITE));
+		chart.setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_WHITE));
 		ISeries<?> lineSeries = chart.getSeriesSet().createSeries(SeriesType.LINE, "line series");
 		lineSeries.setYSeries(ySeries);
 		// add paint listeners

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/CustomPaintListenerExample.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/CustomPaintListenerExample.java
@@ -61,7 +61,7 @@ public class CustomPaintListenerExample {
 	 *            The parent composite
 	 * @return The created chart
 	 */
-	static public Chart createChart(Composite parent) {
+	public static Chart createChart(Composite parent) {
 
 		// create a chart
 		Chart chart = new Chart(parent, SWT.NONE);
@@ -71,7 +71,7 @@ public class CustomPaintListenerExample {
 		ISeries<?> lineSeries = chart.getSeriesSet().createSeries(SeriesType.LINE, "line series");
 		lineSeries.setYSeries(ySeries);
 		// add paint listeners
-		IPlotArea plotArea = (IPlotArea)chart.getPlotArea();
+		IPlotArea plotArea = chart.getPlotArea();
 		plotArea.addCustomPaintListener(new FrontPaintListener());
 		plotArea.addCustomPaintListener(new BehindPaintListener());
 		// adjust the axis range

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/DataToPixelConversionExample.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/DataToPixelConversionExample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 SWTChart project.
+ * Copyright (c) 2008, 2023 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -68,6 +68,8 @@ public class DataToPixelConversionExample {
 		// create a chart
 		Chart chart = new Chart(parent, SWT.NONE);
 		chart.getTitle().setText("Data To Pixel Conversion");
+		chart.getPlotArea().setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_WHITE));
+		chart.setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_WHITE));
 		// get Y axis
 		final IAxis yAxis = chart.getAxisSet().getYAxis(0);
 		// create line series

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/DataToPixelConversionExample.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/DataToPixelConversionExample.java
@@ -63,7 +63,7 @@ public class DataToPixelConversionExample {
 	 *            The parent composite
 	 * @return The created chart
 	 */
-	static public Chart createChart(Composite parent) {
+	public static Chart createChart(Composite parent) {
 
 		// create a chart
 		Chart chart = new Chart(parent, SWT.NONE);

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/HighlightMultiLevelPie.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/HighlightMultiLevelPie.java
@@ -72,6 +72,8 @@ public class HighlightMultiLevelPie {
 
 		Chart chart = new Chart(parent, SWT.NONE);
 		chart.getTitle().setText("Multi Level Pie Chart");
+		chart.getPlotArea().setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_WHITE));
+		chart.setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_WHITE));
 		ICircularSeries<?> multiLevelPie = (ICircularSeries<?>)chart.getSeriesSet().createSeries(SeriesType.PIE, "countries");
 		multiLevelPie.setSeries(continentLabels, continentValues);
 		multiLevelPie.getNodeById("Asia").addChildren(AsianCountriesLabels, AsianCountriesValues);

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/HighlightMultiLevelPie.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/HighlightMultiLevelPie.java
@@ -68,7 +68,7 @@ public class HighlightMultiLevelPie {
 	 *            The parent composite
 	 * @return The created chart
 	 */
-	static public Chart createChart(Composite parent) {
+	public static Chart createChart(Composite parent) {
 
 		Chart chart = new Chart(parent, SWT.NONE);
 		chart.getTitle().setText("Multi Level Pie Chart");

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/LegendBoundsExample.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/LegendBoundsExample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 SWTChart project.
+ * Copyright (c) 2008, 2023 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -68,6 +68,8 @@ public class LegendBoundsExample {
 		// create a chart
 		final Chart chart = new Chart(parent, SWT.NONE);
 		chart.getTitle().setText("Legend Bounds");
+		chart.getPlotArea().setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_WHITE));
+		chart.setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_WHITE));
 		// create bar series
 		IBarSeries<?> series1 = (IBarSeries<?>)chart.getSeriesSet().createSeries(SeriesType.BAR, "series 1");
 		series1.setYSeries(ySeries1);

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/LegendBoundsExample.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/LegendBoundsExample.java
@@ -63,7 +63,7 @@ public class LegendBoundsExample {
 	 *            The parent composite
 	 * @return The created chart
 	 */
-	static public Chart createChart(Composite parent) {
+	public static Chart createChart(Composite parent) {
 
 		// create a chart
 		final Chart chart = new Chart(parent, SWT.NONE);

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/PixelToDataConversionExample.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/PixelToDataConversionExample.java
@@ -59,7 +59,7 @@ public class PixelToDataConversionExample {
 	 *            The parent composite
 	 * @return The created chart
 	 */
-	static public Chart createChart(Composite parent) {
+	public static Chart createChart(Composite parent) {
 
 		// create a chart
 		final Chart chart = new Chart(parent, SWT.NONE);

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/PixelToDataConversionExample.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/PixelToDataConversionExample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 SWTChart project.
+ * Copyright (c) 2008, 2023 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -63,7 +63,9 @@ public class PixelToDataConversionExample {
 
 		// create a chart
 		final Chart chart = new Chart(parent, SWT.NONE);
-		chart.getTitle().setText("Pxiel To Data Conversion");
+		chart.getTitle().setText("Pixel To Data Conversion");
+		chart.getPlotArea().setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_WHITE));
+		chart.setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_WHITE));
 		// get axes
 		final IAxis xAxis = chart.getAxisSet().getXAxis(0);
 		final IAxis yAxis = chart.getAxisSet().getYAxis(0);

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/SymbolBoundsExample.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/SymbolBoundsExample.java
@@ -63,7 +63,7 @@ public class SymbolBoundsExample {
 	 *            The parent composite
 	 * @return The created chart
 	 */
-	static public Chart createChart(Composite parent) {
+	public static Chart createChart(Composite parent) {
 
 		// create a chart
 		final Chart chart = new Chart(parent, SWT.NONE);

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/SymbolBoundsExample.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/SymbolBoundsExample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 SWTChart project.
+ * Copyright (c) 2008, 2023 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -68,6 +68,8 @@ public class SymbolBoundsExample {
 		// create a chart
 		final Chart chart = new Chart(parent, SWT.NONE);
 		chart.getTitle().setText("Symbol Bounds");
+		chart.getPlotArea().setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_WHITE));
+		chart.setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_WHITE));
 		// create line series
 		ILineSeries<?> series1 = (ILineSeries<?>)chart.getSeriesSet().createSeries(SeriesType.LINE, "series 1");
 		series1.setYSeries(ySeries1);

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/ComplexPieChartExample.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/ComplexPieChartExample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 SWTChart project.
+ * Copyright (c) 2020, 2023 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,9 +12,11 @@
  *******************************************************************************/
 package org.eclipse.swtchart.extensions.examples.charts;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swtchart.extensions.core.IChartSettings;
 import org.eclipse.swtchart.extensions.examples.parts.ComplexPieChart;
 
 public class ComplexPieChartExample {
@@ -27,7 +29,12 @@ public class ComplexPieChartExample {
 		shell.setSize(700, 600);
 		shell.setLayout(new FillLayout());
 		//
-		new ComplexPieChart(shell);
+		ComplexPieChart complexPieChart = new ComplexPieChart(shell);
+		IChartSettings chartSettings = complexPieChart.getChartSettings();
+		chartSettings.setBackground(display.getSystemColor(SWT.COLOR_WHITE));
+		chartSettings.setBackgroundChart(display.getSystemColor(SWT.COLOR_WHITE));
+		chartSettings.setBackgroundPlotArea(display.getSystemColor(SWT.COLOR_WHITE));
+		complexPieChart.applySettings(chartSettings);
 		shell.open();
 		//
 		while(!shell.isDisposed()) {

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/DemoBoxPlotChart.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/DemoBoxPlotChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2023 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -53,6 +53,9 @@ public class DemoBoxPlotChart {
 		chartSettings.setBufferSelection(true);
 		chartSettings.setHorizontalSliderVisible(false);
 		chartSettings.setVerticalSliderVisible(false);
+		chartSettings.setBackground(display.getSystemColor(SWT.COLOR_WHITE));
+		chartSettings.setBackgroundChart(display.getSystemColor(SWT.COLOR_WHITE));
+		chartSettings.setBackgroundPlotArea(display.getSystemColor(SWT.COLOR_WHITE));
 		RangeRestriction rangeRestriction = chartSettings.getRangeRestriction();
 		rangeRestriction.setExtendTypeX(ExtendType.ABSOLUTE);
 		rangeRestriction.setExtendMinX(0.5d);

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/DemoChart.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/DemoChart.java
@@ -50,6 +50,7 @@ public class DemoChart {
 		 */
 		IChartSettings chartSettings = scrollableChart.getChartSettings();
 		chartSettings.setTitle("Chromatogram Example");
+		chartSettings.setTitleVisible(true);
 		chartSettings.setTitleColor(display.getSystemColor(SWT.COLOR_BLACK));
 		chartSettings.setLegendExtendedVisible(true);
 		chartSettings.setBufferSelection(true);

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/FixedRangeChart.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/FixedRangeChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 SWTChart project.
+ * Copyright (c) 2022, 2023 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,12 +12,14 @@
  *******************************************************************************/
 package org.eclipse.swtchart.extensions.examples.charts;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtchart.IAxis;
 import org.eclipse.swtchart.Range;
 import org.eclipse.swtchart.extensions.core.BaseChart;
+import org.eclipse.swtchart.extensions.core.IChartSettings;
 import org.eclipse.swtchart.extensions.core.ScrollableChart;
 import org.eclipse.swtchart.extensions.examples.parts.BarSeries_1_1_Part;
 
@@ -32,6 +34,11 @@ public class FixedRangeChart {
 		shell.setLayout(new FillLayout());
 		//
 		ScrollableChart scrollableChart = new BarSeries_1_1_Part(shell);
+		IChartSettings chartSettings = scrollableChart.getChartSettings();
+		chartSettings.setBackground(display.getSystemColor(SWT.COLOR_WHITE));
+		chartSettings.setBackgroundChart(display.getSystemColor(SWT.COLOR_WHITE));
+		chartSettings.setBackgroundPlotArea(display.getSystemColor(SWT.COLOR_WHITE));
+		scrollableChart.applySettings(chartSettings);
 		shell.open();
 		/*
 		 * Set a fixed range.

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/NoBorderSimpleChart.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/NoBorderSimpleChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Lablicate GmbH.
+ * Copyright (c) 2022, 2023 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -52,6 +52,9 @@ public class NoBorderSimpleChart {
 		chartSettings.setTitleColor(Display.getDefault().getSystemColor(SWT.COLOR_BLACK));
 		chartSettings.setTitleFont(font);
 		chartSettings.setTitleVisible(true);
+		chartSettings.setBackground(display.getSystemColor(SWT.COLOR_WHITE));
+		chartSettings.setBackgroundChart(display.getSystemColor(SWT.COLOR_WHITE));
+		chartSettings.setBackgroundPlotArea(display.getSystemColor(SWT.COLOR_WHITE));
 		disableSecondaryAxes(chartSettings.getSecondaryAxisSettingsListX());
 		disableSecondaryAxes(chartSettings.getSecondaryAxisSettingsListY());
 		scrollableChart.applySettings(chartSettings);

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/SimplePieChartExample.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/SimplePieChartExample.java
@@ -13,9 +13,11 @@
  *******************************************************************************/
 package org.eclipse.swtchart.extensions.examples.charts;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swtchart.extensions.core.IChartSettings;
 import org.eclipse.swtchart.extensions.examples.parts.SimplePieChart;
 
 public class SimplePieChartExample {
@@ -30,7 +32,12 @@ public class SimplePieChartExample {
 		//
 		boolean doughnut = true;
 		boolean highlightSeries = false;
-		new SimplePieChart(shell, doughnut, highlightSeries);
+		SimplePieChart simplePieChart = new SimplePieChart(shell, doughnut, highlightSeries);
+		IChartSettings chartSettings = simplePieChart.getChartSettings();
+		chartSettings.setBackground(display.getSystemColor(SWT.COLOR_WHITE));
+		chartSettings.setBackgroundChart(display.getSystemColor(SWT.COLOR_WHITE));
+		chartSettings.setBackgroundPlotArea(display.getSystemColor(SWT.COLOR_WHITE));
+		simplePieChart.applySettings(chartSettings);
 		shell.open();
 		//
 		while(!shell.isDisposed()) {

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/SimplePieChart.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/SimplePieChart.java
@@ -83,8 +83,7 @@ public class SimplePieChart extends PieChart {
 		if(highlightSeries) {
 			settings.setRedrawOnClick(false);
 			ISeriesSettings seriesSettingsHighlight = settings.getSeriesSettingsHighlight();
-			if(seriesSettingsHighlight instanceof ICircularSeriesSettings) {
-				ICircularSeriesSettings settingsHighlight = (ICircularSeriesSettings)seriesSettingsHighlight;
+			if(seriesSettingsHighlight instanceof ICircularSeriesSettings settingsHighlight) {
 				settingsHighlight.setBorderColor(Display.getDefault().getSystemColor(SWT.COLOR_CYAN));
 				settingsHighlight.setBorderWidth(5);
 				settingsHighlight.setBorderStyle(LineStyle.DOT);

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ChartSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ChartSettings.java
@@ -131,7 +131,11 @@ public class ChartSettings implements IChartSettings {
 		//
 		colorHintRangeSelector = display.getSystemColor(SWT.COLOR_RED);
 		//
-		titleColor = display.getSystemColor(SWT.COLOR_TITLE_FOREGROUND);
+		if(Display.isSystemDarkTheme()) {
+			titleColor = display.getSystemColor(SWT.COLOR_WHITE);
+		} else {
+			titleColor = display.getSystemColor(SWT.COLOR_BLACK);
+		}
 		titleFont = defaultFont;
 		//
 		rangeRestriction.setZeroX(true);

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ChartSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ChartSettings.java
@@ -77,7 +77,7 @@ public class ChartSettings implements IChartSettings {
 	 * title is set and WHITE is used to hide it.
 	 */
 	private String title = Messages.getString(Messages.CHART_TITLE);
-	private boolean titleVisible = true;
+	private boolean titleVisible = false;
 	private Color titleColor;
 	private Font titleFont;
 	//


### PR DESCRIPTION
I removed the strange default of rendering a white diagram title on white background. On the other hand, defaulting to gray widget background during my dark mode changes seemed to have visually regressed the examples which were clearly designed with a white background in mind, so I changed this back.