### PR TITLE
Update GitHub Actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
     - name: Checkout SWTChart
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '17'


### PR DESCRIPTION
I don't see a NodeJS deprecation warning yet. Maybe this time I am quicker.