### PR TITLE
Don't print unnecessary exception

### DIFF
--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ResourceSupport.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ResourceSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2024 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ResourceSupport.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ResourceSupport.java
@@ -13,6 +13,7 @@
 package org.eclipse.swtchart.extensions.core;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
 import java.util.HashSet;
@@ -100,6 +101,8 @@ public class ResourceSupport extends Resources {
 			 */
 			try {
 				((PreferenceStore)preferenceStore).load();
+			} catch(FileNotFoundException e) {
+				// Ignore
 			} catch(IOException e) {
 				e.printStackTrace();
 			}


### PR DESCRIPTION
No exception printing when `~/.eclipseswtchartsettings` does not exist.

Fixes #380.