### PR TITLE
Build with Temurin 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022, 2023 SWTChart project
+# Copyright (c) 2022, 2024 SWTChart project
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -22,11 +22,11 @@ jobs:
     steps:
     - name: Checkout SWTChart
       uses: actions/checkout@v3
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '11'
         cache: 'maven'
     - name: Build with Maven
       uses: coactions/setup-xvfb@v1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
 	}
 	tools {
 		maven 'apache-maven-latest'
-		jdk   'temurin-jdk17-latest'
+		jdk   'temurin-jdk11-latest'
 	}
 	stages {
 		stage('Build') {

--- a/org.eclipse.swtchart.customcharts/.classpath
+++ b/org.eclipse.swtchart.customcharts/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.eclipse.swtchart.customcharts/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.customcharts/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.swtchart;bundle-version="0.14.0",
  org.eclipse.swtchart.extensions;bundle-version="0.14.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.swtchart.customcharts
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.swtchart.customcharts.core

--- a/org.eclipse.swtchart.examples/.classpath
+++ b/org.eclipse.swtchart.examples/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.eclipse.swtchart.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.examples/META-INF/MANIFEST.MF
@@ -9,5 +9,5 @@ Bundle-Vendor: Eclipse
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.swtchart;bundle-version="0.14.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.swtchart.export.extended.test/.classpath
+++ b/org.eclipse.swtchart.export.extended.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src">
 		<attributes>

--- a/org.eclipse.swtchart.export.extended.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.export.extended.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-Version: 0.14.0.qualifier
 Bundle-Vendor: ChemClipse
 Fragment-Host: org.eclipse.swtchart.export.extended;bundle-version="0.14.0"
 Automatic-Module-Name: org.eclipse.swtchart.export.extended.test
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/org.eclipse.swtchart.export.extended/.classpath
+++ b/org.eclipse.swtchart.export.extended/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.eclipse.swtchart.export.extended/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.export.extended/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.swtchart;bundle-version="0.14.0",
  org.eclipse.swtchart.extensions;bundle-version="0.14.0",
  org.eclipse.swtchart.export;bundle-version="0.14.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Eclipse SWTChart
 Export-Package: org.eclipse.swtchart.export.extended.menu.vector

--- a/org.eclipse.swtchart.export.test/.classpath
+++ b/org.eclipse.swtchart.export.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.eclipse.swtchart.export.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.export.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: Test
 Bundle-SymbolicName: org.eclipse.swtchart.export.test
 Bundle-Version: 0.14.0.qualifier
 Fragment-Host: org.eclipse.swtchart.export;bundle-version="0.14.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse SWTChart
 Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.swtchart.customcharts;bundle-version="0.14.0"

--- a/org.eclipse.swtchart.export/.classpath
+++ b/org.eclipse.swtchart.export/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.eclipse.swtchart.export/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.export/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.swtchart;bundle-version="0.14.0",
  org.eclipse.swtchart.extensions;bundle-version="0.14.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Eclipse SWTChart
 Export-Package: org.eclipse.swtchart.export.core,

--- a/org.eclipse.swtchart.extensions.eclipse/.classpath
+++ b/org.eclipse.swtchart.extensions.eclipse/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.eclipse.swtchart.extensions.eclipse/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.extensions.eclipse/META-INF/MANIFEST.MF
@@ -13,5 +13,5 @@ Require-Bundle: org.eclipse.jface,
  org.eclipse.ui.workbench;bundle-version="3.111.0",
  org.eclipse.core.databinding;bundle-version="1.6.200",
  org.eclipse.swtchart.extensions;bundle-version="0.14.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.swtchart.extensions.examples/.classpath
+++ b/org.eclipse.swtchart.extensions.examples/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.eclipse.swtchart.extensions.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.extensions.examples/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.e4.ui.model.workbench;bundle-version="1.2.0.v20160229-1459",
  javax.inject,
  org.eclipse.swtchart.customcharts;bundle-version="0.14.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: javax.annotation;version="1.2.0"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.swtchart.extensions.examples.support

--- a/org.eclipse.swtchart.extensions.test/.classpath
+++ b/org.eclipse.swtchart.extensions.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.eclipse.swtchart.extensions.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.extensions.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: org.eclipse.swtchart.extensions.test
 Bundle-Version: 0.14.0.qualifier
 Bundle-Vendor: ChemClipse
 Fragment-Host: org.eclipse.swtchart.extensions;bundle-version="0.14.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/org.eclipse.swtchart.extensions/.classpath
+++ b/org.eclipse.swtchart.extensions/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.eclipse.swtchart.extensions/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.extensions/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.jface,
  org.eclipse.swt,
  org.eclipse.swtchart;bundle-version="0.14.0",
  org.eclipse.core.databinding;bundle-version="1.6.200"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.swtchart.extensions.axisconverter,
  org.eclipse.swtchart.extensions.barcharts,

--- a/org.eclipse.swtchart.test/.classpath
+++ b/org.eclipse.swtchart.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.eclipse.swtchart.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.test/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-SymbolicName: org.eclipse.swtchart.test
 Bundle-Version: 0.14.0.qualifier
 Bundle-Vendor: SWTChart
 Fragment-Host: org.eclipse.swtchart;bundle-version="0.14.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/org.eclipse.swtchart/.classpath
+++ b/org.eclipse.swtchart/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.eclipse.swtchart/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-SymbolicName: org.eclipse.swtchart
 Bundle-Version: 0.14.0.qualifier
 Bundle-Vendor: Eclipse SWTChart
 Require-Bundle: org.eclipse.swt
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.swtchart,
  org.eclipse.swtchart.internal;x-friends:="org.eclipse.swtchart.export",


### PR DESCRIPTION
The code base is still meant to be Java 11. https://adoptium.net/support/ is supported until at least Oct 2027. This reverts https://github.com/eclipse/swtchart/issues/358.