### PR TITLE
Update to Eclipse 4.30

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022, 2023 SWTChart project
+# Copyright (c) 2022, 2024 SWTChart project
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -15,6 +15,9 @@ name: Continuous Integration
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,12 +25,19 @@ jobs:
     steps:
     - name: Checkout SWTChart
       uses: actions/checkout@v3
-    - name: Set up JDK 17
+
+    - name: Set up JDK
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: '17'
         cache: 'maven'
+
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4.5
+      with:
+        maven-version: 3.9.6
+
     - name: Build with Maven
       uses: coactions/setup-xvfb@v1
       with:

--- a/org.eclipse.swtchart.cbi/pom.xml
+++ b/org.eclipse.swtchart.cbi/pom.xml
@@ -87,9 +87,9 @@
   -->
   <properties>
     <!-- VERSIONS -->
-    <tycho.version>2.7.5</tycho.version>
-    <pmd.version>2.7.1</pmd.version>
-    <checkstyle.version>2.9.1</checkstyle.version>
+    <tycho.version>4.0.7</tycho.version>
+    <pmd.version>3.22.0</pmd.version>
+    <checkstyle.version>3.3.1</checkstyle.version>
     <!-- IDS -->
     <tycho.groupid>org.eclipse.tycho</tycho.groupid>
     <maven.groupid>org.apache.maven.plugins</maven.groupid>
@@ -184,7 +184,7 @@
         <configuration>
           <useUIHarness>true</useUIHarness>
           <appArgLine>-nl en</appArgLine>
-        </configuration> 
+        </configuration>
       </plugin>
       <plugin>
         <groupId>${maven.groupid}</groupId>

--- a/org.eclipse.swtchart.export.extended.feature/pom.xml
+++ b/org.eclipse.swtchart.export.extended.feature/pom.xml
@@ -15,8 +15,8 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-source-plugin</artifactId>
 				<version>${tycho.version}</version>
 
 				<executions>
@@ -24,7 +24,7 @@
 						<id>source-feature</id>
 						<phase>package</phase>
 						<goals>
-							<goal>source-feature</goal>
+							<goal>feature-source</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/org.eclipse.swtchart.extensions.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.extensions.examples/META-INF/MANIFEST.MF
@@ -12,8 +12,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.swtchart.extensions;bundle-version="0.14.0",
  org.eclipse.e4.ui.di;bundle-version="1.1.100",
  org.eclipse.e4.ui.model.workbench;bundle-version="1.2.0.v20160229-1459",
- org.eclipse.swtchart.customcharts;bundle-version="0.14.0",
- jakarta.inject.jakarta.inject-api;bundle-version="2.0.1"
+ org.eclipse.swtchart.customcharts;bundle-version="0.14.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.swtchart.extensions.examples.support
+Import-Package: jakarta.inject;version="2.0.1"

--- a/org.eclipse.swtchart.extensions.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.extensions.test/META-INF/MANIFEST.MF
@@ -7,4 +7,5 @@ Bundle-Version: 0.14.0.qualifier
 Bundle-Vendor: ChemClipse
 Fragment-Host: org.eclipse.swtchart.extensions;bundle-version="0.14.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.junit;bundle-version="4.12.0"
+Require-Bundle: org.junit;bundle-version="4.12.0",
+ org.eclipse.jdt.junit4.runtime;bundle-version="1.3.100"

--- a/org.eclipse.swtchart.feature/pom.xml
+++ b/org.eclipse.swtchart.feature/pom.xml
@@ -15,8 +15,8 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-source-plugin</artifactId>
 				<version>${tycho.version}</version>
 
 				<executions>
@@ -24,7 +24,7 @@
 						<id>source-feature</id>
 						<phase>package</phase>
 						<goals>
-							<goal>source-feature</goal>
+							<goal>feature-source</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/org.eclipse.swtchart.targetplatform/org.eclipse.swtchart.targetplatform.target
+++ b/org.eclipse.swtchart.targetplatform/org.eclipse.swtchart.targetplatform.target
@@ -2,15 +2,22 @@
 <?pde version="3.8"?>
 <target name="Eclipse SWTChart" sequenceNumber="3">
 <locations>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.sdk.ide" version="0.0.0"/>
-<unit id="org.apache.batik.anim" version="0.0.0"/>
-<unit id="org.apache.batik.svggen" version="0.0.0"/>
-<unit id="org.apache.batik.awt.util" version="0.0.0"/>
-<unit id="org.apache.batik.dom" version="0.0.0"/>
-<unit id="org.w3c.dom.events" version="0.0.0"/>
-<unit id="org.apache.batik.ext" version="0.0.0"/>
-<repository location="https://download.eclipse.org/releases/2023-03/"/>
-</location>
+	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<repository location="https://download.eclipse.org/releases/2024-03/"/>
+		<unit id="org.eclipse.swt" version="0.0.0"/>
+		<unit id="org.eclipse.ui" version="0.0.0"/>
+		<unit id="org.eclipse.core.runtime" version="0.0.0"/>
+		<unit id="org.hamcrest.core" version="0.0.0"/>
+		<unit id="org.junit" version="0.0.0"/>
+		<unit id="org.eclipse.jdt.junit.runtime" version="0.0.0"/>
+		<unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0"/>
+		<unit id="org.eclipse.equinox.launcher" version="0.0.0"/>
+		<unit id="org.eclipse.ui.ide.application" version="0.0.0"/>
+		<unit id="org.apache.batik.anim" version="0.0.0"/>
+		<unit id="org.apache.batik.svggen" version="0.0.0"/>
+		<unit id="org.apache.batik.awt.util" version="0.0.0"/>
+		<unit id="org.apache.batik.dom" version="0.0.0"/>
+		<unit id="org.apache.batik.ext" version="0.0.0"/>
+	</location>
 </locations>
 </target>

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/AxisTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/AxisTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SWTChart project.
+ * Copyright (c) 2008, 2024 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -494,7 +494,7 @@ public class AxisTest extends ChartTestCase {
 		showChart();
 		yRange = yAxis.getRange();
 		assertEquals(0d, yRange.lower, 0.01);
-		assertEquals(4.42, yRange.upper, 0.01); // was before 4.41
+		assertEquals(4.43, yRange.upper, 0.01);
 		barSeries.setYSeries(ySeries4);
 		showChart();
 		yAxis.adjustRange();
@@ -509,7 +509,7 @@ public class AxisTest extends ChartTestCase {
 		yAxis.adjustRange();
 		showChart();
 		yRange = yAxis.getRange();
-		assertEquals(-5.14, yRange.lower, 0.01); // was before -5.13
+		assertEquals(-5.15, yRange.lower, 0.01);
 		assertEquals(0d, yRange.upper, 0.01);
 		// bar + vertical orientation
 		barSeries.setYSeries(ySeries2);


### PR DESCRIPTION
also reduced the number of packages in the target platform from 619 to 231.