### PR TITLE
Downgrade Maven.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@v4.5
       with:
-        maven-version: 3.9.6
+        maven-version: 3.9.2
 
     - name: Build with Maven
       uses: coactions/setup-xvfb@v1

--- a/org.eclipse.swtchart.cbi/pom.xml
+++ b/org.eclipse.swtchart.cbi/pom.xml
@@ -112,7 +112,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                <version>3.9.6</version>
+                <version>3.9.2</version>
                 </requireMavenVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
Resolves
> [ERROR] Detected Maven Version: 3.9.5 is not in the allowed range [3.9.6,).

https://ci.eclipse.org/swtchart/job/build/job/develop/3055/

and we don't need Maven that high for Tycho.