### PR TITLE
Fix resource leak issue - 372

### DIFF
--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/Chart.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/Chart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SWTChart project.
+ * Copyright (c) 2008, 2024 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -386,12 +386,10 @@ public class Chart extends Composite implements Listener {
 	@Override
 	public void dispose() {
 
-		if(!isDisposed()) {
-			title.dispose();
-			legend.dispose();
-			axisSet.dispose();
-			super.dispose();
-		}
+		title.dispose();
+		legend.dispose();
+		axisSet.dispose();
+		super.dispose();
 	}
 
 	@Override

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/Title.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/Title.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SWTChart project.
+ * Copyright (c) 2008, 2024 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -277,8 +277,9 @@ public class Title implements ITitle, PaintListener {
 	 * Disposes the resources.
 	 */
 	public void dispose() {
-
-		chart.removePaintListener(this);
+		if(!chart.isDisposed()) {
+			chart.removePaintListener(this);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Scenario - If we have multiple level of parents for chart widget and If we dispose bottom most(top most is chart) widget by invoking dispose chart widget get disposed without calling chart.dispose(). Any subsequent call to dispose never calls dispose for it's children. So checking if chart disposed in the dispose method never give an opportunity to children dispose in the above Scenario. I have added chart disposed safety check at Title because this was causing the issue https://github.com/eclipse/swtchart/issues/289.

Fixes https://github.com/eclipse/swtchart/issues/372