### PR TITLE
Make yRange checks less strict

### DIFF
--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/AxisTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/AxisTest.java
@@ -494,7 +494,7 @@ public class AxisTest extends ChartTestCase {
 		showChart();
 		yRange = yAxis.getRange();
 		assertEquals(0d, yRange.lower, 0.01);
-		assertEquals(4.43, yRange.upper, 0.01);
+		assertEquals(4.41, yRange.upper, 0.03);
 		barSeries.setYSeries(ySeries4);
 		showChart();
 		yAxis.adjustRange();
@@ -509,7 +509,7 @@ public class AxisTest extends ChartTestCase {
 		yAxis.adjustRange();
 		showChart();
 		yRange = yAxis.getRange();
-		assertEquals(-5.15, yRange.lower, 0.01);
+		assertEquals(-5.13, yRange.lower, 0.03);
 		assertEquals(0d, yRange.upper, 0.01);
 		// bar + vertical orientation
 		barSeries.setYSeries(ySeries2);


### PR DESCRIPTION
Try to fix https://ci.eclipse.org/swtchart/job/build/job/develop/3024/console as they seem to depend a lot on the runtime.