### PR TITLE
Don't use multithread for the release build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
 			steps {
 				wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
 					sh '''
-						mvn -f org.eclipse.swtchart.cbi/pom.xml -T 1C -Peclipse-sign clean install
+						mvn -f org.eclipse.swtchart.cbi/pom.xml -Peclipse-sign clean install
 					'''
 				}
 			}


### PR DESCRIPTION
This partly reverts https://github.com/eclipse/swtchart/pull/301 but keeping it for the pull request builds. It seems that parallel Maven is still not ready for prime time. It prints a large warning on https://ci.eclipse.org/swtchart/job/build/job/develop/3056/console
```
[WARNING] *****************************************************************
[WARNING] * Your build is requesting parallel execution, but this         *
[WARNING] * project contains the following plugin(s) that have goals not  *
[WARNING] * marked as thread-safe to support parallel execution.          *
[WARNING] * While this /may/ work fine, please look for plugin updates    *
[WARNING] * and/or request plugins be made thread-safe.                   *
[WARNING] * If reporting an issue, report it against the plugin in        *
[WARNING] * question, not against Apache Maven.                           *
[WARNING] *****************************************************************
[WARNING] The following plugins are not marked as thread-safe in Eclipse SWTChart:
[WARNING]   org.eclipse.cbi.maven.plugins:eclipse-jarsigner-plugin:1.3.2
[WARNING] 
[WARNING] Enable debug to see precisely which goals are not marked as thread-safe.
[WARNING] *****************************************************************
```