### PR TITLE
Remove empty comment lines

### DIFF
--- a/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/ChromatogramChart.java
+++ b/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/ChromatogramChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -57,7 +57,7 @@ public class ChromatogramChart extends LineChart {
 		chartSettings.getRangeRestriction().setZeroY(true);
 		chartSettings.removeMenuEntry(chartSettings.getChartMenuEntryByClass(ResetChartHandler.class));
 		chartSettings.addMenuEntry(new ResetChromatogramHandler());
-		//
+
 		setPrimaryAxisSet(chartSettings);
 		addSecondaryAxisSet(chartSettings);
 		applySettings(chartSettings);
@@ -73,7 +73,7 @@ public class ChromatogramChart extends LineChart {
 		primaryAxisSettingsX.setPosition(Position.Secondary);
 		primaryAxisSettingsX.setVisible(false);
 		primaryAxisSettingsX.setGridLineStyle(LineStyle.NONE);
-		//
+
 		IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
 		primaryAxisSettingsY.setTitle(Messages.getString(Messages.INTENSITY));
 		primaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.0#E0"), new DecimalFormatSymbols(Locale.ENGLISH))); //$NON-NLS-1$
@@ -88,7 +88,7 @@ public class ChromatogramChart extends LineChart {
 		secondaryAxisSettingsX.setDecimalFormat(new DecimalFormat(("0.00"), new DecimalFormatSymbols(Locale.ENGLISH))); //$NON-NLS-1$
 		secondaryAxisSettingsX.setColor(getDisplay().getSystemColor(SWT.COLOR_LIST_FOREGROUND));
 		chartSettings.getSecondaryAxisSettingsListX().add(secondaryAxisSettingsX);
-		//
+
 		ISecondaryAxisSettings secondaryAxisSettingsY = new SecondaryAxisSettings(Messages.getString(Messages.RELATIVE_INTENSITY), new PercentageConverter(SWT.VERTICAL, true));
 		secondaryAxisSettingsY.setPosition(Position.Secondary);
 		secondaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.00"), new DecimalFormatSymbols(Locale.ENGLISH))); //$NON-NLS-1$

--- a/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/HighlightedStaticPie.java
+++ b/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/HighlightedStaticPie.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -45,7 +45,7 @@ public class HighlightedStaticPie extends PieChart {
 		if(seriesSettingsHighlight instanceof ICircularSeriesSettings) {
 			((ICircularSeriesSettings)seriesSettingsHighlight).setBorderWidth(3);
 		}
-		//
+
 		super.addSeriesData(model);
 	}
 }

--- a/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/MassSpectrumChart.java
+++ b/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/MassSpectrumChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -49,7 +49,7 @@ public class MassSpectrumChart extends BarChart {
 	}
 
 	private static final DecimalFormat DEFAULT_DECIMAL_FORMAT = new DecimalFormat();
-	//
+
 	private int numberOfHighestIntensitiesToLabel;
 	private BarSeriesIonComparator barSeriesIonComparator;
 	private LabelOption labelOption;
@@ -94,7 +94,7 @@ public class MassSpectrumChart extends BarChart {
 		barSeriesIonComparator = new BarSeriesIonComparator();
 		labelOption = LabelOption.EXACT;
 		customLabels = new HashMap<>();
-		//
+
 		IChartSettings chartSettings = getChartSettings();
 		chartSettings.setOrientation(SWT.HORIZONTAL);
 		chartSettings.setHorizontalSliderVisible(true);
@@ -108,11 +108,11 @@ public class MassSpectrumChart extends BarChart {
 		rangeRestriction.setExtendMaxX(2.0d);
 		rangeRestriction.setExtendTypeY(RangeRestriction.ExtendType.RELATIVE);
 		rangeRestriction.setExtendMaxY(0.1d);
-		//
+
 		setPrimaryAxisSet(chartSettings);
 		addSecondaryAxisSet(chartSettings);
 		applySettings(chartSettings);
-		//
+
 		addSeriesLabelMarker();
 		setData("org.eclipse.e4.ui.css.CssClassName", "MassSpectrumChart");
 	}
@@ -122,7 +122,7 @@ public class MassSpectrumChart extends BarChart {
 		IPrimaryAxisSettings primaryAxisSettingsX = chartSettings.getPrimaryAxisSettingsX();
 		primaryAxisSettingsX.setTitle("m/z"); //$NON-NLS-1$
 		primaryAxisSettingsX.setDecimalFormat(new DecimalFormat(("0.0##"), new DecimalFormatSymbols(Locale.ENGLISH))); //$NON-NLS-1$
-		//
+
 		IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
 		primaryAxisSettingsY.setTitle(Messages.getString(Messages.INTENSITY));
 		primaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.0#E0"), new DecimalFormatSymbols(Locale.ENGLISH))); //$NON-NLS-1$
@@ -222,16 +222,16 @@ public class MassSpectrumChart extends BarChart {
 	private List<BarSeriesIon> getBarSeriesIonList() {
 
 		List<BarSeriesIon> barSeriesIons = new ArrayList<>();
-		//
+
 		int widthPlotArea = getBaseChart().getPlotArea().getSize().x;
 		ISeries<?>[] series = getBaseChart().getSeriesSet().getSeries();
 		for(ISeries<?> barSeries : series) {
 			if(barSeries != null) {
-				//
+
 				double[] xSeries = barSeries.getXSeries();
 				double[] ySeries = barSeries.getYSeries();
 				int size = barSeries.getXSeries().length;
-				//
+
 				for(int i = 0; i < size; i++) {
 					Point point = barSeries.getPixelCoordinates(i);
 					if(point.x >= 0 && point.x <= widthPlotArea) {

--- a/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/Messages.java
+++ b/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWT Chart Project
+ * Copyright (c) 2020, 2025 SWT Chart Project
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,7 @@ public class Messages {
 
 	private static final String BUNDLE_NAME = "org.eclipse.swtchart.customcharts.core.messages"; //$NON-NLS-1$
 	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
-	//
+
 	public static final String INTENSITY = "INTENSITY";
 	public static final String MINUTES = "MINUTES";
 	public static final String RELATIVE_INTENSITY = "RELATIVE_INTENSITY";

--- a/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/PCAChart.java
+++ b/org.eclipse.swtchart.customcharts/src/org/eclipse/swtchart/customcharts/core/PCAChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -34,7 +34,7 @@ import org.eclipse.swtchart.extensions.scattercharts.ScatterChart;
 public class PCAChart extends ScatterChart {
 
 	private Color colorBlack = getDisplay().getSystemColor(SWT.COLOR_BLACK);
-	//
+
 	private String chartTitle = ""; //$NON-NLS-1$
 	private String xAxisTitle = "PC1"; //$NON-NLS-1$
 	private String yAxisTitle = "PC2"; //$NON-NLS-1$
@@ -67,7 +67,7 @@ public class PCAChart extends ScatterChart {
 		this.chartTitle = chartTitle;
 		this.xAxisTitle = xAxisTitle;
 		this.yAxisTitle = yAxisTitle;
-		//
+
 		IChartSettings chartSettings = getChartSettings();
 		chartSettings.setTitle(chartTitle);
 		chartSettings.setTitleVisible(true);
@@ -79,7 +79,7 @@ public class PCAChart extends ScatterChart {
 	public void setDecimalFormat(DecimalFormat decimalFormat) {
 
 		this.decimalFormat = decimalFormat;
-		//
+
 		IChartSettings chartSettings = getChartSettings();
 		chartSettings.getPrimaryAxisSettingsX().setDecimalFormat(decimalFormat);
 		chartSettings.getPrimaryAxisSettingsY().setDecimalFormat(decimalFormat);
@@ -112,10 +112,10 @@ public class PCAChart extends ScatterChart {
 		chartSettings.setColorAxisZeroMarker(colorBlack);
 		chartSettings.setShowSeriesLabelMarker(true);
 		chartSettings.setColorSeriesLabelMarker(colorBlack);
-		//
+
 		setPrimaryAxisSet(chartSettings);
 		addSecondaryAxisSet(chartSettings);
-		//
+
 		applySettings(chartSettings);
 		setData("org.eclipse.e4.ui.css.CssClassName", "PCAChart");
 	}
@@ -126,7 +126,7 @@ public class PCAChart extends ScatterChart {
 		primaryAxisSettingsX.setTitle(xAxisTitle);
 		primaryAxisSettingsX.setDecimalFormat(decimalFormat);
 		primaryAxisSettingsX.setColor(colorBlack);
-		//
+
 		IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
 		primaryAxisSettingsY.setTitle(yAxisTitle);
 		primaryAxisSettingsY.setDecimalFormat(decimalFormat);
@@ -141,7 +141,7 @@ public class PCAChart extends ScatterChart {
 		secondaryAxisSettingsX.setDecimalFormat(decimalFormat);
 		secondaryAxisSettingsX.setColor(colorBlack);
 		chartSettings.getSecondaryAxisSettingsListX().add(secondaryAxisSettingsX);
-		//
+
 		ISecondaryAxisSettings secondaryAxisSettingsY = new SecondaryAxisSettings(yAxisTitle, new PassThroughConverter());
 		secondaryAxisSettingsY.setPosition(Position.Secondary);
 		secondaryAxisSettingsY.setDecimalFormat(decimalFormat);

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/MultiLevelDoughnutChart.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/MultiLevelDoughnutChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -79,9 +79,9 @@ public class MultiLevelDoughnutChart {
 		multiLevelDoughnut.setSeries(continentLabels, continentValues);
 		// adding Asian countries. These go in as second level
 		multiLevelDoughnut.getNodeById("Asia").addChildren(AsianCountriesLabels, AsianCountriesValues);
-		//
+
 		multiLevelDoughnut.getNodeById("Africa").addChildren(AfricanCountriesLabels, AfricanCountriesValues);
-		//
+
 		multiLevelDoughnut.getNodeById("North America").addChildren(NorthAmericanCountriesLabels, NorthAmericanCountriesValues);
 		/*
 		 * Adding Indian states. These go as third level.
@@ -90,7 +90,7 @@ public class MultiLevelDoughnutChart {
 		multiLevelDoughnut.getNodeById("India").addChildren(IndianStatesLabels, IndianStateValues);
 		// Another API
 		multiLevelDoughnut.getNodeById("Europe").addChild("Germany", 137847);
-		//
+
 		return chart;
 	}
 }

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/MultiLevelPieExample.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/MultiLevelPieExample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -95,7 +95,7 @@ public class MultiLevelPieExample {
 		multiLevelPie.getNodeById("India").addChildren(IndianStatesLabels, IndianStateValues);
 		// Another API
 		multiLevelPie.getNodeById("Europe").addChild("Germany", 137847);
-		//
+
 		return chart;
 	}
 }

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/SingleLevelDoughnutChartExample.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/SingleLevelDoughnutChartExample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -73,7 +73,7 @@ public class SingleLevelDoughnutChartExample {
 		// change color of India to DARK_RED
 		Color color = Display.getDefault().getSystemColor(SWT.COLOR_DARK_RED);
 		circularSeries.setColor("India", color);
-		//
+
 		return chart;
 	}
 }

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/SingleLevelPieChartExample.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/SingleLevelPieChartExample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -67,7 +67,7 @@ public class SingleLevelPieChartExample {
 		ICircularSeries<?> circularSeries = (ICircularSeries<?>)chart.getSeriesSet().createSeries(SeriesType.PIE, "pie series");
 		circularSeries.setSeries(labels, values);
 		circularSeries.setColor("India", Display.getDefault().getSystemColor(SWT.COLOR_DARK_RED));
-		//
+
 		return chart;
 	}
 }

--- a/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/HighlightMultiLevelPie.java
+++ b/org.eclipse.swtchart.examples/src/org/eclipse/swtchart/examples/advanced/HighlightMultiLevelPie.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -84,7 +84,7 @@ public class HighlightMultiLevelPie {
 		multiLevelPie.setSliceColor(Display.getDefault().getSystemColor(SWT.COLOR_WHITE));
 		multiLevelPie.setSliceColorHighlight(Display.getDefault().getSystemColor(SWT.COLOR_BLACK));
 		multiLevelPie.setHighlightedNode(multiLevelPie.getNodeById("Russia"));
-		//
+
 		return chart;
 	}
 }

--- a/org.eclipse.swtchart.export.extended/src/org/eclipse/swtchart/export/extended/menu/vector/Messages.java
+++ b/org.eclipse.swtchart.export.extended/src/org/eclipse/swtchart/export/extended/menu/vector/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWT Chart Project
+ * Copyright (c) 2020, 2025 SWT Chart Project
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,7 @@ public class Messages {
 
 	private static final String BUNDLE_NAME = "org.eclipse.swtchart.export.extended.menu.vector.messages"; //$NON-NLS-1$
 	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
-	//
+
 	public static final String EXPORT_TO_SVG = "EXPORT_TO_SVG";
 	public static final String SAVE_AS_SVG = "SAVE_AS_SVG";
 	public static final String SVG = "SVG";

--- a/org.eclipse.swtchart.export.extended/src/org/eclipse/swtchart/export/extended/menu/vector/SVGExportHandler.java
+++ b/org.eclipse.swtchart.export.extended/src/org/eclipse/swtchart/export/extended/menu/vector/SVGExportHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 Lablicate GmbH.
+ * Copyright (c) 2019, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -57,7 +57,7 @@ public class SVGExportHandler extends AbstractSeriesExportHandler implements ISe
 		fileDialog.setText(NAME);
 		fileDialog.setFilterExtensions(new String[]{"*.svg"}); //$NON-NLS-1$
 		fileDialog.setFileName(scrollableChart.getFileName());
-		//
+
 		String fileName = fileDialog.open();
 		if(fileName != null) {
 			try {

--- a/org.eclipse.swtchart.export.test/src/org/eclipse/swtchart/export/SeriesConverter.java
+++ b/org.eclipse.swtchart.export.test/src/org/eclipse/swtchart/export/SeriesConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,7 +29,7 @@ public class SeriesConverter {
 		int size = getNumberOfLines(file);
 		double[] xSeries = new double[size];
 		double[] ySeries = new double[size];
-		//
+
 		BufferedReader bufferedReader = null;
 		try {
 			String line;
@@ -44,17 +44,17 @@ public class SeriesConverter {
 				}
 			}
 		} catch(Exception e) {
-			//
+
 		} finally {
 			if(bufferedReader != null) {
 				try {
 					bufferedReader.close();
 				} catch(IOException e) {
-					//
+
 				}
 			}
 		}
-		//
+
 		ISeriesData seriesData = new SeriesData(xSeries, ySeries, file);
 		return seriesData;
 	}
@@ -63,7 +63,7 @@ public class SeriesConverter {
 
 		int size = getNumberOfLines(fileName);
 		double[] ySeries = new double[size];
-		//
+
 		BufferedReader bufferedReader = null;
 		try {
 			String line;
@@ -73,17 +73,17 @@ public class SeriesConverter {
 				ySeries[i++] = Double.parseDouble(line.trim());
 			}
 		} catch(Exception e) {
-			//
+
 		} finally {
 			if(bufferedReader != null) {
 				try {
 					bufferedReader.close();
 				} catch(IOException e) {
-					//
+
 				}
 			}
 		}
-		//
+
 		ISeriesData seriesData = new SeriesData(ySeries, fileName);
 		return seriesData;
 	}
@@ -91,7 +91,7 @@ public class SeriesConverter {
 	public static List<ISeriesData> getSeriesScatter(String fileName) {
 
 		List<ISeriesData> scatterSeriesList = new ArrayList<ISeriesData>();
-		//
+
 		BufferedReader bufferedReader = null;
 		try {
 			String line;
@@ -105,13 +105,13 @@ public class SeriesConverter {
 				scatterSeriesList.add(seriesData);
 			}
 		} catch(Exception e) {
-			//
+
 		} finally {
 			if(bufferedReader != null) {
 				try {
 					bufferedReader.close();
 				} catch(IOException e) {
-					//
+
 				}
 			}
 		}
@@ -128,13 +128,13 @@ public class SeriesConverter {
 				i++;
 			}
 		} catch(Exception e) {
-			//
+
 		} finally {
 			if(bufferedReader != null) {
 				try {
 					bufferedReader.close();
 				} catch(IOException e) {
-					//
+
 				}
 			}
 		}

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/core/AbstractSeparatedValueHandler.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/core/AbstractSeparatedValueHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -56,7 +56,7 @@ public abstract class AbstractSeparatedValueHandler extends AbstractSeriesExport
 		fileDialog.setText(title);
 		fileDialog.setFilterExtensions(new String[]{fileExtension});
 		fileDialog.setFileName(scrollableChart.getFileName());
-		//
+
 		String fileName = fileDialog.open();
 		if(fileName != null) {
 			/*
@@ -65,10 +65,10 @@ public abstract class AbstractSeparatedValueHandler extends AbstractSeriesExport
 			VectorExportSettingsDialog exportSettingsDialog = new VectorExportSettingsDialog(shell, baseChart);
 			exportSettingsDialog.create();
 			if(exportSettingsDialog.open() == Window.OK) {
-				//
+
 				int indexAxisX = exportSettingsDialog.getIndexAxisSelectionX();
 				int indexAxisY = exportSettingsDialog.getIndexAxisSelectionY();
-				//
+
 				if(indexAxisX >= 0 && indexAxisY >= 0) {
 					/*
 					 * X Axis Settings
@@ -118,7 +118,7 @@ public abstract class AbstractSeparatedValueHandler extends AbstractSeriesExport
 								exportSeries(dataSeries, widthPlotArea, axisSettings, printWriter);
 							}
 						}
-						//
+
 						printWriter.flush();
 						MessageDialog.openInformation(shell, title, MESSAGE_OK);
 					} catch(FileNotFoundException e) {
@@ -127,7 +127,7 @@ public abstract class AbstractSeparatedValueHandler extends AbstractSeriesExport
 					}
 				}
 			}
-			//
+
 			exportSettingsDialog.reset();
 			scrollableChart.updateLegend();
 		}
@@ -147,11 +147,11 @@ public abstract class AbstractSeparatedValueHandler extends AbstractSeriesExport
 		 * Series
 		 */
 		printWriter.println(getIdentifier(dataSeries));
-		//
+
 		double[] xSeries = dataSeries.getXSeries();
 		double[] ySeries = dataSeries.getYSeries();
 		int size = dataSeries.getXSeries().length;
-		//
+
 		for(int i = 0; i < size; i++) {
 			/*
 			 * Only export if the data point is visible.
@@ -164,7 +164,7 @@ public abstract class AbstractSeparatedValueHandler extends AbstractSeriesExport
 				printWriter.println(""); //$NON-NLS-1$
 			}
 		}
-		//
+
 		printWriter.println(""); //$NON-NLS-1$
 	}
 

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/core/BitmapExportSettingsDialog.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/core/BitmapExportSettingsDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Lablicate GmbH.
+ * Copyright (c) 2021, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -35,14 +35,14 @@ import org.eclipse.swtchart.extensions.preferences.PreferenceConstants;
 public class BitmapExportSettingsDialog extends TitleAreaDialog {
 
 	private Rectangle boundsMax;
-	//
+
 	private boolean customSize = false;
 	private int customWidth = 0;
 	private int customHeight = 0;
-	//
+
 	private Text textWidth;
 	private Text textHeight;
-	//
+
 	private IPreferenceStore preferenceStore = ResourceSupport.getPreferenceStore();
 
 	public BitmapExportSettingsDialog(Shell parent) {
@@ -80,21 +80,21 @@ public class BitmapExportSettingsDialog extends TitleAreaDialog {
 		customSize = preferenceStore != null ? preferenceStore.getBoolean(PreferenceConstants.P_BITMAP_EXPORT_CUSTOM_SIZE) : PreferenceConstants.DEF_BITMAP_EXPORT_CUSTOM_SIZE;
 		customWidth = preferenceStore != null ? preferenceStore.getInt(PreferenceConstants.P_BITMAP_EXPORT_WIDTH) : PreferenceConstants.DEF_BITMAP_EXPORT_WIDTH;
 		customHeight = preferenceStore != null ? preferenceStore.getInt(PreferenceConstants.P_BITMAP_EXPORT_HEIGHT) : PreferenceConstants.DEF_BITMAP_EXPORT_HEIGHT;
-		//
+
 		Composite container = (Composite)super.createDialogArea(parent);
-		//
+
 		Composite composite = new Composite(container, SWT.NONE);
 		composite.setLayoutData(new GridData(GridData.FILL_BOTH));
 		GridLayout layout = new GridLayout(2, false);
 		composite.setLayout(layout);
-		//
+
 		createLabelInfo(composite);
 		createSectionCustomSize(composite);
 		textWidth = createSectionWidth(composite);
 		textHeight = createSectionHeight(composite);
-		//
+
 		updateWidgets();
-		//
+
 		return container;
 	}
 
@@ -127,7 +127,7 @@ public class BitmapExportSettingsDialog extends TitleAreaDialog {
 		GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
 		gridData.horizontalSpan = 2;
 		button.setLayoutData(gridData);
-		//
+
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -143,7 +143,7 @@ public class BitmapExportSettingsDialog extends TitleAreaDialog {
 
 		Label label = new Label(parent, SWT.NONE);
 		label.setText("Custom Width");
-		//
+
 		Text text = new Text(parent, SWT.BORDER);
 		text.setText(Integer.toString(customWidth));
 		text.setToolTipText("Max width: " + boundsMax.width);
@@ -163,7 +163,7 @@ public class BitmapExportSettingsDialog extends TitleAreaDialog {
 				}
 			}
 		});
-		//
+
 		return text;
 	}
 
@@ -171,7 +171,7 @@ public class BitmapExportSettingsDialog extends TitleAreaDialog {
 
 		Label label = new Label(parent, SWT.NONE);
 		label.setText("Custom Height");
-		//
+
 		Text text = new Text(parent, SWT.BORDER);
 		text.setText(Integer.toString(customHeight));
 		text.setToolTipText("Max height: " + boundsMax.height);
@@ -191,7 +191,7 @@ public class BitmapExportSettingsDialog extends TitleAreaDialog {
 				}
 			}
 		});
-		//
+
 		return text;
 	}
 

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/core/VectorExportSettingsDialog.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/core/VectorExportSettingsDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -66,13 +66,13 @@ public class VectorExportSettingsDialog extends TitleAreaDialog {
 	 * Hence, cache the original settings.
 	 */
 	private Map<String, ISeriesSettings> cachedSeriesSettings = new HashMap<>();
-	//
+
 	private Combo comboScaleX;
 	private Combo comboScaleY;
-	//
+
 	private int indexAxisX;
 	private int indexAxisY;
-	//
+
 	private BaseChart baseChart = null;
 
 	public VectorExportSettingsDialog(Shell parent, BaseChart baseChart) {
@@ -112,11 +112,11 @@ public class VectorExportSettingsDialog extends TitleAreaDialog {
 		container.setLayoutData(new GridData(GridData.FILL_BOTH));
 		GridLayout layout = new GridLayout(2, false);
 		container.setLayout(layout);
-		//
+
 		createSelectionAxisX(container);
 		createSelectionAxisY(container);
 		createSeriesSection(container);
-		//
+
 		return composite;
 	}
 
@@ -127,7 +127,7 @@ public class VectorExportSettingsDialog extends TitleAreaDialog {
 		gridData.horizontalSpan = 2;
 		tabFolder.setLayoutData(gridData);
 		tabFolder.setLayout(new GridLayout(1, true));
-		//
+
 		createStandardSeriesList(tabFolder);
 		createCustomSeriesList(tabFolder);
 	}
@@ -136,14 +136,14 @@ public class VectorExportSettingsDialog extends TitleAreaDialog {
 
 		TabItem tabItem = new TabItem(tabFolder, SWT.NONE);
 		tabItem.setText("Standard Series");
-		//
+
 		SeriesListUI seriesListUI = new SeriesListUI(tabFolder, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION | SWT.BORDER);
 		seriesListUI.setTableSortable(preferenceStore.getBoolean(PreferenceConstants.P_SORT_LEGEND_TABLE));
 		Table table = seriesListUI.getTable();
 		table.setLayoutData(new GridData(GridData.FILL_BOTH));
 		seriesListUI.setInput(baseChart.getSeriesSet());
 		seriesListUI.setBaseChart(baseChart);
-		//
+
 		table.addMouseListener(new MouseAdapter() {
 
 			@Override
@@ -185,7 +185,7 @@ public class VectorExportSettingsDialog extends TitleAreaDialog {
 				}
 			}
 		});
-		//
+
 		listControl.set(seriesListUI);
 		tabItem.setControl(seriesListUI.getTable());
 	}
@@ -194,13 +194,13 @@ public class VectorExportSettingsDialog extends TitleAreaDialog {
 
 		TabItem tabItem = new TabItem(tabFolder, SWT.NONE);
 		tabItem.setText("Custom Series");
-		//
+
 		CustomSeriesListUI seriesListUI = new CustomSeriesListUI(tabFolder, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION | SWT.BORDER);
 		// seriesListUI.setTableSortable(preferenceStore.getBoolean(PreferenceConstants.P_SORT_LEGEND_TABLE));
 		Table table = seriesListUI.getTable();
 		table.setLayoutData(new GridData(GridData.FILL_BOTH));
 		seriesListUI.setInput(baseChart.getCustomSeries().toArray());
-		//
+
 		tabItem.setControl(seriesListUI.getTable());
 	}
 
@@ -217,7 +217,7 @@ public class VectorExportSettingsDialog extends TitleAreaDialog {
 
 		Label label = new Label(container, SWT.NONE);
 		label.setText(Messages.getString(Messages.X_AXIS));
-		//
+
 		String[] axisLabelsX = baseChart.getAxisLabels(IExtendedChart.X_AXIS);
 		comboScaleX = ExtendedCombo.create(container, SWT.READ_ONLY);
 		comboScaleX.setItems(axisLabelsX);
@@ -252,7 +252,7 @@ public class VectorExportSettingsDialog extends TitleAreaDialog {
 
 		Label label = new Label(container, SWT.NONE);
 		label.setText(Messages.getString(Messages.Y_AXIS));
-		//
+
 		String[] axisLabelsY = baseChart.getAxisLabels(IExtendedChart.Y_AXIS);
 		comboScaleY = ExtendedCombo.create(container, SWT.READ_ONLY);
 		comboScaleY.setItems(axisLabelsY);

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/images/ImageFactory.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/images/ImageFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -35,11 +35,10 @@ public class ImageFactory<T extends ScrollableChart> {
 	 */
 	public ImageFactory(Class<T> clazz, int width, int height) throws InstantiationException, IllegalAccessException {
 
-		//
 		try {
 			t = clazz.getDeclaredConstructor().newInstance();
 			imageSupplier = new ImageSupplier();
-			//
+
 			display = ((ScrollableChart)t).getBaseChart().getDisplay();
 			if(display != null) {
 				width = (width > display.getBounds().width) ? display.getBounds().width : width;

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/PrinterExportHandler.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/PrinterExportHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -83,7 +83,7 @@ public class PrinterExportHandler extends AbstractSeriesExportHandler implements
 				gc.dispose();
 				printer.endPage();
 				printer.endJob();
-				//
+
 				MessageDialog.openInformation(shell, TITLE, MESSAGE_OK);
 			}
 			printer.dispose();

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/bitmap/AbstractBitmapExportHandler.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/bitmap/AbstractBitmapExportHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -68,7 +68,7 @@ public abstract class AbstractBitmapExportHandler extends AbstractSeriesExportHa
 		fileDialog.setText(name);
 		fileDialog.setFilterExtensions(filterExtensions); // $NON-NLS-1$ //$NON-NLS-2$
 		fileDialog.setFileName(scrollableChart.getFileName());
-		//
+
 		String fileName = fileDialog.open();
 		if(fileName != null) {
 			/*
@@ -122,7 +122,7 @@ public abstract class AbstractBitmapExportHandler extends AbstractSeriesExportHa
 				baseChart.updateLayout();
 			}
 		});
-		//
+
 		imageShell.open();
 		while(!imageShell.isDisposed()) {
 			if(!display.readAndDispatch()) {

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/bitmap/Messages.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/bitmap/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWT Chart Project
+ * Copyright (c) 2020, 2025 SWT Chart Project
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,7 @@ public class Messages {
 
 	private static final String BUNDLE_NAME = "org.eclipse.swtchart.export.menu.bitmap.messages"; //$NON-NLS-1$
 	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
-	//
+
 	public static final String IMAGE = "IMAGE";
 	public static final String SAVE_AS_IMAGE = "SAVE_AS_IMAGE";
 	public static final String COPY_IMAGE_TO_CLIPBOARD = "COPY_IMAGE_TO_CLIPBOARD";

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/text/CSVExportHandler.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/text/CSVExportHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,7 +24,7 @@ public class CSVExportHandler extends AbstractSeparatedValueHandler implements I
 
 	private static final String FILE_EXTENSION = "*.csv"; //$NON-NLS-1$
 	public static final String NAME = MessageFormat.format(Messages.getString(Messages.COMMA_SEPARATED_VALUES), FILE_EXTENSION);
-	//
+
 	private static final String TITLE = Messages.getString(Messages.SAVE_AS_COMMA_SEPARATED);
 	private static final String DELIMITER = ","; //$NON-NLS-1$
 

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/text/LaTeXTableExportHandler.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/text/LaTeXTableExportHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -42,7 +42,7 @@ public class LaTeXTableExportHandler extends AbstractSeriesExportHandler impleme
 
 	private static final String FILE_EXTENSION = "*.tex"; //$NON-NLS-1$
 	public static final String NAME = MessageFormat.format(Messages.getString(Messages.LATEX_TABLE), FILE_EXTENSION);
-	//
+
 	private static final String TITLE = Messages.getString(Messages.SAVE_AS_LATEX);
 	private static final String TAB = "\t"; //$NON-NLS-1$
 	private static final String DELIMITER = " & "; //$NON-NLS-1$
@@ -73,7 +73,7 @@ public class LaTeXTableExportHandler extends AbstractSeriesExportHandler impleme
 		fileDialog.setText(TITLE);
 		fileDialog.setFilterExtensions(new String[]{FILE_EXTENSION});
 		fileDialog.setFileName(scrollableChart.getFileName());
-		//
+
 		String fileName = fileDialog.open();
 		if(fileName != null) {
 			/*
@@ -82,10 +82,10 @@ public class LaTeXTableExportHandler extends AbstractSeriesExportHandler impleme
 			VectorExportSettingsDialog exportSettingsDialog = new VectorExportSettingsDialog(shell, baseChart);
 			exportSettingsDialog.create();
 			if(exportSettingsDialog.open() == Window.OK) {
-				//
+
 				int indexAxisX = exportSettingsDialog.getIndexAxisSelectionX();
 				int indexAxisY = exportSettingsDialog.getIndexAxisSelectionY();
-				//
+
 				if(indexAxisX >= 0 && indexAxisY >= 0) {
 					/*
 					 * X Axis Settings
@@ -114,7 +114,7 @@ public class LaTeXTableExportHandler extends AbstractSeriesExportHandler impleme
 						 */
 						printWriter.println("\\begin{center}"); //$NON-NLS-1$
 						printWriter.println("\\begin{tabular}{ c c }"); //$NON-NLS-1$
-						//
+
 						printWriter.print(TAB);
 						printWriter.print(axisSettingsX.getLabel());
 						printWriter.print(DELIMITER);
@@ -140,7 +140,7 @@ public class LaTeXTableExportHandler extends AbstractSeriesExportHandler impleme
 								exportSeries(dataSeries, widthPlotArea, axisSettings, printWriter);
 							}
 						}
-						//
+
 						printWriter.println("\\end{tabular}"); //$NON-NLS-1$
 						printWriter.println("\\end{center}"); //$NON-NLS-1$
 						printWriter.flush();
@@ -151,7 +151,7 @@ public class LaTeXTableExportHandler extends AbstractSeriesExportHandler impleme
 					}
 				}
 			}
-			//
+
 			exportSettingsDialog.reset();
 			scrollableChart.updateLegend();
 		}
@@ -173,11 +173,11 @@ public class LaTeXTableExportHandler extends AbstractSeriesExportHandler impleme
 		printWriter.println(TAB + HORIZONTAL_LINE);
 		printWriter.println(TAB + getIdentifier(dataSeries) + DELIMITER + LINE_END);
 		printWriter.println(TAB + HORIZONTAL_LINE);
-		//
+
 		double[] xSeries = dataSeries.getXSeries();
 		double[] ySeries = dataSeries.getYSeries();
 		int size = dataSeries.getXSeries().length;
-		//
+
 		for(int i = 0; i < size; i++) {
 			/*
 			 * Only export if the data point is visible.
@@ -191,7 +191,7 @@ public class LaTeXTableExportHandler extends AbstractSeriesExportHandler impleme
 				printWriter.println(LINE_END);
 			}
 		}
-		//
+
 		printWriter.print(TAB);
 		printWriter.print(DELIMITER);
 		printWriter.println(LINE_END);

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/text/RScriptExportHandler.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/text/RScriptExportHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -53,12 +53,12 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 
 	private static final String FILE_EXTENSION = "*.R"; //$NON-NLS-1$
 	public static final String NAME = MessageFormat.format(Messages.getString(Messages.IMAGE_R_SCRIPT), FILE_EXTENSION);
-	//
+
 	private static final String TITLE = Messages.getString(Messages.SAVE_AS_IMAGE_R_SCRIPT);
-	//
+
 	private static final String AXIS_X = "x"; //$NON-NLS-1$
 	private static final String AXIS_Y = "y"; //$NON-NLS-1$
-	//
+
 	private Map<PlotSymbolType, Integer> plotSymbolsMap;
 	private Map<LineStyle, Integer> lineStylesMap;
 
@@ -86,7 +86,7 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 		fileDialog.setText(TITLE);
 		fileDialog.setFilterExtensions(new String[]{FILE_EXTENSION});
 		fileDialog.setFileName(scrollableChart.getFileName());
-		//
+
 		String fileName = fileDialog.open();
 		if(fileName != null) {
 			/*
@@ -95,10 +95,10 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 			VectorExportSettingsDialog exportSettingsDialog = new VectorExportSettingsDialog(shell, baseChart);
 			exportSettingsDialog.create();
 			if(exportSettingsDialog.open() == Window.OK) {
-				//
+
 				int indexAxisX = exportSettingsDialog.getIndexAxisSelectionX();
 				int indexAxisY = exportSettingsDialog.getIndexAxisSelectionY();
-				//
+
 				if(indexAxisX >= 0 && indexAxisY >= 0) {
 					/*
 					 * X Axis Settings
@@ -141,7 +141,7 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 						plotSymbolsMap.put(PlotSymbolType.SQUARE, 0);
 						plotSymbolsMap.put(PlotSymbolType.TRIANGLE, 2);
 						plotSymbolsMap.put(PlotSymbolType.NONE, 20);
-						//
+
 						lineStylesMap = new HashMap<LineStyle, Integer>();
 						lineStylesMap.put(LineStyle.NONE, 0);
 						lineStylesMap.put(LineStyle.DASH, 2);
@@ -149,7 +149,7 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 						lineStylesMap.put(LineStyle.DASHDOTDOT, 6);
 						lineStylesMap.put(LineStyle.DOT, 3);
 						lineStylesMap.put(LineStyle.SOLID, 1);
-						//
+
 						/*
 						 * First check via instance of. If that fails, perform the enhanced
 						 * check via the chart type.
@@ -185,7 +185,7 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 									break;
 							}
 						}
-						//
+
 						printWriter.flush();
 						MessageDialog.openInformation(shell, TITLE, MESSAGE_OK);
 					} catch(FileNotFoundException e) {
@@ -194,7 +194,7 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 					}
 				}
 			}
-			//
+
 			exportSettingsDialog.reset();
 			scrollableChart.updateLegend();
 		}
@@ -234,7 +234,7 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 
 		IAxisSettings axisSettingsX = axisSettings.getAxisSettingsX();
 		IAxisSettings axisSettingsY = axisSettings.getAxisSettingsY();
-		//
+
 		BaseChart baseChart = scrollableChart.getBaseChart();
 		ISeries<?>[] series = baseChart.getSeriesSet().getSeries();
 		/*
@@ -295,7 +295,7 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 		}
 		list.append(")");
 		printWriter.println(list); // $NON-NLS-1$
-		//
+
 		StringBuilder plotSymbol_List = new StringBuilder("symbolList<-c(");
 		int length2 = plotSymbols.size();
 		int symbol_count = 0;
@@ -308,7 +308,7 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 		}
 		plotSymbol_List.append(")");
 		printWriter.println(plotSymbol_List);
-		//
+
 		StringBuilder lineStyle_List = new StringBuilder("styleList<-c(");
 		int length3 = lineStyles.size();
 		int style_count = 0;
@@ -321,7 +321,7 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 		}
 		lineStyle_List.append(")");
 		printWriter.println(lineStyle_List);
-		//
+
 		StringBuilder lineType_List = new StringBuilder("typeList<-c(");
 		int length4 = lineTypes.size();
 		int type_count = 0;
@@ -336,7 +336,7 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 		}
 		lineType_List.append(")");
 		printWriter.println(lineType_List);
-		//
+
 		printWriter.println(""); //$NON-NLS-1$
 		printWriter.println("plot("); //$NON-NLS-1$
 		printWriter.println("	xValueList[[1]], yValueList[[1]],"); //$NON-NLS-1$
@@ -350,15 +350,15 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 		printWriter.println("	xlab='" + axisSettingsX.getLabel() + "'"); //$NON-NLS-1$ //$NON-NLS-2$
 		printWriter.println(")"); //$NON-NLS-1$
 		printWriter.println(""); //$NON-NLS-1$
-		//
+
 		if(seriesSize > 1) {
 			printWriter.println("for(i in 2:" + seriesSize + "){"); //$NON-NLS-1$ style//$NON-NLS-2$
 			printWriter.println("	lines(xValueList[[i]], yValueList[[i]], type=typeList[i],lty=styleList[i], col=colorList[i], pch=symbolList[i])"); //$NON-NLS-1$
 			printWriter.println("}"); //$NON-NLS-1$
 			printWriter.println(""); //$NON-NLS-1$
 		}
-		//
-		//
+
+
 		int size = seriesSize;
 		int k;
 		printWriter.println("legend('topleft',"); //$NON-NLS-1$
@@ -399,11 +399,11 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 		int indexAxisY = axisSettings.getIndexAxisY();
 		IAxisScaleConverter axisScaleConverterX = axisSettings.getAxisScaleConverterX();
 		IAxisScaleConverter axisScaleConverterY = axisSettings.getAxisScaleConverterY();
-		//
+
 		double[] xSeries = dataSeries.getXSeries();
 		double[] ySeries = dataSeries.getYSeries();
 		int size = dataSeries.getXSeries().length;
-		//
+
 		for(int i = 0; i < size; i++) {
 			/*
 			 * Only export if the data point is visible.
@@ -439,7 +439,7 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 
 		IAxisSettings axisSettingsX = axisSettings.getAxisSettingsX();
 		IAxisSettings axisSettingsY = axisSettings.getAxisSettingsY();
-		//
+
 		BaseChart baseChart = scrollableChart.getBaseChart();
 		ISeries<?>[] series = baseChart.getSeriesSet().getSeries();
 		/*
@@ -492,7 +492,7 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 		double[] xSeries = dataSeries.getXSeries();
 		double[] ySeries = dataSeries.getYSeries();
 		int size = dataSeries.getXSeries().length;
-		//
+
 		for(int i = 0; i < size; i++) {
 			/*
 			 * Only export if the data point is visible.
@@ -520,7 +520,7 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 
 		IAxisSettings axisSettingsX = axisSettings.getAxisSettingsX();
 		IAxisSettings axisSettingsY = axisSettings.getAxisSettingsY();
-		//
+
 		BaseChart baseChart = scrollableChart.getBaseChart();
 		ISeries<?>[] series = baseChart.getSeriesSet().getSeries();
 		/*
@@ -572,7 +572,7 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 		}
 		list.append(")");
 		printWriter.println(list); // $NON-NLS-1$
-		//
+
 		StringBuilder plotSymbol_List = new StringBuilder("symbolList<-c(");
 		int length2 = plotSymbols.size();
 		int symbol_count = 0;
@@ -585,7 +585,7 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 		}
 		plotSymbol_List.append(")");
 		printWriter.println(plotSymbol_List);
-		//
+
 		printWriter.println(""); //$NON-NLS-1$
 		printWriter.println("plot("); //$NON-NLS-1$
 		printWriter.println("	xValueList[[1]], yValueList[[1]],"); //$NON-NLS-1$
@@ -598,15 +598,15 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 		printWriter.println("	xlab='" + axisSettingsX.getLabel() + "'"); //$NON-NLS-1$ //$NON-NLS-2$
 		printWriter.println(")"); //$NON-NLS-1$
 		printWriter.println(""); //$NON-NLS-1$
-		//
+
 		if(seriesSize > 1) {
 			printWriter.println("for(i in 2:" + seriesSize + "){"); //$NON-NLS-1$ //$NON-NLS-2$
 			printWriter.println("	points(xValueList[[i]], yValueList[[i]], type='p', col=colorList[i], pch=symbolList[i])"); //$NON-NLS-1$
 			printWriter.println("}"); //$NON-NLS-1$
 			printWriter.println(""); //$NON-NLS-1$
 		}
-		//
-		//
+
+
 		printWriter.println("abline(h=0)"); //$NON-NLS-1$
 		printWriter.println("abline(v=0)"); //$NON-NLS-1$
 	}
@@ -615,7 +615,7 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 
 		IAxisSettings axisSettingsX = axisSettings.getAxisSettingsX();
 		IAxisSettings axisSettingsY = axisSettings.getAxisSettingsY();
-		//
+
 		BaseChart baseChart = scrollableChart.getBaseChart();
 		ISeries<?>[] series = baseChart.getSeriesSet().getSeries();
 		/*
@@ -664,7 +664,7 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 		}
 		list.append(")");
 		printWriter.println(list); // $NON-NLS-1$
-		//
+
 		printWriter.println(""); //$NON-NLS-1$
 		printWriter.println("plot("); //$NON-NLS-1$
 		printWriter.println("	xValueList[[1]], yValueList[[1]],"); //$NON-NLS-1$
@@ -676,15 +676,15 @@ public class RScriptExportHandler extends AbstractSeriesExportHandler implements
 		printWriter.println("	xlab='" + axisSettingsX.getLabel() + "'"); //$NON-NLS-1$ //$NON-NLS-2$
 		printWriter.println(")"); //$NON-NLS-1$
 		printWriter.println(""); //$NON-NLS-1$
-		//
+
 		if(seriesSize > 1) {
 			printWriter.println("for(i in 2:" + seriesSize + "){"); //$NON-NLS-1$ //$NON-NLS-2$
 			printWriter.println("	lines(xValueList[[i]], yValueList[[i]], type='s', col=colorList[i])"); //$NON-NLS-1$
 			printWriter.println("}"); //$NON-NLS-1$
 			printWriter.println(""); //$NON-NLS-1$
 		}
-		//
-		//
+
+
 		int size = seriesSize;
 		int k;
 		printWriter.println("legend('topleft',"); //$NON-NLS-1$

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/text/TSVExportHandler.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/text/TSVExportHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,7 +22,7 @@ public class TSVExportHandler extends AbstractSeparatedValueHandler implements I
 
 	private static final String FILE_EXTENSION = "*.tsv"; //$NON-NLS-1$
 	public static final String NAME = MessageFormat.format(Messages.getString(Messages.TAB_SEPARATED_VALUES), FILE_EXTENSION);
-	//
+
 	private static final String TITLE = Messages.getString(Messages.SAVE_AS_TAB_SEPARATED); // $NON-NLS-1$
 	private static final String DELIMITER = "\t"; //$NON-NLS-1$
 

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/vector/AbstractInkscapeLineChart.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/vector/AbstractInkscapeLineChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -39,12 +39,12 @@ public abstract class AbstractInkscapeLineChart extends AbstractInkscapeTemplate
 		int indexAxisY = axisSettings.getIndexAxisY();
 		IAxisScaleConverter axisScaleConverterX = axisSettings.getAxisScaleConverterX();
 		IAxisScaleConverter axisScaleConverterY = axisSettings.getAxisScaleConverterY();
-		//
+
 		double[] xSeries = dataSeries.getXSeries();
 		double[] ySeries = dataSeries.getYSeries();
 		String split[] = data.toString().split(SPLIT_LINE_DELIMITER);
 		int size = dataSeries.getXSeries().length;
-		//
+
 		String match1 = ".*%COLOR%.*";
 		String match2 = ".*%x-coordinate%.*";
 		String match3 = ".*%y-coordinate%.*";

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/vector/AbstractInkscapeTemplate.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/vector/AbstractInkscapeTemplate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,7 @@ public abstract class AbstractInkscapeTemplate implements IVectorDataExport {
 
 	protected static final String LINE_DELIMITER = "\n";
 	protected static final String SPLIT_LINE_DELIMITER = "\\n";
-	//
+
 	protected static final String AXIS_X = "x"; //$NON-NLS-1$
 	protected static final String AXIS_Y = "y"; //$NON-NLS-1$
 
@@ -33,12 +33,12 @@ public abstract class AbstractInkscapeTemplate implements IVectorDataExport {
 	protected String getColor(Color color) {
 
 		StringBuilder builder = new StringBuilder("#");
-		//
+
 		double r = color.getRed();
 		double g = color.getGreen();
 		double b = color.getBlue();
 		double[] rgb = new double[]{r, g, b};
-		//
+
 		for(double x : rgb) {
 			double hex = 16.0d;
 			double div = x / hex;
@@ -46,23 +46,23 @@ public abstract class AbstractInkscapeTemplate implements IVectorDataExport {
 			double remainder = div - count;
 			remainder = (int)(remainder * hex);
 			char first, second;
-			//
+
 			if(count >= 10) {
 				first = (char)('a' + (count - 10));
 			} else {
 				first = (char)('0' + count);
 			}
-			//
+
 			if(remainder >= 10) {
 				second = (char)('a' + (remainder - 10));
 			} else {
 				second = (char)('0' + remainder);
 			}
-			//
+
 			builder.append(first);
 			builder.append(second);
 		}
-		//
+
 		return builder.toString();
 	}
 

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/vector/InkscapeBarChart.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/vector/InkscapeBarChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -39,19 +39,19 @@ public class InkscapeBarChart extends AbstractInkscapeTemplate {
 	public String generate(ScrollableChart scrollableChart, AxisSettings axisSettings) throws Exception {
 
 		StringBuilder builder = new StringBuilder();
-		//
+
 		IAxisSettings axisSettingsX = axisSettings.getAxisSettingsX();
 		IAxisSettings axisSettingsY = axisSettings.getAxisSettingsY();
 		boolean isReversedX = axisSettingsX.isReversed();
 		boolean isReversedY = axisSettingsY.isReversed();
 		DecimalFormat formatX = axisSettingsX.getDecimalFormat();
 		DecimalFormat formatY = axisSettingsY.getDecimalFormat();
-		//
+
 		BaseChart baseChart = scrollableChart.getBaseChart();
 		boolean isShowAxisZeroMarker = baseChart.getChartSettings().isShowAxisZeroMarker();
 		ISeries<?>[] series = baseChart.getSeriesSet().getSeries();
 		String template = TEMPLATE_BAR_CHART;
-		//
+
 		try (BufferedReader in = new BufferedReader(new InputStreamReader(getClass().getResourceAsStream(template)))) {
 			double xTicks[] = baseChart.getAxisSet().getXAxis(axisSettings.getIndexAxisX()).getTick().getTickLabelValues();
 			double yTicks[] = baseChart.getAxisSet().getYAxis(axisSettings.getIndexAxisY()).getTick().getTickLabelValues();
@@ -255,7 +255,7 @@ public class InkscapeBarChart extends AbstractInkscapeTemplate {
 		} catch(Exception e) {
 			e.printStackTrace();
 		}
-		//
+
 		return builder.toString();
 	}
 
@@ -274,12 +274,12 @@ public class InkscapeBarChart extends AbstractInkscapeTemplate {
 		int indexAxisY = axisSettings.getIndexAxisY();
 		IAxisScaleConverter axisScaleConverterX = axisSettings.getAxisScaleConverterX();
 		IAxisScaleConverter axisScaleConverterY = axisSettings.getAxisScaleConverterY();
-		//
+
 		double[] xSeries = dataSeries.getXSeries();
 		double[] ySeries = dataSeries.getYSeries();
 		String split[] = data.toString().split("\\n");
 		int size = dataSeries.getXSeries().length;
-		//
+
 		String match1 = ".*%COLOR%.*";
 		String match2 = ".*%x-coordinate%.*";
 		String match3 = ".*%y-coordinate%.*";

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/vector/InkscapeLineChart.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/vector/InkscapeLineChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -35,7 +35,7 @@ import org.eclipse.swtchart.extensions.core.ScrollableChart;
 public class InkscapeLineChart extends AbstractInkscapeLineChart {
 
 	private static final String TEMPLATE_LINE_CHART = "Template_LineChart.svg";
-	//
+
 	private static final String X_AXIS_TICKS = "%X-AXIS_TICKS%";
 	private static final String Y_AXIS_TICKS = "%Y-AXIS_TICKS%";
 	private static final String PLACEHOLDER_X_AXIS = "%PLACEHOLDER X-AXIS%";
@@ -54,7 +54,7 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 	private static final String X2_COORDINATE = "%X2-COORDINATE%";
 	private static final String Y1_COORDINATE = "%Y1-COORDINATE%";
 	private static final String Y2_COORDINATE = "%Y2-COORDINATE%";
-	//
+
 	private static final String HEADER_TICK_X = "<path\n" //
 			+ "                       inkscape:connector-curvature=\"0\"\n" //
 			+ "                       id=\"path888\"\n" //
@@ -71,7 +71,7 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 			+ "                         y=\"289.01782\"\n" //
 			+ "                         x=\"" + X_COORDINATE + "\"\n" //
 			+ "                         sodipodi:role=\"line\">" + X_01 + "</tspan></text>";
-	//
+
 	private static final String HEADER_TICK_Y = "<path\n" //
 			+ "                       inkscape:connector-curvature=\"0\"\n" //
 			+ "                       id=\"path1299\"\n" //
@@ -88,7 +88,7 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 			+ "                         x=\"14.211229\"\n" //
 			+ "                         y=\"" + Y_COORDINATE + "\"\n" //
 			+ "                         style=\"font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:arial;-inkscape-font-specification:arial;text-align:end;text-anchor:end;stroke-width:0.26458332\">" + Y_01 + "</tspan></text>";
-	//
+
 	private static final String HEADER_LEGEND = "<path\n" //
 			+ "                   style=\"fill:url(#linearGradient3662);fill-opacity:1;stroke:" + COLOR + ";stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1\"\n" //
 			+ "                   d=\"m 209.71446," + Y1_COORDINATE + " h 20.93268\"\n" //
@@ -105,13 +105,13 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 			+ "                     x=\"230.91121\"\n" //
 			+ "                     y=\"" + Y2_COORDINATE + "\"\n" //
 			+ "                     style=\"font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:Arial;-inkscape-font-specification:Arial;fill:url(#linearGradient4353);fill-opacity:1;stroke-width:0.26458332\">" + SERIES_A + "</tspan></text>";
-	//
+
 	private static final String HEADER_LABEL = "                     <path\n" //
 			+ "         style=\"fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:0.52999998,0.52999998;stroke-dashoffset:0;opacity:1\"\n" //
 			+ "         d=\"M " + X1_COORDINATE + "," + Y1_COORDINATE + " L " + X2_COORDINATE + "," + Y2_COORDINATE + "\"\n" //
 			+ "         id=\"path850\"\n" //
 			+ "         inkscape:connector-curvature=\"0\" />";
-	//
+
 	private static final String HEADER_DATA = "                    <path\n" //
 			+ "               style=\"fill:none;stroke:" + COLOR + ";stroke-width:0.45888707;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1\"\n" //
 			+ "               d=\"M " + DATA_POINTS + "\"\n" //
@@ -122,7 +122,7 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 	public String generate(ScrollableChart scrollableChart, AxisSettings axisSettings) throws Exception {
 
 		StringBuilder builder = new StringBuilder();
-		//
+
 		IAxisSettings axisSettingsX = axisSettings.getAxisSettingsX();
 		IAxisSettings axisSettingsY = axisSettings.getAxisSettingsY();
 		boolean isReversedX = axisSettingsX.isReversed();
@@ -130,17 +130,17 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 		DecimalFormat formatX = axisSettingsX.getDecimalFormat();
 		DecimalFormat formatY = axisSettingsY.getDecimalFormat();
 		BaseChart baseChart = scrollableChart.getBaseChart();
-		//
+
 		boolean isShowAxisZeroMarker = baseChart.getChartSettings().isShowAxisZeroMarker();
 		ISeries<?>[] series = baseChart.getSeriesSet().getSeries();
-		//
+
 		try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(getClass().getResourceAsStream(TEMPLATE_LINE_CHART)))) {
 			/*
 			 * Ticks
 			 */
 			double xTicks[] = baseChart.getAxisSet().getXAxis(axisSettings.getIndexAxisX()).getTick().getTickLabelValues();
 			double yTicks[] = baseChart.getAxisSet().getYAxis(axisSettings.getIndexAxisY()).getTick().getTickLabelValues();
-			//
+
 			StringBuilder tickX = new StringBuilder(HEADER_TICK_X);
 			StringBuilder tickY = new StringBuilder(HEADER_TICK_Y);
 			StringBuilder legend = new StringBuilder(HEADER_LEGEND);
@@ -152,7 +152,7 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 			String data_series = getRegularExpression(DATA_SERIES);
 			String regex_legend = getRegularExpression(LEGEND);
 			String axis_label = getRegularExpression(AXIS_LABELS);
-			//
+
 			String line;
 			while((line = bufferedReader.readLine()) != null) {
 				if(Pattern.matches(regexX, line)) {
@@ -175,7 +175,7 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 		} catch(Exception e) {
 			e.printStackTrace();
 		}
-		//
+
 		return builder.toString();
 	}
 
@@ -187,19 +187,19 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 		StringBuilder builder = new StringBuilder("");
 		double upper = baseChart.getAxisSet().getXAxis(axisSettings.getIndexAxisX()).getRange().upper;
 		double lower = baseChart.getAxisSet().getXAxis(axisSettings.getIndexAxisX()).getRange().lower;
-		//
+
 		for(int count = 0; count < ticklabel_size; count++) {
 			String split[] = tickX.toString().split(SPLIT_LINE_DELIMITER);
 			String matchXCoordinate = getRegularExpression(X_COORDINATE);
 			String matchX01 = getRegularExpression(X_01);
 			double x;
-			//
+
 			if(!isReversedX) {
 				x = start + ((xTicks[count] - lower) / (upper - lower) * height);
 			} else {
 				x = ((start + height) - (((xTicks[count] - lower) / (upper - lower) * height)));
 			}
-			//
+
 			for(String string : split) {
 				if(Pattern.matches(matchXCoordinate, string)) {
 					string = string.replace(X_COORDINATE, String.valueOf(x));
@@ -211,7 +211,7 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 			}
 			builder.append(LINE_DELIMITER);
 		}
-		//
+
 		return line.replaceAll(regexX, builder.toString());
 	}
 
@@ -223,19 +223,19 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 		StringBuilder builder = new StringBuilder("");
 		double upper = baseChart.getAxisSet().getYAxis(axisSettings.getIndexAxisY()).getRange().upper;
 		double lower = baseChart.getAxisSet().getYAxis(axisSettings.getIndexAxisY()).getRange().lower;
-		//
+
 		for(int count = 0; count < ticklabel_size; count++) {
 			String split[] = tickY.toString().split(SPLIT_LINE_DELIMITER);
 			String matchYCoordinate = getRegularExpression(Y_COORDINATE);
 			String matchY01 = getRegularExpression(Y_01);
 			double y;
-			//
+
 			if(!isReversedY) {
 				y = start - (height - ((upper - yTicks[count]) / (upper - lower) * height));
 			} else {
 				y = ((start - height) + (height - ((upper - yTicks[count]) / (upper - lower) * height)));
 			}
-			//
+
 			for(String string : split) {
 				if(Pattern.matches(matchYCoordinate, string)) {
 					string = string.replace(Y_COORDINATE, String.valueOf(y));
@@ -247,7 +247,7 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 			}
 			builder.append(LINE_DELIMITER);
 		}
-		//
+
 		return line.replaceAll(regexY, builder.toString());
 	}
 
@@ -257,7 +257,7 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 		double start2 = 102.06668;
 		StringBuilder builder = new StringBuilder("");
 		int count = 0;
-		//
+
 		for(ISeries<?> serie : series) {
 			if(serie.isVisible()) {
 				ILineSeries<?> lineSerie = (ILineSeries<?>)serie;
@@ -274,7 +274,7 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 				String matchY2Coordinate = getRegularExpression(Y2_COORDINATE);
 				String matchColor = getRegularExpression(COLOR);
 				String matchSeriesA = getRegularExpression(SERIES_A);
-				//
+
 				for(String string : split) {
 					if(Pattern.matches(matchY1Coordinate, string)) {
 						string = string.replace(Y1_COORDINATE, String.valueOf(y1));
@@ -292,14 +292,14 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 				count++;
 			}
 		}
-		//
+
 		return line.replaceAll(regex_legend, builder.toString());
 	}
 
 	private String getAxisLabel(BaseChart baseChart, AxisSettings axisSettings, StringBuilder axisLabel, boolean isReversedX, boolean isReversedY, boolean isShowAxisZeroMarker, String axis_label, String line) {
 
 		String label = "";
-		//
+
 		if(isShowAxisZeroMarker) {
 			StringBuilder builder = new StringBuilder("");
 			String split[] = axisLabel.toString().split(SPLIT_LINE_DELIMITER);
@@ -341,13 +341,13 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 			double upper2 = baseChart.getAxisSet().getYAxis(axisSettings.getIndexAxisY()).getRange().upper;
 			double lower2 = baseChart.getAxisSet().getYAxis(axisSettings.getIndexAxisY()).getRange().lower;
 			double y1;
-			//
+
 			if(!isReversedY) {
 				y1 = start2 - (height2 - ((upper2 - 0.0) / (upper2 - lower2) * height2));
 			} else {
 				y1 = ((start2 - height2) + (height2 - ((upper2 - 0.0) / (upper2 - lower2) * height2)));
 			}
-			//
+
 			if(y1 <= start2 && y1 >= start2 - height2) {
 				for(String string : split) {
 					if(Pattern.matches(matchX1Coordinate, string)) {
@@ -368,7 +368,7 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 			}
 			label = line.replaceAll(axis_label, builder.toString());
 		}
-		//
+
 		return label;
 	}
 
@@ -392,7 +392,7 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 				builder.append(string);
 			}
 		}
-		//
+
 		return line.replaceAll(data_series, builder.toString());
 	}
 
@@ -410,12 +410,12 @@ public class InkscapeLineChart extends AbstractInkscapeLineChart {
 		int indexAxisY = axisSettings.getIndexAxisY();
 		IAxisScaleConverter axisScaleConverterX = axisSettings.getAxisScaleConverterX();
 		IAxisScaleConverter axisScaleConverterY = axisSettings.getAxisScaleConverterY();
-		//
+
 		double[] xSeries = dataSeries.getXSeries();
 		double[] ySeries = dataSeries.getYSeries();
 		String split[] = data.toString().split(SPLIT_LINE_DELIMITER);
 		int size = dataSeries.getXSeries().length;
-		//
+
 		String match1 = getRegularExpression(COLOR);
 		String match2 = getRegularExpression(DATA_POINTS);
 		for(String string : split) {

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/vector/InkscapeScatterChart.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/vector/InkscapeScatterChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -36,19 +36,19 @@ public class InkscapeScatterChart extends AbstractInkscapeLineChart {
 	public String generate(ScrollableChart scrollableChart, AxisSettings axisSettings) throws Exception {
 
 		StringBuilder builder = new StringBuilder();
-		//
+
 		IAxisSettings axisSettingsX = axisSettings.getAxisSettingsX();
 		IAxisSettings axisSettingsY = axisSettings.getAxisSettingsY();
 		boolean isReversedX = axisSettingsX.isReversed();
 		boolean isReversedY = axisSettingsY.isReversed();
 		DecimalFormat formatX = axisSettingsX.getDecimalFormat();
 		DecimalFormat formatY = axisSettingsY.getDecimalFormat();
-		//
+
 		BaseChart baseChart = scrollableChart.getBaseChart();
 		boolean isShowAxisZeroMarker = baseChart.getChartSettings().isShowAxisZeroMarker();
 		ISeries<?>[] series = baseChart.getSeriesSet().getSeries();
 		String template = TEMPLATE_SCATTER_CHART;
-		//
+
 		try (BufferedReader in = new BufferedReader(new InputStreamReader(getClass().getResourceAsStream(template)))) {
 			double xTicks[] = baseChart.getAxisSet().getXAxis(axisSettings.getIndexAxisX()).getTick().getTickLabelValues();
 			double yTicks[] = baseChart.getAxisSet().getYAxis(axisSettings.getIndexAxisY()).getTick().getTickLabelValues();
@@ -252,7 +252,7 @@ public class InkscapeScatterChart extends AbstractInkscapeLineChart {
 		} catch(Exception e) {
 			e.printStackTrace();
 		}
-		//
+
 		return builder.toString();
 	}
 }

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/vector/Messages.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/vector/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWT Chart Project
+ * Copyright (c) 2020, 2025 SWT Chart Project
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,7 @@ public class Messages {
 
 	private static final String BUNDLE_NAME = "org.eclipse.swtchart.export.menu.vector.messages"; //$NON-NLS-1$
 	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
-	//
+
 	public static final String EXPORT_TO_SVG = "EXPORT_TO_SVG";
 	public static final String SAVE_AS_SVG = "SAVE_AS_SVG";
 	public static final String SVG = "SVG";

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/vector/SVGExportHandler.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/menu/vector/SVGExportHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 Lablicate GmbH.
+ * Copyright (c) 2019, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -70,7 +70,7 @@ public class SVGExportHandler extends AbstractSeriesExportHandler implements ISe
 		fileDialog.setText(NAME);
 		fileDialog.setFilterExtensions(new String[]{FILE_EXTENSION});
 		fileDialog.setFileName(scrollableChart.getFileName());
-		//
+
 		String fileName = fileDialog.open();
 		if(fileName != null) {
 			try {
@@ -161,7 +161,7 @@ public class SVGExportHandler extends AbstractSeriesExportHandler implements ISe
 											if(vectorDataExport != null) {
 												exportPlot(printWriter, vectorDataExport, scrollableChart, axisSettings);
 											}
-											//
+
 											MessageDialog.openInformation(shell, TITLE, MESSAGE_OK);
 										} catch(FileNotFoundException e) {
 											MessageDialog.openError(shell, TITLE, MESSAGE_ERROR);
@@ -180,7 +180,7 @@ public class SVGExportHandler extends AbstractSeriesExportHandler implements ISe
 						}
 					}
 				}
-				//
+
 				exportSettingsDialog.reset();
 				scrollableChart.updateLegend();
 			} catch(InvocationTargetException e) {

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/Activator.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/Activator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -41,7 +41,7 @@ public class Activator extends AbstractUIPlugin {
 	public static final String ICON_DOWN = "ICON_DOWN"; // $NON-NLS-1$
 	public static final String ICON_LEFT = "ICON_LEFT"; // $NON-NLS-1$
 	public static final String ICON_RIGHT = "ICON_RIGHT"; // $NON-NLS-1$
-	//
+
 	private static Activator plugin;
 
 	/**
@@ -94,7 +94,7 @@ public class Activator extends AbstractUIPlugin {
 		imageHashMap.put(ICON_DOWN, "icons/16x16/down.gif"); // $NON-NLS-1$
 		imageHashMap.put(ICON_LEFT, "icons/16x16/left.gif"); // $NON-NLS-1$
 		imageHashMap.put(ICON_RIGHT, "icons/16x16/right.gif"); // $NON-NLS-1$
-		//
+
 		ImageRegistry imageRegistry = getImageRegistry();
 		if(imageRegistry != null) {
 			/*

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/ComplexPieChartExample.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/ComplexPieChartExample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -28,7 +28,7 @@ public class ComplexPieChartExample {
 		shell.setText("Complex PieChart");
 		shell.setSize(700, 600);
 		shell.setLayout(new FillLayout());
-		//
+
 		ComplexPieChart complexPieChart = new ComplexPieChart(shell);
 		IChartSettings chartSettings = complexPieChart.getChartSettings();
 		chartSettings.setBackground(display.getSystemColor(SWT.COLOR_WHITE));
@@ -36,7 +36,7 @@ public class ComplexPieChartExample {
 		chartSettings.setBackgroundPlotArea(display.getSystemColor(SWT.COLOR_WHITE));
 		complexPieChart.applySettings(chartSettings);
 		shell.open();
-		//
+
 		while(!shell.isDisposed()) {
 			if(!display.readAndDispatch()) {
 				display.sleep();

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/DemoBarChart.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/DemoBarChart.java
@@ -33,7 +33,7 @@ public class DemoBarChart {
 		shell.setText("DemoBarChart");
 		shell.setSize(500, 400);
 		shell.setLayout(new FillLayout());
-		//
+
 		ScrollableChart scrollableChart = new BarSeries_5_Part(shell);
 		scrollableChart.setFileName("NegativeX");
 		shell.open();
@@ -51,7 +51,7 @@ public class DemoBarChart {
 		chartSettings.setBackgroundChart(display.getSystemColor(SWT.COLOR_WHITE));
 		chartSettings.setBackgroundPlotArea(display.getSystemColor(SWT.COLOR_WHITE));
 		scrollableChart.applySettings(chartSettings);
-		//
+
 		while(!shell.isDisposed()) {
 			if(!display.readAndDispatch()) {
 				display.sleep();

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/DemoBoxPlotChart.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/DemoBoxPlotChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Lablicate GmbH.
+ * Copyright (c) 2022, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -43,7 +43,7 @@ public class DemoBoxPlotChart {
 		shell.setText("Box Plot Chart");
 		shell.setSize(1024, 768);
 		shell.setLayout(new FillLayout());
-		//
+
 		BoxPlotChart boxPlotChart = new BoxPlotChart(shell, SWT.NONE);
 		shell.open();
 		/*
@@ -75,7 +75,7 @@ public class DemoBoxPlotChart {
 		 */
 		Color colorBlue = Display.getDefault().getSystemColor(SWT.COLOR_BLUE);
 		Color colorRed = Display.getDefault().getSystemColor(SWT.COLOR_RED);
-		//
+
 		List<ISeriesData> boxPlotSeriesList = SeriesConverter.getSeriesBoxPlot(SeriesConverter.BOXPLOT_SERIES_1);
 		List<IScatterSeriesData> scatterSeriesDataList = new ArrayList<IScatterSeriesData>();
 		for(int i = 0; i < boxPlotSeriesList.size(); i++) {
@@ -89,13 +89,13 @@ public class DemoBoxPlotChart {
 			scatterSeriesDataList.add(scatterSeriesData);
 		}
 		boxPlotChart.addSeriesData(scatterSeriesDataList);
-		//
+
 		while(!shell.isDisposed()) {
 			if(!display.readAndDispatch()) {
 				display.sleep();
 			}
 		}
-		//
+
 		display.dispose();
 	}
 }

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/DemoChart.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/DemoChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -41,7 +41,7 @@ public class DemoChart {
 		shell.setText("DemoChart");
 		shell.setSize(500, 400);
 		shell.setLayout(new FillLayout());
-		//
+
 		ScrollableChart scrollableChart = new LineSeries_1_Part(shell);
 		scrollableChart.setFileName("Demo Chart");
 		shell.open();
@@ -61,7 +61,7 @@ public class DemoChart {
 		addClipboardMenuEntry(chartSettings);
 		addToggleAxisLinesMenuEntry(chartSettings);
 		scrollableChart.applySettings(chartSettings);
-		//
+
 		while(!shell.isDisposed()) {
 			if(!display.readAndDispatch()) {
 				display.sleep();
@@ -100,7 +100,7 @@ public class DemoChart {
 				builder.append(getAxisTicks(axisSet.getXAxes()));
 				builder.append(getAxisTicks(axisSet.getYAxes()));
 				Object[] data = new Object[]{builder.toString()};
-				//
+
 				TextTransfer textTransfer = TextTransfer.getInstance();
 				Transfer[] dataTypes = new Transfer[]{textTransfer};
 				Clipboard clipboard = new Clipboard(Display.getDefault());
@@ -171,11 +171,11 @@ public class DemoChart {
 				for(ISecondaryAxisSettings secondaryAxisSettings : chartSettings.getSecondaryAxisSettingsListX()) {
 					secondaryAxisSettings.setDrawAxisLine(!secondaryAxisSettings.isDrawAxisLine());
 				}
-				//
+
 				for(ISecondaryAxisSettings secondaryAxisSettings : chartSettings.getSecondaryAxisSettingsListY()) {
 					secondaryAxisSettings.setDrawAxisLine(!secondaryAxisSettings.isDrawAxisLine());
 				}
-				//
+
 				scrollableChart.applySettings(chartSettings);
 			}
 		});

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/DemoChart1a.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/DemoChart1a.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -39,10 +39,10 @@ public class DemoChart1a {
 		shell.setText("Area Strict Example (Experimental)");
 		shell.setSize(500, 400);
 		shell.setLayout(new FillLayout());
-		//
+
 		ScrollableChart scrollableChart = new LineSeries_1a_Part(shell);
 		scrollableChart.setLayoutData(new GridData(GridData.FILL_BOTH));
-		//
+
 		shell.open();
 		/*
 		 * Demo Chart Background (experimental)
@@ -59,7 +59,7 @@ public class DemoChart1a {
 		addOrientationOption(chartSettings);
 		addAreaStrictOption(chartSettings);
 		scrollableChart.applySettings(chartSettings);
-		//
+
 		while(!shell.isDisposed()) {
 			if(!display.readAndDispatch()) {
 				display.sleep();

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/DemoChartDialog.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/DemoChartDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 SWTChart project.
+ * Copyright (c) 2023, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -36,7 +36,7 @@ public class DemoChartDialog {
 		shell.setText("DemoChartDialog");
 		shell.setSize(250, 100);
 		shell.setLayout(new FillLayout());
-		//
+
 		Button button = new Button(shell, SWT.PUSH);
 		button.setText("Open Chart Dynamically");
 		button.setToolTipText("https://github.com/eclipse/swtchart/issues/372");
@@ -57,11 +57,11 @@ public class DemoChartDialog {
 						chart.getTitle().setText("Bar Chart");
 						chart.getAxisSet().getXAxis(0).getTitle().setText("Data Points");
 						chart.getAxisSet().getYAxis(0).getTitle().setText("Amplitude");
-						//
+
 						IBarSeries<?> barSeries = (IBarSeries<?>)chart.getSeriesSet().createSeries(SeriesType.BAR, "bar series");
 						barSeries.setYSeries(ySeries);
 						chart.getAxisSet().adjustRange();
-						//
+
 						parent.addDisposeListener(new DisposeListener() {
 
 							@Override
@@ -95,15 +95,15 @@ public class DemoChartDialog {
 				shell.setText("Bar Chart");
 				shell.setSize(650, 500);
 				shell.setLayout(new FillLayout());
-				//
+
 				BarChartView barChartView = new BarChartView();
 				barChartView.createPartControl(shell);
-				//
+
 				shell.open();
 			}
 		});
 		shell.open();
-		//
+
 		while(!shell.isDisposed()) {
 			if(!display.readAndDispatch()) {
 				display.sleep();

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/DemoChart_427.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/DemoChart_427.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 SWTChart project.
+ * Copyright (c) 2024, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -41,7 +41,7 @@ public class DemoChart_427 {
 		shell.setSize(500, 400);
 		shell.setLayout(new FillLayout());
 		shell.setBackgroundMode(SWT.INHERIT_FORCE);
-		//
+
 		LineChart lineChart = new LineChart(shell, SWT.NONE);
 		lineChart.setFileName("DemoChart_427");
 		lineChart.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
@@ -80,7 +80,7 @@ public class DemoChart_427 {
 		lineSeriesSettings.setEnableArea(true);
 		lineSeriesDataList.add(lineSeriesData);
 		lineChart.addSeriesData(lineSeriesDataList, ICompressionSupport.HIGH_COMPRESSION);
-		//
+
 		while(!shell.isDisposed()) {
 			if(!display.readAndDispatch()) {
 				display.sleep();

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/Demo_375_MinorLabels.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/Demo_375_MinorLabels.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 SWTChart project.
+ * Copyright (c) 2023, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -36,7 +36,7 @@ public class Demo_375_MinorLabels {
 		axis.setRange(new Range(10000, 10000.3));
 		Format format = new DecimalFormat("#.0");
 		axis.getTick().setFormat(format);
-		//
+
 		shell.open();
 		while(!shell.isDisposed()) {
 			if(!display.readAndDispatch()) {

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/Demo_375_ZeroLabel.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/Demo_375_ZeroLabel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 SWTChart project.
+ * Copyright (c) 2023, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -31,7 +31,7 @@ public class Demo_375_ZeroLabel {
 		Chart chart = new Chart(shell, SWT.NONE);
 		IAxis axis = chart.getAxisSet().getXAxis(0);
 		axis.setRange(new Range(-3, 5));
-		//
+
 		shell.open();
 		while(!shell.isDisposed()) {
 			if(!display.readAndDispatch()) {

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/FixedRangeChart.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/FixedRangeChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 SWTChart project.
+ * Copyright (c) 2022, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,7 +32,7 @@ public class FixedRangeChart {
 		shell.setText("FixedRangeChart");
 		shell.setSize(500, 400);
 		shell.setLayout(new FillLayout());
-		//
+
 		ScrollableChart scrollableChart = new BarSeries_1_1_Part(shell);
 		IChartSettings chartSettings = scrollableChart.getChartSettings();
 		chartSettings.setBackground(display.getSystemColor(SWT.COLOR_WHITE));
@@ -47,7 +47,7 @@ public class FixedRangeChart {
 		axisX.setRange(new Range(10, 250));
 		IAxis axisY = scrollableChart.getBaseChart().getAxisSet().getYAxis(BaseChart.ID_PRIMARY_Y_AXIS);
 		axisY.setRange(new Range(0, 1500));
-		//
+
 		while(!shell.isDisposed()) {
 			if(!display.readAndDispatch()) {
 				display.sleep();

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/InteractiveChartDemo.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/InteractiveChartDemo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 SWTChart project.
+ * Copyright (c) 2024, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,10 +27,10 @@ public class InteractiveChartDemo {
 		shell.setText("InteractiveChartDemo");
 		shell.setSize(500, 400);
 		shell.setLayout(new FillLayout());
-		//
+
 		new InteractiveChart(shell, SWT.NONE);
 		shell.open();
-		//
+
 		while(!shell.isDisposed()) {
 			if(!display.readAndDispatch()) {
 				display.sleep();

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/NoBorderSimpleChart.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/NoBorderSimpleChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Lablicate GmbH.
+ * Copyright (c) 2022, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -34,7 +34,7 @@ public class NoBorderSimpleChart {
 		shell.setText("NoBorderSimpleChart");
 		shell.setSize(300, 300);
 		shell.setLayout(new FillLayout());
-		//
+
 		ScrollableChart scrollableChart = new PeakSeries_1_Part(shell);
 		shell.open();
 		/*
@@ -58,13 +58,13 @@ public class NoBorderSimpleChart {
 		disableSecondaryAxes(chartSettings.getSecondaryAxisSettingsListX());
 		disableSecondaryAxes(chartSettings.getSecondaryAxisSettingsListY());
 		scrollableChart.applySettings(chartSettings);
-		//
+
 		while(!shell.isDisposed()) {
 			if(!display.readAndDispatch()) {
 				display.sleep();
 			}
 		}
-		//
+
 		font.dispose();
 		display.dispose();
 	}

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/SecondaryAxisChart.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/SecondaryAxisChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -46,7 +46,7 @@ public class SecondaryAxisChart {
 		shell.setText("Kibibyte Example");
 		shell.setSize(500, 400);
 		shell.setLayout(new FillLayout());
-		//
+
 		LineChart scrollableChart = new LineChart(shell, SWT.NONE);
 		shell.open();
 		/*
@@ -70,7 +70,7 @@ public class SecondaryAxisChart {
 		lineSeriesSettings.setEnableArea(false);
 		lineSeriesDataList.add(lineSeriesData);
 		scrollableChart.addSeriesData(lineSeriesDataList);
-		//
+
 		while(!shell.isDisposed()) {
 			if(!display.readAndDispatch()) {
 				display.sleep();
@@ -83,7 +83,7 @@ public class SecondaryAxisChart {
 
 		IPrimaryAxisSettings primaryAxisSettingsX = chartSettings.getPrimaryAxisSettingsX();
 		primaryAxisSettingsX.setVisible(false);
-		//
+
 		IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
 		primaryAxisSettingsY.setGridLineStyle(LineStyle.NONE);
 		primaryAxisSettingsY.setTitle("KB (kilobyte)");
@@ -94,7 +94,7 @@ public class SecondaryAxisChart {
 		ISecondaryAxisSettings secondaryAxisSettingsY = new SecondaryAxisSettings("KiB (kibibyte)", new ByteToKibibyteConverter());
 		secondaryAxisSettingsY.setPosition(Position.Secondary);
 		secondaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.00"), new DecimalFormatSymbols(Locale.ENGLISH)));
-		//
+
 		chartSettings.getSecondaryAxisSettingsListY().add(secondaryAxisSettingsY);
 	}
 
@@ -102,16 +102,16 @@ public class SecondaryAxisChart {
 
 		int size = 100;
 		double[] ySeries = new double[size];
-		//
+
 		for(int i = 0; i < size; i++) {
 			ySeries[i] = 500000;
 		}
-		//
+
 		Random random = new Random();
 		for(int i = 35; i < 50; i++) {
 			ySeries[i] = random.nextDouble() * 1000000;
 		}
-		//
+
 		return new SeriesData(ySeries, "Demo");
 	}
 }

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/SimplePieChartExample.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/SimplePieChartExample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,7 +29,7 @@ public class SimplePieChartExample {
 		shell.setText("PieChart");
 		shell.setSize(700, 600);
 		shell.setLayout(new FillLayout());
-		//
+
 		boolean doughnut = true;
 		boolean highlightSeries = false;
 		SimplePieChart simplePieChart = new SimplePieChart(shell, doughnut, highlightSeries);
@@ -39,7 +39,7 @@ public class SimplePieChartExample {
 		chartSettings.setBackgroundPlotArea(display.getSystemColor(SWT.COLOR_WHITE));
 		simplePieChart.applySettings(chartSettings);
 		shell.open();
-		//
+
 		while(!shell.isDisposed()) {
 			if(!display.readAndDispatch()) {
 				display.sleep();

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/macos/BaselineSelectionPaintListenerX.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/macos/BaselineSelectionPaintListenerX.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Lablicate GmbH.
+ * Copyright (c) 2011, 2025 Lablicate GmbH.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,12 +20,11 @@ import org.eclipse.swtchart.ICustomPaintListener;
 public class BaselineSelectionPaintListenerX implements ICustomPaintListener {
 
 	private final static int VERTICAL_MARKER_SIZE = 10;
-	//
+
 	private int x1;
 	private int y1;
 	private int x2;
 	private int y2;
-	//
 
 	@Override
 	public void paintControl(PaintEvent e) {

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/macos/DemoChart.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/macos/DemoChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,7 +27,7 @@ public class DemoChart {
 		shell.setText("DemoChart (macOS)");
 		shell.setSize(500, 400);
 		shell.setLayout(new FillLayout());
-		//
+
 		LineChartX lineChartX = new LineChartX(shell);
 		shell.open();
 		/*
@@ -44,7 +44,7 @@ public class DemoChart {
 		chartSettings.addHandledEventProcessor(new MouseMoveShiftEventX());
 		chartSettings.addHandledEventProcessor(new MouseUpEventX());
 		lineChartX.applySettings(chartSettings);
-		//
+
 		while(!shell.isDisposed()) {
 			if(!display.readAndDispatch()) {
 				display.sleep();

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/macos/LineChartX.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/macos/LineChartX.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Lablicate GmbH.
+ * Copyright (c) 2021, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,7 +23,7 @@ public class LineChartX extends LineSeries_1_Part {
 
 	private Cursor defaultCursor;
 	private BaselineSelectionPaintListenerX baselineSelectionPaintListenerX;
-	//
+
 	private int xStart;
 	private int yStart;
 	private int xStop;
@@ -96,12 +96,12 @@ public class LineChartX extends LineSeries_1_Part {
 
 		xStop = x;
 		yStop = y;
-		//
+
 		baselineSelectionPaintListenerX.setX1(xStart);
 		baselineSelectionPaintListenerX.setY1(yStart);
 		baselineSelectionPaintListenerX.setX2(xStop);
 		baselineSelectionPaintListenerX.setY2(yStop);
-		//
+
 		redrawChart();
 	}
 
@@ -114,12 +114,12 @@ public class LineChartX extends LineSeries_1_Part {
 	private void resetSelectedRange() {
 
 		baselineSelectionPaintListenerX.reset();
-		//
+
 		xStart = 0;
 		yStart = 0;
 		xStop = 0;
 		yStop = 0;
-		//
+
 		redrawChart();
 	}
 

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/BarSeries_1_1_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/BarSeries_1_1_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -54,7 +54,7 @@ public class BarSeries_1_1_Part extends MassSpectrumChart {
 		 */
 		List<IBarSeriesData> barSeriesDataList = new ArrayList<>();
 		ISeriesData seriesData = SeriesConverter.getSeriesXY(SeriesConverter.BAR_SERIES_1);
-		//
+
 		IBarSeriesData barSeriesData = new BarSeriesData(seriesData);
 		barSeriesDataList.add(barSeriesData);
 		/*

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/BarSeries_1_2_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/BarSeries_1_2_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -55,7 +55,7 @@ public class BarSeries_1_2_Part extends MassSpectrumChart {
 		 */
 		List<IBarSeriesData> barSeriesDataList = new ArrayList<IBarSeriesData>();
 		ISeriesData seriesData = SeriesConverter.getSeriesXY(SeriesConverter.BAR_SERIES_1);
-		//
+
 		IBarSeriesData barSeriesData = new BarSeriesData(seriesData);
 		barSeriesDataList.add(barSeriesData);
 		/*

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/BarSeries_1_3_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/BarSeries_1_3_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -57,7 +57,7 @@ public class BarSeries_1_3_Part extends MassSpectrumChart {
 		 */
 		List<IBarSeriesData> barSeriesDataList = new ArrayList<IBarSeriesData>();
 		ISeriesData seriesData = SeriesConverter.getSeriesXY(SeriesConverter.BAR_SERIES_1);
-		//
+
 		IBarSeriesData barSeriesData = new BarSeriesData(seriesData);
 		barSeriesDataList.add(barSeriesData);
 		/*
@@ -69,7 +69,7 @@ public class BarSeries_1_3_Part extends MassSpectrumChart {
 	private Map<Double, String> createCustomLabels() {
 
 		Map<Double, String> customLabels = new HashMap<Double, String>();
-		//
+
 		customLabels.put(16.0, "245 > 16.0 @12");
 		customLabels.put(17.0, "245 > 17.0 @12");
 		customLabels.put(18.0, "245 > 18.0 @12");
@@ -148,7 +148,7 @@ public class BarSeries_1_3_Part extends MassSpectrumChart {
 		customLabels.put(149.0, "245 > 149.0 @12");
 		customLabels.put(150.0, "245 > 150.0 @12");
 		customLabels.put(191.0, "245 > 191.0 @12");
-		//
+
 		return customLabels;
 	}
 }

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/BarSeries_2_1_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/BarSeries_2_1_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -48,24 +48,24 @@ public class BarSeries_2_1_Part extends BarChart {
 		chartSettings.setVerticalSliderVisible(true);
 		chartSettings.getRangeRestriction().setZeroX(false);
 		chartSettings.getRangeRestriction().setZeroY(false);
-		//
+
 		IPrimaryAxisSettings primaryAxisSettingsX = chartSettings.getPrimaryAxisSettingsX();
 		primaryAxisSettingsX.setTitle("m/z");
 		primaryAxisSettingsX.setDecimalFormat(new DecimalFormat(("0.0##"), new DecimalFormatSymbols(Locale.ENGLISH)));
 		primaryAxisSettingsX.setColor(getDisplay().getSystemColor(SWT.COLOR_BLACK));
-		//
+
 		IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
 		primaryAxisSettingsY.setTitle("Intensity");
 		primaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.0#E0"), new DecimalFormatSymbols(Locale.ENGLISH)));
 		primaryAxisSettingsY.setColor(getDisplay().getSystemColor(SWT.COLOR_BLACK));
-		//
+
 		applySettings(chartSettings);
 		/*
 		 * Create series.
 		 */
 		List<IBarSeriesData> barSeriesDataList = new ArrayList<IBarSeriesData>();
 		ISeriesData seriesData = SeriesConverter.getSeriesXY(SeriesConverter.BAR_SERIES_2);
-		//
+
 		IBarSeriesData barSeriesData = new BarSeriesData(seriesData);
 		barSeriesDataList.add(barSeriesData);
 		/*

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/BarSeries_2_2_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/BarSeries_2_2_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -47,7 +47,7 @@ public class BarSeries_2_2_Part extends MassSpectrumChart {
 		rangeRestriction.setExtendTypeY(RangeRestriction.ExtendType.RELATIVE);
 		rangeRestriction.setExtendMaxY(0.1d);
 		applySettings(chartSettings);
-		//
+
 		setNumberOfHighestIntensitiesToLabel(5);
 		setLabelOption(LabelOption.EXACT);
 		setCustomLabels(null);
@@ -56,7 +56,7 @@ public class BarSeries_2_2_Part extends MassSpectrumChart {
 		 */
 		List<IBarSeriesData> barSeriesDataList = new ArrayList<IBarSeriesData>();
 		ISeriesData seriesData = SeriesConverter.getSeriesXY(SeriesConverter.BAR_SERIES_2);
-		//
+
 		IBarSeriesData barSeriesData = new BarSeriesData(seriesData);
 		barSeriesDataList.add(barSeriesData);
 		/*

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/BarSeries_3_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/BarSeries_3_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -46,7 +46,7 @@ public class BarSeries_3_Part extends MassSpectrumChart {
 		rangeRestriction.setExtendTypeY(RangeRestriction.ExtendType.RELATIVE);
 		rangeRestriction.setExtendMinY(0.1d);
 		applySettings(chartSettings);
-		//
+
 		setNumberOfHighestIntensitiesToLabel(5);
 		setLabelOption(LabelOption.NOMIMAL);
 		setCustomLabels(null);

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/BarSeries_4_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/BarSeries_4_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -56,7 +56,7 @@ public class BarSeries_4_Part extends BarChart {
 		indexSeries = 0;
 		List<IBarSeriesData> barSeriesDataList = new ArrayList<IBarSeriesData>();
 		ISeriesData seriesData = SeriesConverter.getSeriesXY(SeriesConverter.BAR_SERIES_1);
-		//
+
 		IBarSeriesData barSeriesData = new BarSeriesData(seriesData);
 		barSeriesDataList.add(barSeriesData);
 		/*
@@ -72,7 +72,7 @@ public class BarSeries_4_Part extends BarChart {
 		labels.put(21, "2-Methoxy-4-vinylphenol");
 		labels.put(40, "Ethanone, 1-(2-hydroxy-5-methylphenyl)-");
 		labels.put(64, "4-Hydroxy-3-methylacetophenone");
-		//
+
 		labelMarker.setLabels(labels, indexSeries, SWT.VERTICAL);
 		plotArea.addCustomPaintListener(labelMarker);
 	}

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/BarSeries_Preferences_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/BarSeries_Preferences_Part.java
@@ -98,7 +98,7 @@ public class BarSeries_Preferences_Part extends Composite {
 		gridDataComposite.horizontalAlignment = SWT.END;
 		compositeButtons.setLayoutData(gridDataComposite);
 		compositeButtons.setLayout(new GridLayout(1, false));
-		//
+
 		Button buttonOpenSettings = new Button(compositeButtons, SWT.PUSH);
 		modifySettingsButton(buttonOpenSettings);
 		buttonOpenSettings.addSelectionListener(new SelectionAdapter() {
@@ -114,14 +114,14 @@ public class BarSeries_Preferences_Part extends Composite {
 				preferenceSecondaryAxesPage.setTitle("Secondary Axes");
 				IPreferencePage preferenceDataPage = new BarSeriesDataPreferencePage();
 				preferenceDataPage.setTitle("Series Data");
-				//
+
 				PreferenceManager preferenceManager = new PreferenceManager();
 				preferenceManager.addToRoot(new PreferenceNode("1", preferencePage));
 				preferenceManager.addToRoot(new PreferenceNode("2", preferencePrimaryAxesPage));
 				preferenceManager.addToRoot(new PreferenceNode("3", preferenceSecondaryAxesPage));
 				preferenceManager.addToRoot(new PreferenceNode("4", preferenceDataPage));
-				//
-				//
+
+
 				PreferenceDialog preferenceDialog = new PreferenceDialog(e.display.getActiveShell(), preferenceManager);
 				preferenceDialog.create();
 				preferenceDialog.setMessage("Settings");
@@ -135,10 +135,10 @@ public class BarSeries_Preferences_Part extends Composite {
 				}
 			}
 		});
-		//
+
 		barChart = new BarChart(this, SWT.NONE);
 		barChart.setLayoutData(new GridData(GridData.FILL_BOTH));
-		//
+
 		applyChartSettings();
 		applySeriesSettings();
 	}
@@ -154,7 +154,7 @@ public class BarSeries_Preferences_Part extends Composite {
 
 		IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
 		setBackground(getDisplay().getSystemColor(SWT.COLOR_WHITE));
-		//
+
 		Color colorHintRangeSelector = getColor(PreferenceConverter.getColor(preferenceStore, BarSeriesPreferenceConstants.P_COLOR_HINT_RANGE_SELECTOR));
 		Color colorTitle = getColor(PreferenceConverter.getColor(preferenceStore, BarSeriesPreferenceConstants.P_TITLE_COLOR));
 		Color colorBackground = getColor(PreferenceConverter.getColor(preferenceStore, BarSeriesPreferenceConstants.P_BACKGROUND));
@@ -171,7 +171,7 @@ public class BarSeries_Preferences_Part extends Composite {
 		Color colorLegendMarker = getColor(PreferenceConverter.getColor(preferenceStore, BarSeriesPreferenceConstants.P_COLOR_LEGEND_MARKER));
 		Color colorAxisZeroMarker = getColor(PreferenceConverter.getColor(preferenceStore, BarSeriesPreferenceConstants.P_COLOR_AXIS_ZERO_MARKER));
 		Color colorSeriesLabelMarker = getColor(PreferenceConverter.getColor(preferenceStore, BarSeriesPreferenceConstants.P_COLOR_SERIES_LABEL_MARKER));
-		//
+
 		IChartSettings chartSettings = barChart.getChartSettings();
 		chartSettings.setEnableRangeSelector(preferenceStore.getBoolean(BarSeriesPreferenceConstants.P_ENABLE_RANGE_SELECTOR));
 		chartSettings.setShowRangeSelectorInitially(preferenceStore.getBoolean(BarSeriesPreferenceConstants.P_SHOW_RANGE_SELECTOR_INITIALLY));
@@ -203,7 +203,7 @@ public class BarSeries_Preferences_Part extends Composite {
 		rangeRestriction.setExtendTypeY(RangeRestriction.ExtendType.valueOf(preferenceStore.getString(BarSeriesPreferenceConstants.P_EXTEND_TYPE_Y)));
 		rangeRestriction.setExtendMinY(preferenceStore.getDouble(BarSeriesPreferenceConstants.P_EXTEND_MIN_Y));
 		rangeRestriction.setExtendMaxY(preferenceStore.getDouble(BarSeriesPreferenceConstants.P_EXTEND_MAX_Y));
-		//
+
 		chartSettings.setShowPositionMarker(preferenceStore.getBoolean(BarSeriesPreferenceConstants.P_SHOW_POSITION_MARKER));
 		chartSettings.setColorPositionMarker(colorPositionMarker);
 		chartSettings.setShowPlotCenterMarker(preferenceStore.getBoolean(BarSeriesPreferenceConstants.P_SHOW_PLOT_CENTER_MARKER));
@@ -214,7 +214,7 @@ public class BarSeries_Preferences_Part extends Composite {
 		chartSettings.setColorLegendMarker(colorAxisZeroMarker);
 		chartSettings.setShowSeriesLabelMarker(preferenceStore.getBoolean(BarSeriesPreferenceConstants.P_SHOW_SERIES_LABEL_MARKER));
 		chartSettings.setColorSeriesLabelMarker(colorSeriesLabelMarker);
-		//
+
 		chartSettings.setCreateMenu(preferenceStore.getBoolean(BarSeriesPreferenceConstants.P_CREATE_MENU));
 		/*
 		 * Primary X-Axis
@@ -259,7 +259,7 @@ public class BarSeries_Preferences_Part extends Composite {
 		secondaryAxisSettingsY.setLogScaleBase(preferenceStore.getDouble(BarSeriesPreferenceConstants.P_SECONDARY_Y_AXIS_LOG_SCALE_BASE));
 		secondaryAxisSettingsY.setExtraSpaceTitle(preferenceStore.getInt(BarSeriesPreferenceConstants.P_SECONDARY_Y_AXIS_EXTRA_SPACE_TITLE));
 		chartSettings.getSecondaryAxisSettingsListY().add(secondaryAxisSettingsY);
-		//
+
 		barChart.applySettings(chartSettings);
 	}
 
@@ -268,7 +268,7 @@ public class BarSeries_Preferences_Part extends Composite {
 		IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
 		Color barColorSeries1 = getColor(PreferenceConverter.getColor(preferenceStore, BarSeriesPreferenceConstants.P_BAR_COLOR_SERIES_1));
 		Color barColorSeries1Highlight = getColor(PreferenceConverter.getColor(preferenceStore, BarSeriesPreferenceConstants.P_BAR_COLOR_SERIES_1_HIGHLIGHT));
-		//
+
 		barChart.deleteSeries();
 		List<IBarSeriesData> barSeriesDataList = new ArrayList<IBarSeriesData>();
 		ISeriesData seriesData;
@@ -281,14 +281,14 @@ public class BarSeries_Preferences_Part extends Composite {
 		barSeriesData = new BarSeriesData(seriesData);
 		barSeriesSettings = barSeriesData.getSettings();
 		barSeriesSettings.setDescription(preferenceStore.getString(BarSeriesPreferenceConstants.P_DESCRIPTION_SERIES_1));
-		//
+
 		barSeriesSettings.setVisible(preferenceStore.getBoolean(BarSeriesPreferenceConstants.P_VISIBLE_SERIES_1));
 		barSeriesSettings.setVisibleInLegend(preferenceStore.getBoolean(BarSeriesPreferenceConstants.P_VISIBLE_IN_LEGEND_SERIES_1));
 		barSeriesSettings.setBarColor(barColorSeries1);
 		barSeriesSettings.setBarPadding(preferenceStore.getInt(BarSeriesPreferenceConstants.P_BAR_PADDING_SERIES_1));
 		barSeriesSettings.setBarWidth(preferenceStore.getInt(BarSeriesPreferenceConstants.P_BAR_WIDTH_SERIES_1));
 		barSeriesSettings.setBarWidthStyle(BarWidthStyle.valueOf(preferenceStore.getString(BarSeriesPreferenceConstants.P_BAR_WIDTH_STYLE_SERIES_1)));
-		//
+
 		IBarSeriesSettings barSeriesSettingsHighlight = (IBarSeriesSettings)barSeriesSettings.getSeriesSettingsHighlight();
 		barSeriesSettingsHighlight.setVisible(preferenceStore.getBoolean(BarSeriesPreferenceConstants.P_VISIBLE_SERIES_1_HIGHLIGHT));
 		barSeriesSettingsHighlight.setVisibleInLegend(preferenceStore.getBoolean(BarSeriesPreferenceConstants.P_VISIBLE_IN_LEGEND_SERIES_1_HIGHLIGHT));
@@ -296,9 +296,9 @@ public class BarSeries_Preferences_Part extends Composite {
 		barSeriesSettingsHighlight.setBarPadding(preferenceStore.getInt(BarSeriesPreferenceConstants.P_BAR_PADDING_SERIES_1_HIGHLIGHT));
 		barSeriesSettingsHighlight.setBarWidth(preferenceStore.getInt(BarSeriesPreferenceConstants.P_BAR_WIDTH_SERIES_1_HIGHLIGHT));
 		barSeriesSettingsHighlight.setBarWidthStyle(BarWidthStyle.valueOf(preferenceStore.getString(BarSeriesPreferenceConstants.P_BAR_WIDTH_STYLE_SERIES_1_HIGHLIGHT)));
-		//
+
 		barSeriesDataList.add(barSeriesData);
-		//
+
 		barChart.addSeriesData(barSeriesDataList);
 	}
 

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/ComplexPieChart.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/ComplexPieChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -98,7 +98,7 @@ public class ComplexPieChart extends PieChart {
 	private static final String RETAIL_3 = "Retail 3";
 	private static final String RETAIL_4 = "Retail 4";
 	private static final String RETAIL_5 = "Retail 5";
-	//
+
 	private static final String[] labels1 = {WITHOUT_CLASSIFICATION, SECTOR_GICS};
 	private static final double[] values1 = {4446, 32214};
 	private static final String[] labels2 = {"Account"};
@@ -263,12 +263,12 @@ public class ComplexPieChart extends PieChart {
 		 * Create series.
 		 */
 		ICircularSeriesData multiLevelDoughnut = new CircularSeriesData();
-		//
+
 		multiLevelDoughnut.setTitle("DAX");
 		multiLevelDoughnut.setNodeClass("Taxonomie");
 		multiLevelDoughnut.setValueClass("Value (€)");
 		multiLevelDoughnut.setSeries(labels1, values1);
-		//
+
 		multiLevelDoughnut.getNodeById(WITHOUT_CLASSIFICATION).addChildren(labels2, values2);
 		multiLevelDoughnut.getNodeById(SECTOR_GICS).addChildren(labels3, values3);
 		multiLevelDoughnut.getNodeById(PUBLIC_UTILITY_2).addChildren(labels4, values4);
@@ -341,11 +341,11 @@ public class ComplexPieChart extends PieChart {
 		multiLevelDoughnut.getNodeById(BUILDING_MATERIALS_3).addChildren(labels71, values71);
 		multiLevelDoughnut.getNodeById(CHEMICALS_1).addChildren(labels72, values72);
 		multiLevelDoughnut.getNodeById(CHEMICALS_2).addChildren(labels73, values73);
-		//
+
 		ICircularSeriesSettings settings = multiLevelDoughnut.getSettings();
 		settings.setDescription("DAX Taxonomie");
 		settings.setBorderStyle(LineStyle.SOLID);
-		//
+
 		multiLevelDoughnut.getSettings().setSeriesType(SeriesType.DOUGHNUT);
 		/*
 		 * Set series.

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/HighlightedPieChart_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/HighlightedPieChart_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -55,17 +55,17 @@ public class HighlightedPieChart_Part extends HighlightedStaticPie {
 		 * Create series.
 		 */
 		ICircularSeriesData multiLevelDoughnut = new CircularSeriesData();
-		//
+
 		multiLevelDoughnut.setTitle("World");
 		multiLevelDoughnut.setNodeClass("Landmass Name");
 		multiLevelDoughnut.setValueClass("Area in sq miles");
-		//
+
 		multiLevelDoughnut.setSeries(continentLabels, continentValues);
 		// adding Asian countries. These go in as second level
 		multiLevelDoughnut.getNodeById("Asia").addChildren(AsianCountriesLabels, AsianCountriesValues);
-		//
+
 		multiLevelDoughnut.getNodeById("Africa").addChildren(AfricanCountriesLabels, AfricanCountriesValues);
-		//
+
 		multiLevelDoughnut.getNodeById("North America").addChildren(NorthAmericanCountriesLabels, NorthAmericanCountriesValues);
 		/*
 		 * Adding Indian states. These go as third level.
@@ -74,12 +74,12 @@ public class HighlightedPieChart_Part extends HighlightedStaticPie {
 		multiLevelDoughnut.getNodeById("India").addChildren(IndianStatesLabels, IndianStateValues);
 		// Another API
 		multiLevelDoughnut.getNodeById("Europe").addChild("Germany", 137847);
-		//
-		//
+
+
 		ICircularSeriesSettings settings = multiLevelDoughnut.getSettings();
 		settings.setDescription("Landmass Distribultion");
 		settings.setBorderStyle(LineStyle.SOLID);
-		//
+
 		multiLevelDoughnut.getSettings().setSeriesType(SeriesType.DOUGHNUT);
 		/*
 		 * Set series.

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeriesLinked_1_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeriesLinked_1_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -35,11 +35,11 @@ public class LineSeriesLinked_1_Part {
 	private void initialize(Composite parent) throws Exception {
 
 		parent.setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_WHITE));
-		//
+
 		Composite composite = new Composite(parent, SWT.NONE);
 		composite.setLayout(new GridLayout(1, false));
 		composite.setLayoutData(new GridData(GridData.FILL_BOTH));
-		//
+
 		CustomLinkedLineSeries1 customLinkedLineSeries1 = new CustomLinkedLineSeries1(composite, SWT.NONE);
 		customLinkedLineSeries1.setLayoutData(new GridData(GridData.FILL_BOTH));
 		customLinkedLineSeries1.setChartInfo("Signal Z", "Sample", "Reference");

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_10_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_10_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -40,7 +40,7 @@ public class LineSeries_10_Part extends ChromatogramChart {
 
 		super(parent, SWT.NONE);
 		setBackground(getDisplay().getSystemColor(SWT.COLOR_WHITE));
-		//
+
 		try {
 			initialize();
 		} catch(Exception e) {
@@ -60,7 +60,7 @@ public class LineSeries_10_Part extends ChromatogramChart {
 		 * Create series.
 		 */
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
-		//
+
 		ISeriesData seriesData;
 		ILineSeriesData lineSeriesData;
 		ILineSeriesSettings lineSeriesSettings;

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_1_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_1_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -40,7 +40,7 @@ public class LineSeries_1_Part extends ChromatogramChart {
 	public LineSeries_1_Part(Composite parent) {
 
 		super(parent, SWT.NONE);
-		//
+
 		try {
 			initialize();
 		} catch(Exception e) {
@@ -60,7 +60,7 @@ public class LineSeries_1_Part extends ChromatogramChart {
 		 * Create series.
 		 */
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<>();
-		//
+
 		ISeriesData seriesData;
 		ILineSeriesData lineSeriesData;
 		ILineSeriesSettings lineSeriesSettings;

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_1a_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_1a_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -34,7 +34,7 @@ public class LineSeries_1a_Part extends ChromatogramChart {
 	public LineSeries_1a_Part(Composite parent) {
 
 		super(parent, SWT.NONE);
-		//
+
 		try {
 			initialize();
 		} catch(Exception e) {
@@ -56,7 +56,7 @@ public class LineSeries_1a_Part extends ChromatogramChart {
 		 * Create series.
 		 */
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<>();
-		//
+
 		ISeriesData seriesData;
 		ILineSeriesData lineSeriesData;
 		ILineSeriesSettings lineSeriesSettings;

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_2_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_2_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -85,14 +85,14 @@ public class LineSeries_2_Part extends LineChart {
 		secondaryAxisSettingsX1.setDecimalFormat(new DecimalFormat(("0"), new DecimalFormatSymbols(Locale.ENGLISH)));
 		secondaryAxisSettingsX1.setColor(getDisplay().getSystemColor(SWT.COLOR_BLACK));
 		chartSettings.getSecondaryAxisSettingsListX().add(secondaryAxisSettingsX1);
-		//
+
 		applySettings(chartSettings);
 		/*
 		 * Create series.
 		 */
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
 		ISeriesData seriesData = SeriesConverter.getSeriesXY(SeriesConverter.LINE_SERIES_2);
-		//
+
 		ILineSeriesData lineSeriesData = new LineSeriesData(seriesData);
 		ILineSeriesSettings lineSeriesSettings = lineSeriesData.getSettings();
 		lineSeriesSettings.setEnableArea(false);

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_3_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_3_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -97,7 +97,7 @@ public class LineSeries_3_Part extends LineChart {
 		secondaryAxisSettingsX1.setColor(getDisplay().getSystemColor(SWT.COLOR_BLACK));
 		secondaryAxisSettingsX1.setExtraSpaceTitle(0);
 		chartSettings.getSecondaryAxisSettingsListX().add(secondaryAxisSettingsX1);
-		//
+
 		ISecondaryAxisSettings secondaryAxisSettingsX2 = new SecondaryAxisSettings("Time [min]", new MillisecondsToMinuteConverter());
 		secondaryAxisSettingsX2.setPosition(Position.Primary);
 		secondaryAxisSettingsX2.setDecimalFormat(new DecimalFormat(("0.00"), new DecimalFormatSymbols(Locale.ENGLISH)));
@@ -117,14 +117,14 @@ public class LineSeries_3_Part extends LineChart {
 		 */
 		chartSettings.addMenuEntry(new ZoomInHandler());
 		chartSettings.addMenuEntry(new ZoomOutHandler());
-		//
+
 		applySettings(chartSettings);
 		/*
 		 * Create series.
 		 */
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
 		ISeriesData seriesData = SeriesConverter.getSeriesXY(SeriesConverter.LINE_SERIES_3);
-		//
+
 		ILineSeriesData lineSeriesData = new LineSeriesData(seriesData);
 		ILineSeriesSettings lineSeriesSettings = lineSeriesData.getSettings();
 		lineSeriesSettings.setEnableArea(true);

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_4_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_4_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -63,7 +63,7 @@ public class LineSeries_4_Part extends ChromatogramChart {
 		colors.put(3, getDisplay().getSystemColor(SWT.COLOR_GRAY));
 		colors.put(4, getDisplay().getSystemColor(SWT.COLOR_DARK_RED));
 		colors.put(5, getDisplay().getSystemColor(SWT.COLOR_GRAY));
-		//
+
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
 		for(int i = 1; i <= 5; i++) {
 			ISeriesData seriesData = SeriesConverter.getSeriesXY(SeriesConverter.LINE_SERIES + "4_" + i);
@@ -75,7 +75,7 @@ public class LineSeries_4_Part extends ChromatogramChart {
 			lineSeriesSettingsHighlight.setLineWidth(2);
 			lineSeriesDataList.add(lineSeriesData);
 		}
-		//
+
 		addSeriesData(lineSeriesDataList, LineChart.MEDIUM_COMPRESSION);
 	}
 }

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_5_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_5_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -47,9 +47,9 @@ public class LineSeries_5_Part extends ChromatogramChart {
 		chartSettings.setCreateMenu(true);
 		chartSettings.getRangeRestriction().setZeroY(false);
 		applySettings(chartSettings);
-		//
+
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
-		//
+
 		ISeriesData seriesData;
 		ILineSeriesData lineSeriesData;
 		ILineSeriesSettings lineSeriesSettings;

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_6_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_6_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -78,14 +78,14 @@ public class LineSeries_6_Part extends LineChart {
 		primaryAxisSettingsY.setTitle("Intensity");
 		primaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.0#E0"), new DecimalFormatSymbols(Locale.ENGLISH)));
 		primaryAxisSettingsY.setColor(getDisplay().getSystemColor(SWT.COLOR_BLACK));
-		//
+
 		applySettings(chartSettings);
 		/*
 		 * Create series.
 		 */
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
 		ISeriesData seriesData = SeriesConverter.getSeriesXY(SeriesConverter.LINE_SERIES_6);
-		//
+
 		ILineSeriesData lineSeriesData = new LineSeriesData(seriesData);
 		ILineSeriesSettings lineSeriesSettings = lineSeriesData.getSettings();
 		lineSeriesSettings.setEnableArea(false);

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_7_HighBackground_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_7_HighBackground_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -47,9 +47,9 @@ public class LineSeries_7_HighBackground_Part extends ChromatogramChart {
 		IChartSettings chartSettings = getChartSettings();
 		chartSettings.getRangeRestriction().setForceZeroMinY(true);
 		applySettings(chartSettings);
-		//
+
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
-		//
+
 		ISeriesData seriesData;
 		ILineSeriesData lineSeriesData;
 		ILineSeriesSettings lineSeriesSettings;

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_7_Normal_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_7_Normal_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -47,9 +47,9 @@ public class LineSeries_7_Normal_Part extends ChromatogramChart {
 		IChartSettings chartSettings = getChartSettings();
 		chartSettings.getRangeRestriction().setForceZeroMinY(false);
 		applySettings(chartSettings);
-		//
+
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
-		//
+
 		ISeriesData seriesData;
 		ILineSeriesData lineSeriesData;
 		ILineSeriesSettings lineSeriesSettings;

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_8_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_8_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -40,7 +40,7 @@ public class LineSeries_8_Part extends ChromatogramChart {
 
 		super(parent, SWT.NONE);
 		setBackground(getDisplay().getSystemColor(SWT.COLOR_WHITE));
-		//
+
 		try {
 			initialize();
 		} catch(Exception e) {
@@ -60,7 +60,7 @@ public class LineSeries_8_Part extends ChromatogramChart {
 		 * Create series.
 		 */
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
-		//
+
 		ISeriesData seriesData;
 		ILineSeriesData lineSeriesData;
 		ILineSeriesSettings lineSeriesSettings;

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_9_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_9_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -40,7 +40,7 @@ public class LineSeries_9_Part extends ChromatogramChart {
 
 		super(parent, SWT.NONE);
 		setBackground(getDisplay().getSystemColor(SWT.COLOR_WHITE));
-		//
+
 		try {
 			initialize();
 		} catch(Exception e) {
@@ -60,7 +60,7 @@ public class LineSeries_9_Part extends ChromatogramChart {
 		 * Create series.
 		 */
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
-		//
+
 		ISeriesData seriesData;
 		ILineSeriesData lineSeriesData;
 		ILineSeriesSettings lineSeriesSettings;

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_Edit_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_Edit_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -63,7 +63,7 @@ public class LineSeries_Edit_Part extends Composite {
 	private Combo comboScaleX;
 	private Text textShiftY;
 	private Combo comboScaleY;
-	//
+
 	// private int shiftConstraintRangeSelection;
 	private int shiftConstraintDeleteX;
 	private int shiftConstraintDeleteY;
@@ -71,9 +71,9 @@ public class LineSeries_Edit_Part extends Composite {
 	// private int shiftConstraintStretchX;
 	// private int shiftConstraintBroadenX;
 	// private int shiftConstraintNarrowX;
-	//
+
 	private ChromatogramChart chromatogramChart;
-	//
+
 	private Map<Integer, Table> shiftTableMap;
 
 	@Inject
@@ -91,7 +91,7 @@ public class LineSeries_Edit_Part extends Composite {
 	private void initialize() throws Exception {
 
 		shiftTableMap = new HashMap<Integer, Table>();
-		//
+
 		this.setLayout(new GridLayout(1, true));
 		tabFolder = new TabFolder(this, SWT.BOTTOM);
 		tabFolder.setLayoutData(new GridData(GridData.FILL_BOTH));
@@ -142,10 +142,10 @@ public class LineSeries_Edit_Part extends Composite {
 		table.setHeaderVisible(true);
 		table.setLinesVisible(true);
 		table.setLayoutData(new GridData(GridData.FILL_BOTH));
-		//
+
 		String labelAxisX = chromatogramChart.getBaseChart().getXAxisSettings(BaseChart.ID_PRIMARY_X_AXIS).getLabel();
 		String labelAxisY = chromatogramChart.getBaseChart().getYAxisSettings(BaseChart.ID_PRIMARY_Y_AXIS).getLabel();
-		//
+
 		addTableColumn(table, "Start [" + labelAxisX + "]", 150);
 		addTableColumn(table, "Stop [" + labelAxisX + "]", 150);
 		addTableColumn(table, "Shift [" + labelAxisX + "]", 150);
@@ -153,7 +153,7 @@ public class LineSeries_Edit_Part extends Composite {
 		addTableColumn(table, "Stop [" + labelAxisY + "]", 150);
 		addTableColumn(table, "Shift [" + labelAxisY + "]", 150);
 		addTableColumn(table, "Shift Constraints", 150);
-		//
+
 		return table;
 	}
 
@@ -185,7 +185,7 @@ public class LineSeries_Edit_Part extends Composite {
 		gridDataComposite.horizontalAlignment = SWT.BEGINNING;
 		compositeButtons.setLayoutData(gridDataComposite);
 		compositeButtons.setLayout(new GridLayout(18, false));
-		//
+
 		createLabel(compositeButtons);
 		createCombo(compositeButtons);
 		createTextShiftX(compositeButtons);
@@ -204,7 +204,7 @@ public class LineSeries_Edit_Part extends Composite {
 		// createButtonConstraintBroadenX(compositeButtons);
 		// createButtonConstraintNarrowX(compositeButtons);
 		createButtonReset(compositeButtons);
-		//
+
 		createChart(parent);
 	}
 
@@ -334,15 +334,15 @@ public class LineSeries_Edit_Part extends Composite {
 	}
 
 	// private void createButtonConstraintRangeSelection(Composite parent) {
-	//
+
 	// Button button = new Button(parent, SWT.CHECK);
 	// button.setText("Range Selection");
 	// button.setSelection(false);
 	// button.addSelectionListener(new SelectionAdapter() {
-	//
+
 	// @Override
 	// public void widgetSelected(SelectionEvent e) {
-	//
+
 	// if(button.getSelection()) {
 	// shiftConstraintRangeSelection = BaseChart.SHIFT_CONSTRAINT_RANGE_SELECTION;
 	// } else {
@@ -393,15 +393,15 @@ public class LineSeries_Edit_Part extends Composite {
 	}
 
 	// private void createButtonConstraintClinchX(Composite parent) {
-	//
+
 	// Button button = new Button(parent, SWT.CHECK);
 	// button.setText("Clinch X");
 	// button.setSelection(false);
 	// button.addSelectionListener(new SelectionAdapter() {
-	//
+
 	// @Override
 	// public void widgetSelected(SelectionEvent e) {
-	//
+
 	// if(button.getSelection()) {
 	// shiftConstraintClinchX = BaseChart.SHIFT_CONSTRAINT_CLINCH_X;
 	// } else {
@@ -412,15 +412,15 @@ public class LineSeries_Edit_Part extends Composite {
 	// });
 	// }
 	// private void createButtonConstraintStrechX(Composite parent) {
-	//
+
 	// Button button = new Button(parent, SWT.CHECK);
 	// button.setText("Stretch X");
 	// button.setSelection(false);
 	// button.addSelectionListener(new SelectionAdapter() {
-	//
+
 	// @Override
 	// public void widgetSelected(SelectionEvent e) {
-	//
+
 	// if(button.getSelection()) {
 	// shiftConstraintStretchX = BaseChart.SHIFT_CONSTRAINT_STRETCH_X;
 	// } else {
@@ -430,17 +430,17 @@ public class LineSeries_Edit_Part extends Composite {
 	// }
 	// });
 	// }
-	//
+
 	// private void createButtonConstraintBroadenX(Composite parent) {
-	//
+
 	// Button button = new Button(parent, SWT.CHECK);
 	// button.setText("Broaden X");
 	// button.setSelection(false);
 	// button.addSelectionListener(new SelectionAdapter() {
-	//
+
 	// @Override
 	// public void widgetSelected(SelectionEvent e) {
-	//
+
 	// if(button.getSelection()) {
 	// shiftConstraintBroadenX = BaseChart.SHIFT_CONSTRAINT_BROADEN_X;
 	// } else {
@@ -450,17 +450,17 @@ public class LineSeries_Edit_Part extends Composite {
 	// }
 	// });
 	// }
-	//
+
 	// private void createButtonConstraintNarrowX(Composite parent) {
-	//
+
 	// Button button = new Button(parent, SWT.CHECK);
 	// button.setText("Narrow X");
 	// button.setSelection(false);
 	// button.addSelectionListener(new SelectionAdapter() {
-	//
+
 	// @Override
 	// public void widgetSelected(SelectionEvent e) {
-	//
+
 	// if(button.getSelection()) {
 	// shiftConstraintNarrowX = BaseChart.SHIFT_CONSTRAINT_NARROW_X;
 	// } else {
@@ -490,29 +490,29 @@ public class LineSeries_Edit_Part extends Composite {
 
 		chromatogramChart = new ChromatogramChart(parent, SWT.BORDER);
 		chromatogramChart.setLayoutData(new GridData(GridData.FILL_BOTH));
-		//
+
 		IChartSettings chartSettings = chromatogramChart.getChartSettings();
 		chartSettings.setCreateMenu(true);
 		chartSettings.setSupportDataShift(true);
 		chromatogramChart.applySettings(chartSettings);
-		//
+
 		loadChromatogramData();
 	}
 
 	private void loadChromatogramData() {
 
 		chromatogramChart.deleteSeries();
-		//
+
 		Map<Integer, Color> colors = new HashMap<Integer, Color>();
 		colors.put(1, getDisplay().getSystemColor(SWT.COLOR_RED));
 		colors.put(2, getDisplay().getSystemColor(SWT.COLOR_BLACK));
 		colors.put(3, getDisplay().getSystemColor(SWT.COLOR_GRAY));
 		colors.put(4, getDisplay().getSystemColor(SWT.COLOR_DARK_RED));
 		colors.put(5, getDisplay().getSystemColor(SWT.COLOR_GRAY));
-		//
+
 		String[] items = new String[6];
 		items[0] = "No Selection";
-		//
+
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
 		for(int i = 1; i <= NUM_SERIES; i++) {
 			ISeriesData seriesData = SeriesConverter.getSeriesXY(SeriesConverter.LINE_SERIES + "4_" + i);
@@ -525,12 +525,12 @@ public class LineSeries_Edit_Part extends Composite {
 			lineSeriesSettingsHighlight.setLineWidth(2);
 			lineSeriesDataList.add(lineSeriesData);
 		}
-		//
+
 		chromatogramChart.addSeriesData(lineSeriesDataList, LineChart.MEDIUM_COMPRESSION);
 		comboSelectSeries.setItems(items);
 		comboSelectSeries.select(1); // LineSeries4_1
 		selectSeries();
-		//
+
 		setComboAxisItems();
 	}
 
@@ -587,7 +587,7 @@ public class LineSeries_Edit_Part extends Composite {
 			BaseChart baseChart = chromatogramChart.getBaseChart();
 			DecimalFormat decimalFormat;
 			int selectedAxis;
-			//
+
 			if(axis.equals(IExtendedChart.X_AXIS)) {
 				selectedAxis = comboScaleX.getSelectionIndex();
 				decimalFormat = baseChart.getDecimalFormat(IExtendedChart.X_AXIS, selectedAxis);
@@ -595,7 +595,7 @@ public class LineSeries_Edit_Part extends Composite {
 				selectedAxis = comboScaleY.getSelectionIndex();
 				decimalFormat = baseChart.getDecimalFormat(IExtendedChart.Y_AXIS, selectedAxis);
 			}
-			//
+
 			double secondaryValue;
 			if(axis.equals(IExtendedChart.X_AXIS)) {
 				secondaryValue = decimalFormat.parse(textShiftX.getText().trim()).doubleValue();
@@ -614,7 +614,7 @@ public class LineSeries_Edit_Part extends Composite {
 		} catch(ParseException e) {
 			e.printStackTrace();
 		}
-		//
+
 		return shiftValue;
 	}
 

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_Preferences_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_Preferences_Part.java
@@ -98,7 +98,7 @@ public class LineSeries_Preferences_Part extends Composite {
 		gridDataComposite.horizontalAlignment = SWT.END;
 		compositeButtons.setLayoutData(gridDataComposite);
 		compositeButtons.setLayout(new GridLayout(1, false));
-		//
+
 		Button buttonOpenSettings = new Button(compositeButtons, SWT.PUSH);
 		modifySettingsButton(buttonOpenSettings);
 		buttonOpenSettings.addSelectionListener(new SelectionAdapter() {
@@ -114,13 +114,13 @@ public class LineSeries_Preferences_Part extends Composite {
 				preferenceSecondaryAxesPage.setTitle("Secondary Axes");
 				IPreferencePage preferenceDataPage = new LineSeriesDataPreferencePage();
 				preferenceDataPage.setTitle("Series Data");
-				//
+
 				PreferenceManager preferenceManager = new PreferenceManager();
 				preferenceManager.addToRoot(new PreferenceNode("1", preferencePage));
 				preferenceManager.addToRoot(new PreferenceNode("2", preferencePrimaryAxesPage));
 				preferenceManager.addToRoot(new PreferenceNode("3", preferenceSecondaryAxesPage));
 				preferenceManager.addToRoot(new PreferenceNode("4", preferenceDataPage));
-				//
+
 				PreferenceDialog preferenceDialog = new PreferenceDialog(e.display.getActiveShell(), preferenceManager);
 				preferenceDialog.create();
 				preferenceDialog.setMessage("Settings");
@@ -134,10 +134,10 @@ public class LineSeries_Preferences_Part extends Composite {
 				}
 			}
 		});
-		//
+
 		lineChart = new LineChart(this, SWT.NONE);
 		lineChart.setLayoutData(new GridData(GridData.FILL_BOTH));
-		//
+
 		applyChartSettings();
 		applySeriesSettings();
 	}
@@ -153,7 +153,7 @@ public class LineSeries_Preferences_Part extends Composite {
 
 		IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
 		setBackground(getDisplay().getSystemColor(SWT.COLOR_WHITE));
-		//
+
 		Color colorHintRangeSelector = getColor(PreferenceConverter.getColor(preferenceStore, LineSeriesPreferenceConstants.P_COLOR_HINT_RANGE_SELECTOR));
 		Color colorTitle = getColor(PreferenceConverter.getColor(preferenceStore, LineSeriesPreferenceConstants.P_TITLE_COLOR));
 		Color colorBackground = getColor(PreferenceConverter.getColor(preferenceStore, LineSeriesPreferenceConstants.P_BACKGROUND));
@@ -172,7 +172,7 @@ public class LineSeries_Preferences_Part extends Composite {
 		Color colorLegendMarker = getColor(PreferenceConverter.getColor(preferenceStore, LineSeriesPreferenceConstants.P_COLOR_LEGEND_MARKER));
 		Color colorAxisZeroMarker = getColor(PreferenceConverter.getColor(preferenceStore, LineSeriesPreferenceConstants.P_COLOR_AXIS_ZERO_MARKER));
 		Color colorSeriesLabelMarker = getColor(PreferenceConverter.getColor(preferenceStore, LineSeriesPreferenceConstants.P_COLOR_SERIES_LABEL_MARKER));
-		//
+
 		IChartSettings chartSettings = lineChart.getChartSettings();
 		chartSettings.setEnableRangeSelector(preferenceStore.getBoolean(LineSeriesPreferenceConstants.P_ENABLE_RANGE_SELECTOR));
 		chartSettings.setShowRangeSelectorInitially(preferenceStore.getBoolean(LineSeriesPreferenceConstants.P_SHOW_RANGE_SELECTOR_INITIALLY));
@@ -204,7 +204,7 @@ public class LineSeries_Preferences_Part extends Composite {
 		rangeRestriction.setExtendTypeY(RangeRestriction.ExtendType.valueOf(preferenceStore.getString(LineSeriesPreferenceConstants.P_EXTEND_TYPE_Y)));
 		rangeRestriction.setExtendMinY(preferenceStore.getDouble(LineSeriesPreferenceConstants.P_EXTEND_MIN_Y));
 		rangeRestriction.setExtendMaxY(preferenceStore.getDouble(LineSeriesPreferenceConstants.P_EXTEND_MAX_Y));
-		//
+
 		chartSettings.setShowPositionMarker(preferenceStore.getBoolean(LineSeriesPreferenceConstants.P_SHOW_POSITION_MARKER));
 		chartSettings.setColorPositionMarker(colorPositionMarker);
 		chartSettings.setShowPlotCenterMarker(preferenceStore.getBoolean(LineSeriesPreferenceConstants.P_SHOW_PLOT_CENTER_MARKER));
@@ -215,7 +215,7 @@ public class LineSeries_Preferences_Part extends Composite {
 		chartSettings.setColorLegendMarker(colorAxisZeroMarker);
 		chartSettings.setShowSeriesLabelMarker(preferenceStore.getBoolean(LineSeriesPreferenceConstants.P_SHOW_SERIES_LABEL_MARKER));
 		chartSettings.setColorSeriesLabelMarker(colorSeriesLabelMarker);
-		//
+
 		chartSettings.setCreateMenu(preferenceStore.getBoolean(LineSeriesPreferenceConstants.P_CREATE_MENU));
 		/*
 		 * Primary X-Axis
@@ -275,7 +275,7 @@ public class LineSeries_Preferences_Part extends Composite {
 		secondaryAxisSettingsY.setLogScaleBase(preferenceStore.getDouble(LineSeriesPreferenceConstants.P_SECONDARY_Y_AXIS_LOG_SCALE_BASE));
 		secondaryAxisSettingsY.setExtraSpaceTitle(preferenceStore.getInt(LineSeriesPreferenceConstants.P_SECONDARY_Y_AXIS_EXTRA_SPACE_TITLE));
 		chartSettings.getSecondaryAxisSettingsListY().add(secondaryAxisSettingsY);
-		//
+
 		lineChart.applySettings(chartSettings);
 	}
 
@@ -290,7 +290,7 @@ public class LineSeries_Preferences_Part extends Composite {
 		Color symbolColorSeries1Highlight = getColor(PreferenceConverter.getColor(preferenceStore, LineSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_1_HIGHLIGHT));
 		Color lineColorSeries2Highlight = getColor(PreferenceConverter.getColor(preferenceStore, LineSeriesPreferenceConstants.P_LINE_COLOR_SERIES_2_HIGHLIGHT));
 		Color symbolColorSeries2Highlight = getColor(PreferenceConverter.getColor(preferenceStore, LineSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_2_HIGHLIGHT));
-		//
+
 		lineChart.deleteSeries();
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
 		ISeriesData seriesData;
@@ -363,7 +363,7 @@ public class LineSeries_Preferences_Part extends Composite {
 		lineSeriesSettingsHighlight.setVisible(preferenceStore.getBoolean(LineSeriesPreferenceConstants.P_VISIBLE_SERIES_2_HIGHLIGHT));
 		lineSeriesSettingsHighlight.setVisibleInLegend(preferenceStore.getBoolean(LineSeriesPreferenceConstants.P_VISIBLE_IN_LEGEND_SERIES_2_HIGHLIGHT));
 		lineSeriesDataList.add(lineSeriesData);
-		//
+
 		lineChart.addSeriesData(lineSeriesDataList, LineChart.HIGH_COMPRESSION);
 	}
 

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_Random_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_Random_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -38,12 +38,12 @@ public class LineSeries_Random_Part extends Composite {
 	private static final String ID = "LINE_SERIES_RANDOM";
 	private static int x = 0;
 	private static int xDelta = 10;
-	//
+
 	private Button buttonStart;
 	private Button buttonStop;
 	private Button buttonReset;
 	private ChromatogramChart chromatogramChart;
-	//
+
 	private Display display = getDisplay();
 	private Acquisition acquisition;
 	private Recording recording;
@@ -100,7 +100,7 @@ public class LineSeries_Random_Part extends Composite {
 		gridDataComposite.horizontalAlignment = SWT.END;
 		compositeButtons.setLayoutData(gridDataComposite);
 		compositeButtons.setLayout(new GridLayout(3, false));
-		//
+
 		buttonStart = new Button(compositeButtons, SWT.PUSH);
 		buttonStart.setToolTipText("Start Recording");
 		buttonStart.setText(Activator.getDefault() != null ? "" : "Start");
@@ -113,11 +113,11 @@ public class LineSeries_Random_Part extends Composite {
 
 				acquisition.setRecordData(true);
 				display.asyncExec(recording);
-				//
+
 				setButtonsEnabled(true);
 			}
 		});
-		//
+
 		buttonStop = new Button(compositeButtons, SWT.PUSH);
 		buttonStop.setToolTipText("Stop Recording");
 		buttonStop.setText(Activator.getDefault() != null ? "" : "Stop");
@@ -130,11 +130,11 @@ public class LineSeries_Random_Part extends Composite {
 
 				acquisition.setRecordData(false);
 				display.timerExec(-1, recording);
-				//
+
 				setButtonsEnabled(false);
 			}
 		});
-		//
+
 		buttonReset = new Button(compositeButtons, SWT.PUSH);
 		buttonReset.setToolTipText("Reset");
 		buttonReset.setText(Activator.getDefault() != null ? "" : "Reset");
@@ -147,10 +147,10 @@ public class LineSeries_Random_Part extends Composite {
 
 				acquisition.setRecordData(false);
 				display.timerExec(-1, recording);
-				//
+
 				chromatogramChart.deleteSeries();
 				x = 0;
-				//
+
 				List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
 				ISeriesData seriesData = getRandomSeriesData();
 				ILineSeriesData lineSeriesData = new LineSeriesData(seriesData);
@@ -168,7 +168,7 @@ public class LineSeries_Random_Part extends Composite {
 		 */
 		chromatogramChart = new ChromatogramChart(this, SWT.BORDER);
 		chromatogramChart.setLayoutData(new GridData(GridData.FILL_BOTH));
-		//
+
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
 		ISeriesData seriesData = getRandomSeriesData();
 		ILineSeriesData lineSeriesData = new LineSeriesData(seriesData);
@@ -193,11 +193,11 @@ public class LineSeries_Random_Part extends Composite {
 		int length = 101;
 		double[] xSeries = new double[length];
 		double[] ySeries = new double[length];
-		//
+
 		double a = Math.random(); // height
 		double i = -5.0d;
 		double iDelta = 0.1d;
-		//
+
 		for(int j = 0; j < length; j++) {
 			xSeries[j] = x;
 			ySeries[j] = a * Math.exp(-i * i / 2) / Math.sqrt(2 * Math.PI);

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_Selection_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_Selection_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -63,7 +63,7 @@ public class LineSeries_Selection_Part extends Composite {
 	private Text textRangeYStop;
 	private Text textX;
 	private Text textY;
-	//
+
 	private static final String DATA_POINT_SERIES = "DATA_POINT_SERIES";
 	private NavigableSet<Double> xValues;
 	private HashMap<Double, Double> yValues;
@@ -91,13 +91,13 @@ public class LineSeries_Selection_Part extends Composite {
 
 		this.setLayout(new GridLayout(1, true));
 		this.setBackground(getDisplay().getSystemColor(SWT.COLOR_WHITE));
-		//
+
 		Composite compositeInfo = new Composite(this, SWT.NONE);
 		GridData gridDataComposite = new GridData(GridData.FILL_HORIZONTAL);
 		gridDataComposite.horizontalAlignment = SWT.BEGINNING;
 		compositeInfo.setLayoutData(gridDataComposite);
 		compositeInfo.setLayout(new GridLayout(13, false));
-		//
+
 		createLabel(compositeInfo, "X-Start:");
 		textRangeXStart = createText(compositeInfo);
 		createLabel(compositeInfo, "X-Stop:");
@@ -111,7 +111,7 @@ public class LineSeries_Selection_Part extends Composite {
 		createLabel(compositeInfo, "Y:");
 		textY = createText(compositeInfo);
 		createButtonReset(compositeInfo);
-		//
+
 		lineChart = new LineChart(this, SWT.NONE);
 		lineChart.setLayoutData(new GridData(GridData.FILL_BOTH));
 		lineChart.getBaseChart().addCustomRangeSelectionHandler(new ICustomSelectionHandler() {
@@ -138,12 +138,12 @@ public class LineSeries_Selection_Part extends Composite {
 				BaseChart baseChart = lineChart.getBaseChart();
 				double x = baseChart.getSelectedPrimaryAxisValue(event.x, IExtendedChart.X_AXIS);
 				double y = baseChart.getSelectedPrimaryAxisValue(event.y, IExtendedChart.Y_AXIS);
-				//
+
 				DecimalFormat decimalFormatX = baseChart.getDecimalFormat(IExtendedChart.X_AXIS, BaseChart.ID_PRIMARY_X_AXIS);
 				DecimalFormat decimalFormatY = baseChart.getDecimalFormat(IExtendedChart.Y_AXIS, BaseChart.ID_PRIMARY_Y_AXIS);
 				textX.setText(decimalFormatX.format(x));
 				textY.setText(decimalFormatY.format(y));
-				//
+
 				try {
 					ISeries<?> series = baseChart.getSeriesSet().getSeries(DATA_POINT_SERIES);
 					double xSelected = xValues.floor(x);
@@ -154,7 +154,7 @@ public class LineSeries_Selection_Part extends Composite {
 					series.setYSeries(ySeries);
 					baseChart.redraw();
 				} catch(Exception e) {
-					//
+
 				}
 			}
 		});
@@ -230,7 +230,7 @@ public class LineSeries_Selection_Part extends Composite {
 		secondaryAxisSettingsY1.setDecimalFormat(new DecimalFormat(("0.00"), new DecimalFormatSymbols(Locale.ENGLISH)));
 		secondaryAxisSettingsY1.setColor(getDisplay().getSystemColor(SWT.COLOR_BLACK));
 		chartSettings.getSecondaryAxisSettingsListY().add(secondaryAxisSettingsY1);
-		//
+
 		lineChart.applySettings(chartSettings);
 		/*
 		 * Create series.
@@ -251,7 +251,7 @@ public class LineSeries_Selection_Part extends Composite {
 		 */
 		ILineSeriesData lineSeriesData;
 		ILineSeriesSettings lineSeriesSettings;
-		//
+
 		lineSeriesData = new LineSeriesData(seriesDataLine);
 		lineSeriesSettings = lineSeriesData.getSettings();
 		lineSeriesSettings.setEnableArea(true);

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/MeasurementSeries_1_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/MeasurementSeries_1_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -75,7 +75,7 @@ public class MeasurementSeries_1_Part extends LineChart {
 		primaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.00"), new DecimalFormatSymbols(Locale.ENGLISH)));
 		primaryAxisSettingsY.setColor(getDisplay().getSystemColor(SWT.COLOR_BLACK));
 		primaryAxisSettingsY.setGridLineStyle(LineStyle.DOT);
-		//
+
 		applySettings(chartSettings);
 		/*
 		 * Create series.

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/MeasurementSeries_2_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/MeasurementSeries_2_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -78,7 +78,7 @@ public class MeasurementSeries_2_Part extends LineChart {
 		primaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.00"), new DecimalFormatSymbols(Locale.ENGLISH)));
 		primaryAxisSettingsY.setColor(getDisplay().getSystemColor(SWT.COLOR_BLACK));
 		primaryAxisSettingsY.setGridLineStyle(LineStyle.DOT);
-		//
+
 		applySettings(chartSettings);
 		/*
 		 * Create series.
@@ -87,13 +87,13 @@ public class MeasurementSeries_2_Part extends LineChart {
 		colors.put(1, getDisplay().getSystemColor(SWT.COLOR_BLACK));
 		colors.put(2, getDisplay().getSystemColor(SWT.COLOR_RED));
 		colors.put(3, getDisplay().getSystemColor(SWT.COLOR_GRAY));
-		//
+
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
 		ISeriesData seriesData;
 		ILineSeriesData lineSeriesData;
 		ILineSeriesSettings lineSeriesSettings;
 		ILineSeriesSettings lineSeriesSettingsHighlight;
-		//
+
 		for(int i = 1; i <= 3; i++) {
 			/*
 			 * Readings

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/MeasurementSeries_3_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/MeasurementSeries_3_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -75,7 +75,7 @@ public class MeasurementSeries_3_Part extends LineChart {
 		primaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.00"), new DecimalFormatSymbols(Locale.ENGLISH)));
 		primaryAxisSettingsY.setColor(getDisplay().getSystemColor(SWT.COLOR_BLACK));
 		primaryAxisSettingsY.setGridLineStyle(LineStyle.DOT);
-		//
+
 		applySettings(chartSettings);
 		/*
 		 * Create series.

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/MultiplePieChart.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/MultiplePieChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,7 +33,7 @@ public class MultiplePieChart {
 		shell.setText("PieChart");
 		shell.setSize(700, 600);
 		shell.setLayout(new FillLayout());
-		//
+
 		// just change SeriesType to SeriesType.DOUGHNUT
 		ParallelPieCharts charts = new ParallelPieCharts(shell, SeriesType.PIE, true);
 		charts.addPieChartSeries(labels, val);
@@ -41,7 +41,7 @@ public class MultiplePieChart {
 		charts.setChartTitles(titles);
 		charts.setRedrawOnClick(true);
 		shell.open();
-		//
+
 		while(!shell.isDisposed()) {
 			if(!display.readAndDispatch()) {
 				display.sleep();

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/MyChart_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/MyChart_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 Lablicate GmbH.
+ * Copyright (c) 2019, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -57,15 +57,15 @@ public class MyChart_Part extends BarChart {
 		chartSettings.setVerticalSliderVisible(true);
 		RangeRestriction rangeRestriction = chartSettings.getRangeRestriction();
 		rangeRestriction.setRestrictFrame(false);
-		//
+
 		IPrimaryAxisSettings primaryAxisSettingsX = chartSettings.getPrimaryAxisSettingsX();
 		primaryAxisSettingsX.setTitle("X Axis (Primary)");
 		primaryAxisSettingsX.setDecimalFormat(new DecimalFormat(("0.0"), new DecimalFormatSymbols(Locale.ENGLISH)));
-		//
+
 		IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
 		primaryAxisSettingsY.setTitle("Y Axis (Primary)");
 		primaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.0"), new DecimalFormatSymbols(Locale.ENGLISH)));
-		//
+
 		applySettings(chartSettings);
 		/*
 		 * Bar Series

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/PeakSeries_1_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/PeakSeries_1_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 Lablicate GmbH.
+ * Copyright (c) 2022, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -35,7 +35,7 @@ public class PeakSeries_1_Part extends ChromatogramChart {
 
 		super(parent, SWT.NONE);
 		setBackground(getDisplay().getSystemColor(SWT.COLOR_WHITE));
-		//
+
 		try {
 			initialize();
 		} catch(Exception e) {

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/ScatterSeries_1_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/ScatterSeries_1_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -36,7 +36,7 @@ public class ScatterSeries_1_Part extends PCAChart {
 	private Color COLOR_MAGENTA = getDisplay().getSystemColor(SWT.COLOR_MAGENTA);
 	private Color COLOR_CYAN = getDisplay().getSystemColor(SWT.COLOR_CYAN);
 	private Color COLOR_GRAY = getDisplay().getSystemColor(SWT.COLOR_GRAY);
-	//
+
 	private int SYMBOL_SIZE = 8;
 
 	@Inject
@@ -60,7 +60,7 @@ public class ScatterSeries_1_Part extends PCAChart {
 		 */
 		List<ISeriesData> scatterSeriesList = SeriesConverter.getSeriesScatter(SeriesConverter.SCATTER_SERIES_1);
 		List<IScatterSeriesData> scatterSeriesDataList = new ArrayList<IScatterSeriesData>();
-		//
+
 		for(ISeriesData seriesData : scatterSeriesList) {
 			IScatterSeriesData scatterSeriesData = new ScatterSeriesData(seriesData);
 			IScatterSeriesSettings scatterSeriesSettings = scatterSeriesData.getSettings();
@@ -81,7 +81,7 @@ public class ScatterSeries_1_Part extends PCAChart {
 	private void applySettings(IScatterSeriesSettings scatterSeriesSettings, double x, double y, int symbolSize) {
 
 		scatterSeriesSettings.setSymbolSize(SYMBOL_SIZE);
-		//
+
 		if(x > 0 && y > 0) {
 			scatterSeriesSettings.setSymbolColor(COLOR_RED);
 			scatterSeriesSettings.setSymbolType(PlotSymbolType.SQUARE);
@@ -95,7 +95,7 @@ public class ScatterSeries_1_Part extends PCAChart {
 			scatterSeriesSettings.setSymbolColor(COLOR_CYAN);
 			scatterSeriesSettings.setSymbolType(PlotSymbolType.INVERTED_TRIANGLE);
 		}
-		//
+
 		IScatterSeriesSettings scatterSeriesSettingsHighlight = (IScatterSeriesSettings)scatterSeriesSettings.getSeriesSettingsHighlight();
 		scatterSeriesSettingsHighlight.setSymbolColor(COLOR_GRAY);
 		scatterSeriesSettingsHighlight.setSymbolType(PlotSymbolType.CIRCLE);

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/ScatterSeries_2_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/ScatterSeries_2_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -58,17 +58,17 @@ public class ScatterSeries_2_Part extends ScatterChart {
 		 */
 		IChartSettings chartSettings = getChartSettings();
 		chartSettings.setCreateMenu(true);
-		//
+
 		IPrimaryAxisSettings primaryAxisSettingsX = chartSettings.getPrimaryAxisSettingsX();
 		primaryAxisSettingsX.setTitle("1st Dimension");
 		primaryAxisSettingsX.setDecimalFormat(new DecimalFormat(("0"), new DecimalFormatSymbols(Locale.ENGLISH)));
 		primaryAxisSettingsX.setColor(getDisplay().getSystemColor(SWT.COLOR_BLACK));
-		//
+
 		IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
 		primaryAxisSettingsY.setTitle("2nd Dimension");
 		primaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.000"), new DecimalFormatSymbols(Locale.ENGLISH)));
 		primaryAxisSettingsY.setColor(getDisplay().getSystemColor(SWT.COLOR_BLACK));
-		//
+
 		applySettings(chartSettings);
 		/*
 		 * Create series.
@@ -83,7 +83,7 @@ public class ScatterSeries_2_Part extends ScatterChart {
 		colors.put(7, getDisplay().getSystemColor(SWT.COLOR_GREEN));
 		colors.put(8, getDisplay().getSystemColor(SWT.COLOR_DARK_YELLOW));
 		colors.put(9, getDisplay().getSystemColor(SWT.COLOR_DARK_BLUE));
-		//
+
 		Map<Integer, String> descriptions = new HashMap<Integer, String>();
 		descriptions.put(1, "Benzothiophene");
 		descriptions.put(2, "Cyclische Alkane");
@@ -94,7 +94,7 @@ public class ScatterSeries_2_Part extends ScatterChart {
 		descriptions.put(7, "Polyaromaten");
 		descriptions.put(8, "Triaromaten");
 		descriptions.put(9, "Unknown");
-		//
+
 		List<IScatterSeriesData> scatterSeriesDataList = new ArrayList<IScatterSeriesData>();
 		for(int i = 1; i <= 9; i++) {
 			String id = descriptions.get(i);

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/ScatterSeries_3_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/ScatterSeries_3_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -65,17 +65,17 @@ public class ScatterSeries_3_Part extends ScatterChart {
 		rangeRestriction.setExtendMaxY(0.1d);
 		rangeRestriction.setRestrictFrame(false);
 		chartSettings.setCreateMenu(true);
-		//
+
 		IPrimaryAxisSettings primaryAxisSettingsX = chartSettings.getPrimaryAxisSettingsX();
 		primaryAxisSettingsX.setTitle("1st Dimension");
 		primaryAxisSettingsX.setDecimalFormat(new DecimalFormat(("0"), new DecimalFormatSymbols(Locale.ENGLISH)));
 		primaryAxisSettingsX.setColor(getDisplay().getSystemColor(SWT.COLOR_BLACK));
-		//
+
 		IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
 		primaryAxisSettingsY.setTitle("2nd Dimension");
 		primaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.000"), new DecimalFormatSymbols(Locale.ENGLISH)));
 		primaryAxisSettingsY.setColor(getDisplay().getSystemColor(SWT.COLOR_BLACK));
-		//
+
 		applySettings(chartSettings);
 		/*
 		 * Create series.
@@ -92,7 +92,7 @@ public class ScatterSeries_3_Part extends ScatterChart {
 		colors.put(9, getDisplay().getSystemColor(SWT.COLOR_DARK_CYAN));
 		colors.put(10, getDisplay().getSystemColor(SWT.COLOR_DARK_GREEN));
 		colors.put(11, getDisplay().getSystemColor(SWT.COLOR_DARK_RED));
-		//
+
 		List<IScatterSeriesData> scatterSeriesDataList = new ArrayList<IScatterSeriesData>();
 		for(int i = 1; i <= 5; i++) {
 			for(int j = 1; j <= 20; j++) {

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/ScatterSeries_Edit_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/ScatterSeries_Edit_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -51,13 +51,13 @@ public class ScatterSeries_Edit_Part extends Composite {
 	private Color COLOR_MAGENTA = getDisplay().getSystemColor(SWT.COLOR_MAGENTA);
 	private Color COLOR_CYAN = getDisplay().getSystemColor(SWT.COLOR_CYAN);
 	private Color COLOR_GRAY = getDisplay().getSystemColor(SWT.COLOR_GRAY);
-	//
+
 	private int SYMBOL_SIZE = 8;
-	//
+
 	private static final int KEY_CODE_R = 114;
 	private static final int KEY_CODE_S = 115;
 	private boolean isCustomSelection = false;
-	//
+
 	private TabFolder tabFolder;
 	private Table table;
 	private HandledChart handledChart;
@@ -75,7 +75,7 @@ public class ScatterSeries_Edit_Part extends Composite {
 
 			super.handleKeyUpEvent(event);
 			isCustomSelection = false;
-			//
+
 			if(event.keyCode == KEY_CODE_R) {
 				/*
 				 * Reset Selection
@@ -88,7 +88,7 @@ public class ScatterSeries_Edit_Part extends Composite {
 				 */
 				isCustomSelection = true;
 			}
-			//
+
 			enableButtons();
 		}
 
@@ -96,7 +96,7 @@ public class ScatterSeries_Edit_Part extends Composite {
 		public void handleMouseUpEvent(Event event) {
 
 			super.handleMouseUpEvent(event);
-			//
+
 			if(isCustomSelection) {
 				/*
 				 * Set Selection
@@ -104,13 +104,13 @@ public class ScatterSeries_Edit_Part extends Composite {
 				BaseChart baseChart = getBaseChart();
 				Point plotAreaBounds = baseChart.getPlotArea().getSize();
 				ISeries<?>[] series = baseChart.getSeriesSet().getSeries();
-				//
+
 				for(ISeries<?> scatterSeries : series) {
 					if(scatterSeries != null) {
-						//
+
 						int size = scatterSeries.getXSeries().length;
 						String id = scatterSeries.getId();
-						//
+
 						for(int i = 0; i < size; i++) {
 							Point point = scatterSeries.getPixelCoordinates(i);
 							if(isPointVisible(point, plotAreaBounds)) {
@@ -119,11 +119,11 @@ public class ScatterSeries_Edit_Part extends Composite {
 						}
 					}
 				}
-				//
+
 				baseChart.redraw();
 				isCustomSelection = false;
 			}
-			//
+
 			enableButtons();
 		}
 	}
@@ -192,9 +192,9 @@ public class ScatterSeries_Edit_Part extends Composite {
 		table.setHeaderVisible(true);
 		table.setLinesVisible(true);
 		table.setLayoutData(new GridData(GridData.FILL_BOTH));
-		//
+
 		addTableColumn(table, "Selected Series", 500);
-		//
+
 		return table;
 	}
 
@@ -224,10 +224,10 @@ public class ScatterSeries_Edit_Part extends Composite {
 		gridDataComposite.horizontalAlignment = SWT.END;
 		compositeButtons.setLayoutData(gridDataComposite);
 		compositeButtons.setLayout(new GridLayout(2, false));
-		//
+
 		createButtonEnableSelection(compositeButtons);
 		createButtonReset(compositeButtons);
-		//
+
 		createChart(parent);
 	}
 
@@ -271,12 +271,12 @@ public class ScatterSeries_Edit_Part extends Composite {
 
 		handledChart = new HandledChart(parent, SWT.BORDER);
 		handledChart.setLayoutData(new GridData(GridData.FILL_BOTH));
-		//
+
 		IChartSettings chartSettings = handledChart.getChartSettings();
 		chartSettings.setCreateMenu(true);
 		chartSettings.setSupportDataShift(true);
 		handledChart.applySettings(chartSettings);
-		//
+
 		loadScatterData();
 	}
 
@@ -293,7 +293,7 @@ public class ScatterSeries_Edit_Part extends Composite {
 		 */
 		List<ISeriesData> scatterSeriesList = SeriesConverter.getSeriesScatter(SeriesConverter.SCATTER_SERIES_1);
 		List<IScatterSeriesData> scatterSeriesDataList = new ArrayList<IScatterSeriesData>();
-		//
+
 		for(ISeriesData seriesData : scatterSeriesList) {
 			IScatterSeriesData scatterSeriesData = new ScatterSeriesData(seriesData);
 			IScatterSeriesSettings scatterSeriesSettings = scatterSeriesData.getSettings();
@@ -323,7 +323,7 @@ public class ScatterSeries_Edit_Part extends Composite {
 	private void applySettings(IScatterSeriesSettings scatterSeriesSettings, double x, double y, int symbolSize) {
 
 		scatterSeriesSettings.setSymbolSize(SYMBOL_SIZE);
-		//
+
 		if(x > 0 && y > 0) {
 			scatterSeriesSettings.setSymbolColor(COLOR_RED);
 			scatterSeriesSettings.setSymbolType(PlotSymbolType.SQUARE);
@@ -337,7 +337,7 @@ public class ScatterSeries_Edit_Part extends Composite {
 			scatterSeriesSettings.setSymbolColor(COLOR_CYAN);
 			scatterSeriesSettings.setSymbolType(PlotSymbolType.INVERTED_TRIANGLE);
 		}
-		//
+
 		IScatterSeriesSettings scatterSeriesSettingsHighlight = (IScatterSeriesSettings)scatterSeriesSettings.getSeriesSettingsHighlight();
 		scatterSeriesSettingsHighlight.setSymbolColor(COLOR_GRAY);
 		scatterSeriesSettingsHighlight.setSymbolType(PlotSymbolType.CIRCLE);

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/ScatterSeries_Preferences_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/ScatterSeries_Preferences_Part.java
@@ -94,7 +94,7 @@ public class ScatterSeries_Preferences_Part extends Composite {
 		gridDataComposite.horizontalAlignment = SWT.END;
 		compositeButtons.setLayoutData(gridDataComposite);
 		compositeButtons.setLayout(new GridLayout(1, false));
-		//
+
 		Button buttonOpenSettings = new Button(compositeButtons, SWT.PUSH);
 		modifySettingsButton(buttonOpenSettings);
 		buttonOpenSettings.addSelectionListener(new SelectionAdapter() {
@@ -108,12 +108,12 @@ public class ScatterSeries_Preferences_Part extends Composite {
 				preferencePrimaryAxesPage.setTitle("Primary Axes");
 				IPreferencePage preferenceDataPage = new ScatterSeriesDataPreferencePage();
 				preferenceDataPage.setTitle("Series Data");
-				//
+
 				PreferenceManager preferenceManager = new PreferenceManager();
 				preferenceManager.addToRoot(new PreferenceNode("1", preferencePage));
 				preferenceManager.addToRoot(new PreferenceNode("2", preferencePrimaryAxesPage));
 				preferenceManager.addToRoot(new PreferenceNode("3", preferenceDataPage));
-				//
+
 				PreferenceDialog preferenceDialog = new PreferenceDialog(e.display.getActiveShell(), preferenceManager);
 				preferenceDialog.create();
 				preferenceDialog.setMessage("Settings");
@@ -127,10 +127,10 @@ public class ScatterSeries_Preferences_Part extends Composite {
 				}
 			}
 		});
-		//
+
 		scatterChart = new ScatterChart(this, SWT.NONE);
 		scatterChart.setLayoutData(new GridData(GridData.FILL_BOTH));
-		//
+
 		applyChartSettings();
 		applySeriesSettings();
 	}
@@ -146,7 +146,7 @@ public class ScatterSeries_Preferences_Part extends Composite {
 
 		IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
 		setBackground(getDisplay().getSystemColor(SWT.COLOR_WHITE));
-		//
+
 		Color colorHintRangeSelector = getColor(PreferenceConverter.getColor(preferenceStore, ScatterSeriesPreferenceConstants.P_COLOR_HINT_RANGE_SELECTOR));
 		Color colorTitle = getColor(PreferenceConverter.getColor(preferenceStore, ScatterSeriesPreferenceConstants.P_TITLE_COLOR));
 		Color colorBackground = getColor(PreferenceConverter.getColor(preferenceStore, ScatterSeriesPreferenceConstants.P_BACKGROUND));
@@ -161,7 +161,7 @@ public class ScatterSeries_Preferences_Part extends Composite {
 		Color colorLegendMarker = getColor(PreferenceConverter.getColor(preferenceStore, ScatterSeriesPreferenceConstants.P_COLOR_LEGEND_MARKER));
 		Color colorAxisZeroMarker = getColor(PreferenceConverter.getColor(preferenceStore, ScatterSeriesPreferenceConstants.P_COLOR_AXIS_ZERO_MARKER));
 		Color colorSeriesLabelMarker = getColor(PreferenceConverter.getColor(preferenceStore, ScatterSeriesPreferenceConstants.P_COLOR_SERIES_LABEL_MARKER));
-		//
+
 		IChartSettings chartSettings = scatterChart.getChartSettings();
 		chartSettings.setEnableRangeSelector(preferenceStore.getBoolean(ScatterSeriesPreferenceConstants.P_ENABLE_RANGE_SELECTOR));
 		chartSettings.setShowRangeSelectorInitially(preferenceStore.getBoolean(ScatterSeriesPreferenceConstants.P_SHOW_RANGE_SELECTOR_INITIALLY));
@@ -193,7 +193,7 @@ public class ScatterSeries_Preferences_Part extends Composite {
 		rangeRestriction.setExtendTypeY(RangeRestriction.ExtendType.valueOf(preferenceStore.getString(ScatterSeriesPreferenceConstants.P_EXTEND_TYPE_Y)));
 		rangeRestriction.setExtendMinY(preferenceStore.getDouble(ScatterSeriesPreferenceConstants.P_EXTEND_MIN_Y));
 		rangeRestriction.setExtendMaxY(preferenceStore.getDouble(ScatterSeriesPreferenceConstants.P_EXTEND_MAX_Y));
-		//
+
 		chartSettings.setShowPositionMarker(preferenceStore.getBoolean(ScatterSeriesPreferenceConstants.P_SHOW_POSITION_MARKER));
 		chartSettings.setColorPositionMarker(colorPositionMarker);
 		chartSettings.setShowPlotCenterMarker(preferenceStore.getBoolean(ScatterSeriesPreferenceConstants.P_SHOW_PLOT_CENTER_MARKER));
@@ -204,7 +204,7 @@ public class ScatterSeries_Preferences_Part extends Composite {
 		chartSettings.setColorAxisZeroMarker(colorAxisZeroMarker);
 		chartSettings.setShowSeriesLabelMarker(preferenceStore.getBoolean(ScatterSeriesPreferenceConstants.P_SHOW_SERIES_LABEL_MARKER));
 		chartSettings.setColorSeriesLabelMarker(colorSeriesLabelMarker);
-		//
+
 		chartSettings.setCreateMenu(preferenceStore.getBoolean(ScatterSeriesPreferenceConstants.P_CREATE_MENU));
 		/*
 		 * Primary X-Axis
@@ -234,7 +234,7 @@ public class ScatterSeries_Preferences_Part extends Composite {
 		primaryAxisSettingsY.setEnableLogScale(preferenceStore.getBoolean(ScatterSeriesPreferenceConstants.P_PRIMARY_Y_AXIS_ENABLE_LOG_SCALE));
 		primaryAxisSettingsY.setLogScaleBase(preferenceStore.getDouble(ScatterSeriesPreferenceConstants.P_PRIMARY_Y_AXIS_LOG_SCALE_BASE));
 		primaryAxisSettingsY.setExtraSpaceTitle(preferenceStore.getInt(ScatterSeriesPreferenceConstants.P_PRIMARY_Y_AXIS_EXTRA_SPACE_TITLE));
-		//
+
 		scatterChart.applySettings(chartSettings);
 	}
 
@@ -242,7 +242,7 @@ public class ScatterSeries_Preferences_Part extends Composite {
 
 		IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
 		int symbolSize = preferenceStore.getInt(ScatterSeriesPreferenceConstants.P_SYMBOL_SIZE_SERIES);
-		//
+
 		Color symbolColorSeriesLeftTop = getColor(PreferenceConverter.getColor(preferenceStore, ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_LEFT_TOP));
 		Color symbolColorSeriesRightTop = getColor(PreferenceConverter.getColor(preferenceStore, ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_RIGHT_TOP));
 		Color symbolColorSeriesLeftBottom = getColor(PreferenceConverter.getColor(preferenceStore, ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_LEFT_BOTTOM));
@@ -255,7 +255,7 @@ public class ScatterSeries_Preferences_Part extends Composite {
 		boolean isVisibleLeftBottom = preferenceStore.getBoolean(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_LEFT_BOTTOM);
 		PlotSymbolType plotSymbolTypeRightBottom = PlotSymbolType.valueOf(preferenceStore.getString(ScatterSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_RIGHT_BOTTOM));
 		boolean isVisibleRightBottom = preferenceStore.getBoolean(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_RIGHT_BOTTOM);
-		//
+
 		Color symbolColorSeriesLeftTopHighlight = getColor(PreferenceConverter.getColor(preferenceStore, ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_HIGHLIGHT_LEFT_TOP));
 		Color symbolColorSeriesRightTopHighlight = getColor(PreferenceConverter.getColor(preferenceStore, ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_HIGHLIGHT_RIGHT_TOP));
 		Color symbolColorSeriesLeftBottomHighlight = getColor(PreferenceConverter.getColor(preferenceStore, ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_HIGHLIGHT_LEFT_BOTTOM));
@@ -268,14 +268,14 @@ public class ScatterSeries_Preferences_Part extends Composite {
 		boolean isVisibleLeftBottomHighlight = preferenceStore.getBoolean(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_HIGHLIGHT_LEFT_BOTTOM);
 		PlotSymbolType plotSymbolTypeRightBottomHighlight = PlotSymbolType.valueOf(preferenceStore.getString(ScatterSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_HIGHLIGHT_RIGHT_BOTTOM));
 		boolean isVisibleRightBottomHighlight = preferenceStore.getBoolean(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_HIGHLIGHT_RIGHT_BOTTOM);
-		//
+
 		scatterChart.deleteSeries();
 		/*
 		 * Data
 		 */
 		List<ISeriesData> scatterSeriesList = SeriesConverter.getSeriesScatter(SeriesConverter.SCATTER_SERIES_1);
 		List<IScatterSeriesData> scatterSeriesDataList = new ArrayList<IScatterSeriesData>();
-		//
+
 		for(ISeriesData seriesData : scatterSeriesList) {
 			IScatterSeriesData scatterSeriesData = new ScatterSeriesData(seriesData);
 			IScatterSeriesSettings scatterSeriesSettings = scatterSeriesData.getSettings();
@@ -287,7 +287,7 @@ public class ScatterSeries_Preferences_Part extends Composite {
 			double y = seriesData.getYSeries()[0];
 			scatterSeriesSettings.setSymbolSize(symbolSize);
 			scatterSeriesSettingsHighlight.setSymbolSize(symbolSize);
-			//
+
 			if(x > 0 && y > 0) {
 				scatterSeriesSettings.setSymbolColor(symbolColorSeriesRightTop);
 				scatterSeriesSettings.setSymbolType(plotSymbolTypeRightTop);
@@ -317,10 +317,10 @@ public class ScatterSeries_Preferences_Part extends Composite {
 				scatterSeriesSettingsHighlight.setSymbolType(plotSymbolTypeLeftBottomHighlight);
 				scatterSeriesSettingsHighlight.setVisible(isVisibleLeftBottomHighlight);
 			}
-			//
+
 			scatterSeriesDataList.add(scatterSeriesData);
 		}
-		//
+
 		scatterChart.addSeriesData(scatterSeriesDataList);
 	}
 

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/SimplePieChart.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/SimplePieChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -38,7 +38,7 @@ public class SimplePieChart extends PieChart {
 	private static final double[] NorthAmericanCountriesValues = {3900261, 3761363};
 	private static final String[] IndianStatesLabels = {"Maharashtra", "Rajasthan", "Uttar Pradesh", "Madhya Pradesh"};
 	private static final double[] IndianStateValues = {92320, 213900, 150580, 192718};
-	//
+
 	private boolean doughnut = true;
 	private boolean highlightSeries = false;
 
@@ -61,25 +61,25 @@ public class SimplePieChart extends PieChart {
 		 * Create series.
 		 */
 		ICircularSeriesData circularSeriesData = new CircularSeriesData();
-		//
+
 		circularSeriesData.setTitle("World");
 		circularSeriesData.setNodeClass("Landmass Name");
 		circularSeriesData.setValueClass("Area in square miles");
-		//
+
 		circularSeriesData.setSeries(continentLabels, continentValues);
 		circularSeriesData.getNodeById("Asia").addChildren(AsianCountriesLabels, AsianCountriesValues);
 		circularSeriesData.getNodeById("Africa").addChildren(AfricanCountriesLabels, AfricanCountriesValues);
 		circularSeriesData.getNodeById("North America").addChildren(NorthAmericanCountriesLabels, NorthAmericanCountriesValues);
 		circularSeriesData.getNodeById("India").addChildren(IndianStatesLabels, IndianStateValues);
 		circularSeriesData.getNodeById("Europe").addChild("Germany", 137847);
-		//
+
 		ICircularSeriesSettings settings = circularSeriesData.getSettings();
 		settings.setDescription("Landmass Distribution");
 		settings.setSliceColor(null);
 		settings.setBorderWidth(1);
 		settings.setBorderStyle(LineStyle.SOLID);
 		settings.setSeriesType(doughnut ? SeriesType.DOUGHNUT : SeriesType.PIE);
-		//
+
 		if(highlightSeries) {
 			settings.setRedrawOnClick(false);
 			ISeriesSettings seriesSettingsHighlight = settings.getSeriesSettingsHighlight();

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/StepSeries_1_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/StepSeries_1_Part.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -41,7 +41,7 @@ public class StepSeries_1_Part extends ChromatogramChart {
 
 		super(parent, SWT.NONE);
 		setBackground(getDisplay().getSystemColor(SWT.COLOR_WHITE));
-		//
+
 		try {
 			initialize();
 		} catch(Exception e) {
@@ -61,7 +61,7 @@ public class StepSeries_1_Part extends ChromatogramChart {
 		 * Create series.
 		 */
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
-		//
+
 		ISeriesData seriesData;
 		ILineSeriesData lineSeriesData;
 		ILineSeriesSettings lineSeriesSettings;

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/BarSeriesDataPreferencePage.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/BarSeriesDataPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -37,7 +37,7 @@ public class BarSeriesDataPreferencePage extends FieldEditorPreferencePage imple
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Bar Series 1", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new StringFieldEditor(BarSeriesPreferenceConstants.P_DESCRIPTION_SERIES_1, "Description:", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(BarSeriesPreferenceConstants.P_VISIBLE_SERIES_1, "Visible", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(BarSeriesPreferenceConstants.P_VISIBLE_IN_LEGEND_SERIES_1, "Visible in Legend", getFieldEditorParent()));
@@ -45,11 +45,11 @@ public class BarSeriesDataPreferencePage extends FieldEditorPreferencePage imple
 		addField(new IntegerFieldEditor(BarSeriesPreferenceConstants.P_BAR_PADDING_SERIES_1, "Bar Padding:", getFieldEditorParent()));
 		addField(new IntegerFieldEditor(BarSeriesPreferenceConstants.P_BAR_WIDTH_SERIES_1, "Bar Width:", getFieldEditorParent()));
 		addField(new ComboFieldEditor(BarSeriesPreferenceConstants.P_BAR_WIDTH_STYLE_SERIES_1, "Bar Width Style:", PreferenceSupport.BAR_WIDTH_STYLES, getFieldEditorParent()));
-		//
+
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Bar Series 1 (Highlight)", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new BooleanFieldEditor(BarSeriesPreferenceConstants.P_VISIBLE_SERIES_1_HIGHLIGHT, "Visible", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(BarSeriesPreferenceConstants.P_VISIBLE_IN_LEGEND_SERIES_1_HIGHLIGHT, "Visible in Legend", getFieldEditorParent()));
 		addField(new ColorFieldEditor(BarSeriesPreferenceConstants.P_BAR_COLOR_SERIES_1_HIGHLIGHT, "Bar Color:", getFieldEditorParent()));

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/BarSeriesPreferenceConstants.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/BarSeriesPreferenceConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,7 +23,7 @@ import org.eclipse.swtchart.extensions.core.RangeRestriction;
 public class BarSeriesPreferenceConstants {
 
 	public static final String POSTFIX = "BarSeries";
-	//
+
 	public static final String P_ENABLE_RANGE_SELECTOR = "enableRangeSelector" + POSTFIX;
 	public static final boolean DEF_ENABLE_RANGE_SELECTOR = true;
 	public static final String P_SHOW_RANGE_SELECTOR_INITIALLY = "showRangeSelectorInitially" + POSTFIX;
@@ -34,24 +34,24 @@ public class BarSeriesPreferenceConstants {
 	public static final int DEF_RANGE_SELECTOR_DEFAULT_AXIS_X = 0; // Index
 	public static final String P_RANGE_SELECTOR_DEFAULT_AXIS_Y = "rangeSelectorDefaultAxisY" + POSTFIX;
 	public static final int DEF_RANGE_SELECTOR_DEFAULT_AXIS_Y = 0; // Index
-	//
+
 	public static final String P_VERTICAL_SLIDER_VISIBLE = "verticalSliderVisible" + POSTFIX;
 	public static final boolean DEF_VERTICAL_SLIDER_VISIBLE = true;
 	public static final String P_HORIZONTAL_SLIDER_VISIBLE = "HorizontalSliderVisible" + POSTFIX;
 	public static final boolean DEF_HORIZONTALSLIDER_VISIBLE = true;
-	//
+
 	public static final String P_TITLE = "title" + POSTFIX;
 	public static final String DEF_TITLE = "Bar Series";
 	public static final String P_TITLE_VISIBLE = "titleVisible" + POSTFIX;
 	public static final boolean DEF_TITLE_VISIBLE = false;
 	public static final String P_TITLE_COLOR = "titleColor" + POSTFIX;
 	public static final String DEF_TITLE_COLOR = "0,0,0";
-	//
+
 	public static final String P_LEGEND_POSITION = "legendPosition" + POSTFIX;
 	public static final int DEF_LEGEND_POSITION = SWT.RIGHT;
 	public static final String P_LEGEND_VISIBLE = "legendVisible" + POSTFIX;
 	public static final boolean DEF_LEGEND_VISIBLE = false;
-	//
+
 	public static final String P_ORIENTATION = "orientation" + POSTFIX;
 	public static final int DEF_ORIENTATION = SWT.HORIZONTAL;
 	public static final String P_BACKGROUND = "background" + POSTFIX;
@@ -60,7 +60,7 @@ public class BarSeriesPreferenceConstants {
 	public static final String DEF_BACKGROUND_CHART = "255,255,255";
 	public static final String P_BACKGROUND_PLOT_AREA = "backgroundPlotArea" + POSTFIX;
 	public static final String DEF_BACKGROUND_PLOT_AREA = "255,255,255";
-	//
+
 	public static final String P_ENABLE_COMPRESS = "enableCompress" + POSTFIX;
 	public static final boolean DEF_ENABLE_COMPRESS = true;
 	public static final String P_ZERO_Y = "zeroY" + POSTFIX;
@@ -87,7 +87,7 @@ public class BarSeriesPreferenceConstants {
 	public static final double DEF_EXTEND_MIN_Y = 0.0d;
 	public static final String P_EXTEND_MAX_Y = "extendMaxY" + POSTFIX;
 	public static final double DEF_EXTEND_MAX_Y = 0.05d;
-	//
+
 	public static final String P_SHOW_POSITION_MARKER = "showPositionMarker" + POSTFIX;
 	public static final boolean DEF_SHOW_POSITION_MARKER = true;
 	public static final String P_COLOR_POSITION_MARKER = "colorPositionMarker" + POSTFIX;
@@ -108,10 +108,10 @@ public class BarSeriesPreferenceConstants {
 	public static final boolean DEF_SHOW_SERIES_LABEL_MARKER = false;
 	public static final String P_COLOR_SERIES_LABEL_MARKER = "colorSeriesLabelMarker" + POSTFIX;
 	public static final String DEF_COLOR_SERIES_LABEL_MARKER = "100,100,100";
-	//
+
 	public static final String P_CREATE_MENU = "createMenu" + POSTFIX;
 	public static final boolean DEF_CREATE_MENU = true;
-	//
+
 	public static final String P_PRIMARY_X_AXIS_TITLE = "primaryXAxisTitle" + POSTFIX;
 	public static final String DEF_PRIMARY_X_AXIS_TITLE = "m/z";
 	public static final String P_PRIMARY_X_AXIS_DESCRIPTION = "primaryXAxisDescription" + POSTFIX;
@@ -134,7 +134,7 @@ public class BarSeriesPreferenceConstants {
 	public static final double DEF_PRIMARY_X_AXIS_LOG_SCALE_BASE = 10.0d;
 	public static final String P_PRIMARY_X_AXIS_EXTRA_SPACE_TITLE = "primaryXAxisExtraSpaceTitle" + POSTFIX;
 	public static final int DEF_PRIMARY_X_AXIS_EXTRA_SPACE_TITLE = 25;
-	//
+
 	public static final String P_PRIMARY_Y_AXIS_TITLE = "primaryYAxisTitle" + POSTFIX;
 	public static final String DEF_PRIMARY_Y_AXIS_TITLE = "Intensity";
 	public static final String P_PRIMARY_Y_AXIS_DESCRIPTION = "primaryYAxisDescription" + POSTFIX;
@@ -157,7 +157,7 @@ public class BarSeriesPreferenceConstants {
 	public static final double DEF_PRIMARY_Y_AXIS_LOG_SCALE_BASE = 10.0d;
 	public static final String P_PRIMARY_Y_AXIS_EXTRA_SPACE_TITLE = "primaryYAxisExtraSpaceTitle" + POSTFIX;
 	public static final int DEF_PRIMARY_Y_AXIS_EXTRA_SPACE_TITLE = 25;
-	//
+
 	public static final String P_SECONDARY_Y_AXIS_TITLE = "secondaryYAxisTitle" + POSTFIX;
 	public static final String DEF_SECONDARY_Y_AXIS_TITLE = "Int [%]";
 	public static final String P_SECONDARY_Y_AXIS_DESCRIPTION = "secondaryYAxisDescription" + POSTFIX;
@@ -180,10 +180,10 @@ public class BarSeriesPreferenceConstants {
 	public static final double DEF_SECONDARY_Y_AXIS_LOG_SCALE_BASE = 10.0d;
 	public static final String P_SECONDARY_Y_AXIS_EXTRA_SPACE_TITLE = "secondaryYAxisExtraSpaceTitle" + POSTFIX;
 	public static final int DEF_SECONDARY_Y_AXIS_EXTRA_SPACE_TITLE = 25;
-	//
+
 	public static final String P_DESCRIPTION_SERIES_1 = "descriptionSeries1" + POSTFIX;
 	public static final String DEF_DESCRIPTION_SERIES_1 = "Measurement 1";
-	//
+
 	public static final String P_BAR_COLOR_SERIES_1 = "barColorSeries1" + POSTFIX;
 	public static final String DEF_BAR_COLOR_SERIES_1 = "255,0,0";
 	public static final String P_VISIBLE_SERIES_1 = "visibleSeries1" + POSTFIX;
@@ -196,7 +196,7 @@ public class BarSeriesPreferenceConstants {
 	public static final int DEF_BAR_WIDTH_SERIES_1 = 1;
 	public static final String P_BAR_WIDTH_STYLE_SERIES_1 = "barWidthStyleSeries1" + POSTFIX;
 	public static final String DEF_BAR_WIDTH_STYLE_SERIES_1 = BarWidthStyle.FIXED.toString();
-	//
+
 	public static final String P_BAR_COLOR_SERIES_1_HIGHLIGHT = "barColorSeries1Highlight" + POSTFIX;
 	public static final String DEF_BAR_COLOR_SERIES_1_HIGHLIGHT = "255,0,0";
 	public static final String P_VISIBLE_SERIES_1_HIGHLIGHT = "visibleSeries1Highlight" + POSTFIX;

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/BarSeriesPreferencePage.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/BarSeriesPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -38,7 +38,7 @@ public class BarSeriesPreferencePage extends FieldEditorPreferencePage implement
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Chart Settings", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new BooleanFieldEditor(BarSeriesPreferenceConstants.P_ENABLE_RANGE_SELECTOR, "Enable Range Selector", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(BarSeriesPreferenceConstants.P_SHOW_RANGE_SELECTOR_INITIALLY, "Show Range Selector Initially", getFieldEditorParent()));
 		addField(new ColorFieldEditor(BarSeriesPreferenceConstants.P_COLOR_HINT_RANGE_SELECTOR, "Color Hint Range Selector:", getFieldEditorParent()));
@@ -89,7 +89,7 @@ public class BarSeriesPreferencePage extends FieldEditorPreferencePage implement
 		fieldEditor2.setEnabled(false, getFieldEditorParent());
 		fieldEditor3.setEnabled(false, getFieldEditorParent());
 		fieldEditor4.setEnabled(false, getFieldEditorParent());
-		//
+
 		addField(new BooleanFieldEditor(BarSeriesPreferenceConstants.P_CREATE_MENU, "Create Menu", getFieldEditorParent()));
 	}
 

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/BarSeriesPrimaryAxesPreferencePage.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/BarSeriesPrimaryAxesPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -39,7 +39,7 @@ public class BarSeriesPrimaryAxesPreferencePage extends FieldEditorPreferencePag
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("X-Axis", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new StringFieldEditor(BarSeriesPreferenceConstants.P_PRIMARY_X_AXIS_TITLE, "Primary X-Axis Title:", getFieldEditorParent()));
 		addField(new StringFieldEditor(BarSeriesPreferenceConstants.P_PRIMARY_X_AXIS_DESCRIPTION, "Primary X-Axis Description:", getFieldEditorParent()));
 		addField(new StringFieldEditor(BarSeriesPreferenceConstants.P_PRIMARY_X_AXIS_DECIMAL_FORMAT_PATTERN, "Primary X-Axis Format Pattern:", getFieldEditorParent()));
@@ -51,11 +51,11 @@ public class BarSeriesPrimaryAxesPreferencePage extends FieldEditorPreferencePag
 		addField(new BooleanFieldEditor(BarSeriesPreferenceConstants.P_PRIMARY_X_AXIS_ENABLE_LOG_SCALE, "Primary X-Axis Enable Log Scale", getFieldEditorParent()));
 		addField(new DoubleFieldEditor(BarSeriesPreferenceConstants.P_PRIMARY_X_AXIS_LOG_SCALE_BASE, "Primary X-Axis Log Scale Base", getFieldEditorParent()));
 		addField(new IntegerFieldEditor(BarSeriesPreferenceConstants.P_PRIMARY_X_AXIS_EXTRA_SPACE_TITLE, "Primary X-Axis Extra Space Title:", getFieldEditorParent()));
-		//
+
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Y-Axis", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new StringFieldEditor(BarSeriesPreferenceConstants.P_PRIMARY_Y_AXIS_TITLE, "Primary Y-Axis Title:", getFieldEditorParent()));
 		addField(new StringFieldEditor(BarSeriesPreferenceConstants.P_PRIMARY_Y_AXIS_DESCRIPTION, "Primary Y-Axis Description:", getFieldEditorParent()));
 		addField(new StringFieldEditor(BarSeriesPreferenceConstants.P_PRIMARY_Y_AXIS_DECIMAL_FORMAT_PATTERN, "Primary Y-Axis Format Pattern:", getFieldEditorParent()));

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/BarSeriesSecondaryAxesPreferencePage.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/BarSeriesSecondaryAxesPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -39,7 +39,7 @@ public class BarSeriesSecondaryAxesPreferencePage extends FieldEditorPreferenceP
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Y-Axis", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new StringFieldEditor(BarSeriesPreferenceConstants.P_SECONDARY_Y_AXIS_TITLE, "Secondary Y-Axis Title:", getFieldEditorParent()));
 		addField(new StringFieldEditor(BarSeriesPreferenceConstants.P_SECONDARY_Y_AXIS_DESCRIPTION, "Secondary Y-Axis Description:", getFieldEditorParent()));
 		addField(new StringFieldEditor(BarSeriesPreferenceConstants.P_SECONDARY_Y_AXIS_DECIMAL_FORMAT_PATTERN, "Secondary Y-Axis Format Pattern:", getFieldEditorParent()));

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/LineSeriesDataPreferencePage.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/LineSeriesDataPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -37,7 +37,7 @@ public class LineSeriesDataPreferencePage extends FieldEditorPreferencePage impl
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Line Series 1", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new ComboFieldEditor(LineSeriesPreferenceConstants.P_ANTIALIAS_SERIES_1, "Antialias:", PreferenceSupport.ANTIALIAS_OPTIONS, getFieldEditorParent()));
 		addField(new StringFieldEditor(LineSeriesPreferenceConstants.P_DESCRIPTION_SERIES_1, "Description:", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(LineSeriesPreferenceConstants.P_ENABLE_AREA_SERIES_1, "Enable Area", getFieldEditorParent()));
@@ -51,11 +51,11 @@ public class LineSeriesDataPreferencePage extends FieldEditorPreferencePage impl
 		addField(new ComboFieldEditor(LineSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_1, "Symbol Type:", PreferenceSupport.SYMBOL_TYPES, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(LineSeriesPreferenceConstants.P_VISIBLE_SERIES_1, "Visible", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(LineSeriesPreferenceConstants.P_VISIBLE_IN_LEGEND_SERIES_1, "Visible in Legend", getFieldEditorParent()));
-		//
+
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Line Series 1 (Highlight)", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new ComboFieldEditor(LineSeriesPreferenceConstants.P_ANTIALIAS_SERIES_1_HIGHLIGHT, "Antialias:", PreferenceSupport.ANTIALIAS_OPTIONS, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(LineSeriesPreferenceConstants.P_ENABLE_AREA_SERIES_1_HIGHLIGHT, "Enable Area", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(LineSeriesPreferenceConstants.P_ENABLE_STACK_SERIES_1_HIGHLIGHT, "Enable Stack", getFieldEditorParent()));
@@ -68,11 +68,11 @@ public class LineSeriesDataPreferencePage extends FieldEditorPreferencePage impl
 		addField(new ComboFieldEditor(LineSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_1_HIGHLIGHT, "Symbol Type:", PreferenceSupport.SYMBOL_TYPES, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(LineSeriesPreferenceConstants.P_VISIBLE_SERIES_1_HIGHLIGHT, "Visible", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(LineSeriesPreferenceConstants.P_VISIBLE_IN_LEGEND_SERIES_1_HIGHLIGHT, "Visible in Legend", getFieldEditorParent()));
-		//
+
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Line Series 2", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new ComboFieldEditor(LineSeriesPreferenceConstants.P_ANTIALIAS_SERIES_2, "Antialias:", PreferenceSupport.ANTIALIAS_OPTIONS, getFieldEditorParent()));
 		addField(new StringFieldEditor(LineSeriesPreferenceConstants.P_DESCRIPTION_SERIES_2, "Description:", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(LineSeriesPreferenceConstants.P_ENABLE_AREA_SERIES_2, "Enable Area", getFieldEditorParent()));
@@ -86,11 +86,11 @@ public class LineSeriesDataPreferencePage extends FieldEditorPreferencePage impl
 		addField(new ComboFieldEditor(LineSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_2, "Symbol Type:", PreferenceSupport.SYMBOL_TYPES, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(LineSeriesPreferenceConstants.P_VISIBLE_SERIES_2, "Visible", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(LineSeriesPreferenceConstants.P_VISIBLE_IN_LEGEND_SERIES_2, "Visible in Legend", getFieldEditorParent()));
-		//
+
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Line Series 2 (Highlight)", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new ComboFieldEditor(LineSeriesPreferenceConstants.P_ANTIALIAS_SERIES_2_HIGHLIGHT, "Antialias:", PreferenceSupport.ANTIALIAS_OPTIONS, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(LineSeriesPreferenceConstants.P_ENABLE_AREA_SERIES_2_HIGHLIGHT, "Enable Area", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(LineSeriesPreferenceConstants.P_ENABLE_STACK_SERIES_2_HIGHLIGHT, "Enable Stack", getFieldEditorParent()));

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/LineSeriesPreferenceConstants.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/LineSeriesPreferenceConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,7 +23,7 @@ import org.eclipse.swtchart.extensions.core.RangeRestriction;
 public class LineSeriesPreferenceConstants {
 
 	public static final String POSTFIX = "LineSeries";
-	//
+
 	public static final String P_ENABLE_RANGE_SELECTOR = "enableRangeSelector" + POSTFIX;
 	public static final boolean DEF_ENABLE_RANGE_SELECTOR = true;
 	public static final String P_SHOW_RANGE_SELECTOR_INITIALLY = "showRangeSelectorInitially" + POSTFIX;
@@ -34,24 +34,24 @@ public class LineSeriesPreferenceConstants {
 	public static final int DEF_RANGE_SELECTOR_DEFAULT_AXIS_X = 0; // Index
 	public static final String P_RANGE_SELECTOR_DEFAULT_AXIS_Y = "rangeSelectorDefaultAxisY" + POSTFIX;
 	public static final int DEF_RANGE_SELECTOR_DEFAULT_AXIS_Y = 0; // Index
-	//
+
 	public static final String P_VERTICAL_SLIDER_VISIBLE = "verticalSliderVisible" + POSTFIX;
 	public static final boolean DEF_VERTICAL_SLIDER_VISIBLE = true;
 	public static final String P_HORIZONTAL_SLIDER_VISIBLE = "HorizontalSliderVisible" + POSTFIX;
 	public static final boolean DEF_HORIZONTALSLIDER_VISIBLE = true;
-	//
+
 	public static final String P_TITLE = "title" + POSTFIX;
 	public static final String DEF_TITLE = "Line Series";
 	public static final String P_TITLE_VISIBLE = "titleVisible" + POSTFIX;
 	public static final boolean DEF_TITLE_VISIBLE = false;
 	public static final String P_TITLE_COLOR = "titleColor" + POSTFIX;
 	public static final String DEF_TITLE_COLOR = "0,0,0";
-	//
+
 	public static final String P_LEGEND_POSITION = "legendPosition" + POSTFIX;
 	public static final int DEF_LEGEND_POSITION = SWT.RIGHT;
 	public static final String P_LEGEND_VISIBLE = "legendVisible" + POSTFIX;
 	public static final boolean DEF_LEGEND_VISIBLE = false;
-	//
+
 	public static final String P_ORIENTATION = "orientation" + POSTFIX;
 	public static final int DEF_ORIENTATION = SWT.HORIZONTAL;
 	public static final String P_BACKGROUND = "background" + POSTFIX;
@@ -60,7 +60,7 @@ public class LineSeriesPreferenceConstants {
 	public static final String DEF_BACKGROUND_CHART = "255,255,255";
 	public static final String P_BACKGROUND_PLOT_AREA = "backgroundPlotArea" + POSTFIX;
 	public static final String DEF_BACKGROUND_PLOT_AREA = "255,255,255";
-	//
+
 	public static final String P_ENABLE_COMPRESS = "enableCompress" + POSTFIX;
 	public static final boolean DEF_ENABLE_COMPRESS = true;
 	public static final String P_ZERO_Y = "zeroY" + POSTFIX;
@@ -87,7 +87,7 @@ public class LineSeriesPreferenceConstants {
 	public static final double DEF_EXTEND_MIN_Y = 0.0d;
 	public static final String P_EXTEND_MAX_Y = "extendMaxY" + POSTFIX;
 	public static final double DEF_EXTEND_MAX_Y = 0.0d;
-	//
+
 	public static final String P_SHOW_POSITION_MARKER = "showPositionMarker" + POSTFIX;
 	public static final boolean DEF_SHOW_POSITION_MARKER = true;
 	public static final String P_COLOR_POSITION_MARKER = "colorPositionMarker" + POSTFIX;
@@ -108,10 +108,10 @@ public class LineSeriesPreferenceConstants {
 	public static final boolean DEF_SHOW_SERIES_LABEL_MARKER = false;
 	public static final String P_COLOR_SERIES_LABEL_MARKER = "colorSeriesLabelMarker" + POSTFIX;
 	public static final String DEF_COLOR_SERIES_LABEL_MARKER = "100,100,100";
-	//
+
 	public static final String P_CREATE_MENU = "createMenu" + POSTFIX;
 	public static final boolean DEF_CREATE_MENU = true;
-	//
+
 	public static final String P_PRIMARY_X_AXIS_TITLE = "primaryXAxisTitle" + POSTFIX;
 	public static final String DEF_PRIMARY_X_AXIS_TITLE = "Time [ms]";
 	public static final String P_PRIMARY_X_AXIS_DESCRIPTION = "primaryXAxisDescription" + POSTFIX;
@@ -134,7 +134,7 @@ public class LineSeriesPreferenceConstants {
 	public static final double DEF_PRIMARY_X_AXIS_LOG_SCALE_BASE = 10.0d;
 	public static final String P_PRIMARY_X_AXIS_EXTRA_SPACE_TITLE = "primaryXAxisExtraSpaceTitle" + POSTFIX;
 	public static final int DEF_PRIMARY_X_AXIS_EXTRA_SPACE_TITLE = 25;
-	//
+
 	public static final String P_PRIMARY_Y_AXIS_TITLE = "primaryYAxisTitle" + POSTFIX;
 	public static final String DEF_PRIMARY_Y_AXIS_TITLE = "Intensity [counts]";
 	public static final String P_PRIMARY_Y_AXIS_DESCRIPTION = "primaryYAxisDescription" + POSTFIX;
@@ -157,7 +157,7 @@ public class LineSeriesPreferenceConstants {
 	public static final double DEF_PRIMARY_Y_AXIS_LOG_SCALE_BASE = 10.0d;
 	public static final String P_PRIMARY_Y_AXIS_EXTRA_SPACE_TITLE = "primaryYAxisExtraSpaceTitle" + POSTFIX;
 	public static final int DEF_PRIMARY_Y_AXIS_EXTRA_SPACE_TITLE = 25;
-	//
+
 	public static final String P_SECONDARY_X_AXIS_TITLE = "secondaryXAxisTitle" + POSTFIX;
 	public static final String DEF_SECONDARY_X_AXIS_TITLE = "Time [min]";
 	public static final String P_SECONDARY_X_AXIS_DESCRIPTION = "secondaryXAxisDescription" + POSTFIX;
@@ -180,7 +180,7 @@ public class LineSeriesPreferenceConstants {
 	public static final double DEF_SECONDARY_X_AXIS_LOG_SCALE_BASE = 10.0d;
 	public static final String P_SECONDARY_X_AXIS_EXTRA_SPACE_TITLE = "secondaryXAxisExtraSpaceTitle" + POSTFIX;
 	public static final int DEF_SECONDARY_X_AXIS_EXTRA_SPACE_TITLE = 25;
-	//
+
 	public static final String P_SECONDARY_Y_AXIS_TITLE = "secondaryYAxisTitle" + POSTFIX;
 	public static final String DEF_SECONDARY_Y_AXIS_TITLE = "Intensity [%]";
 	public static final String P_SECONDARY_Y_AXIS_DESCRIPTION = "secondaryYAxisDescription" + POSTFIX;
@@ -203,10 +203,10 @@ public class LineSeriesPreferenceConstants {
 	public static final double DEF_SECONDARY_Y_AXIS_LOG_SCALE_BASE = 10.0d;
 	public static final String P_SECONDARY_Y_AXIS_EXTRA_SPACE_TITLE = "secondaryYAxisExtraSpaceTitle" + POSTFIX;
 	public static final int DEF_SECONDARY_Y_AXIS_EXTRA_SPACE_TITLE = 25;
-	//
+
 	public static final String P_DESCRIPTION_SERIES_1 = "descriptionSeries1" + POSTFIX;
 	public static final String DEF_DESCRIPTION_SERIES_1 = "Measurement 1";
-	//
+
 	public static final String P_ANTIALIAS_SERIES_1 = "antialiasSeries1" + POSTFIX;
 	public static final int DEF_ANTIALIAS_SERIES_1 = SWT.DEFAULT;
 	public static final String P_ENABLE_AREA_SERIES_1 = "enableAreaSeries1" + POSTFIX;
@@ -231,7 +231,7 @@ public class LineSeriesPreferenceConstants {
 	public static final boolean DEF_VISIBLE_SERIES_1 = true;
 	public static final String P_VISIBLE_IN_LEGEND_SERIES_1 = "visibleInLegendSeries1" + POSTFIX;
 	public static final boolean DEF_VISIBLE_IN_LEGEND_SERIES_1 = true;
-	//
+
 	public static final String P_ANTIALIAS_SERIES_1_HIGHLIGHT = "antialiasSeries1Highlight" + POSTFIX;
 	public static final int DEF_ANTIALIAS_SERIES_1_HIGHLIGHT = SWT.DEFAULT;
 	public static final String P_ENABLE_AREA_SERIES_1_HIGHLIGHT = "enableAreaSeries1Highlight" + POSTFIX;
@@ -256,10 +256,10 @@ public class LineSeriesPreferenceConstants {
 	public static final boolean DEF_VISIBLE_SERIES_1_HIGHLIGHT = true;
 	public static final String P_VISIBLE_IN_LEGEND_SERIES_1_HIGHLIGHT = "visibleInLegendSeries1Highlight" + POSTFIX;
 	public static final boolean DEF_VISIBLE_IN_LEGEND_SERIES_1_HIGHLIGHT = true;
-	//
+
 	public static final String P_DESCRIPTION_SERIES_2 = "descriptionSeries2" + POSTFIX;
 	public static final String DEF_DESCRIPTION_SERIES_2 = "Measurement 2";
-	//
+
 	public static final String P_ANTIALIAS_SERIES_2 = "antialiasSeries2" + POSTFIX;
 	public static final int DEF_ANTIALIAS_SERIES_2 = SWT.DEFAULT;
 	public static final String P_ENABLE_AREA_SERIES_2 = "enableAreaSeries2" + POSTFIX;
@@ -284,7 +284,7 @@ public class LineSeriesPreferenceConstants {
 	public static final boolean DEF_VISIBLE_SERIES_2 = true;
 	public static final String P_VISIBLE_IN_LEGEND_SERIES_2 = "visibleInLegendSeries2" + POSTFIX;
 	public static final boolean DEF_VISIBLE_IN_LEGEND_SERIES_2 = true;
-	//
+
 	public static final String P_ANTIALIAS_SERIES_2_HIGHLIGHT = "antialiasSeries2Highlight" + POSTFIX;
 	public static final int DEF_ANTIALIAS_SERIES_2_HIGHLIGHT = SWT.DEFAULT;
 	public static final String P_ENABLE_AREA_SERIES_2_HIGHLIGHT = "enableAreaSeries2Highlight" + POSTFIX;

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/LineSeriesPreferencePage.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/LineSeriesPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -38,7 +38,7 @@ public class LineSeriesPreferencePage extends FieldEditorPreferencePage implemen
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Chart Settings", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new BooleanFieldEditor(LineSeriesPreferenceConstants.P_ENABLE_RANGE_SELECTOR, "Enable Range Selector", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(LineSeriesPreferenceConstants.P_SHOW_RANGE_SELECTOR_INITIALLY, "Show Range Selector Initially", getFieldEditorParent()));
 		addField(new ColorFieldEditor(LineSeriesPreferenceConstants.P_COLOR_HINT_RANGE_SELECTOR, "Color Hint Range Selector:", getFieldEditorParent()));
@@ -89,7 +89,7 @@ public class LineSeriesPreferencePage extends FieldEditorPreferencePage implemen
 		fieldEditor2.setEnabled(false, getFieldEditorParent());
 		fieldEditor3.setEnabled(false, getFieldEditorParent());
 		fieldEditor4.setEnabled(false, getFieldEditorParent());
-		//
+
 		addField(new BooleanFieldEditor(LineSeriesPreferenceConstants.P_CREATE_MENU, "Create Menu", getFieldEditorParent()));
 	}
 

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/LineSeriesPrimaryAxesPreferencePage.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/LineSeriesPrimaryAxesPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -39,7 +39,7 @@ public class LineSeriesPrimaryAxesPreferencePage extends FieldEditorPreferencePa
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("X-Axis", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new StringFieldEditor(LineSeriesPreferenceConstants.P_PRIMARY_X_AXIS_TITLE, "Primary X-Axis Title:", getFieldEditorParent()));
 		addField(new StringFieldEditor(LineSeriesPreferenceConstants.P_PRIMARY_X_AXIS_DESCRIPTION, "Primary X-Axis Description:", getFieldEditorParent()));
 		addField(new StringFieldEditor(LineSeriesPreferenceConstants.P_PRIMARY_X_AXIS_DECIMAL_FORMAT_PATTERN, "Primary X-Axis Format Pattern:", getFieldEditorParent()));
@@ -51,11 +51,11 @@ public class LineSeriesPrimaryAxesPreferencePage extends FieldEditorPreferencePa
 		addField(new BooleanFieldEditor(LineSeriesPreferenceConstants.P_PRIMARY_X_AXIS_ENABLE_LOG_SCALE, "Primary X-Axis Enable Log Scale", getFieldEditorParent()));
 		addField(new DoubleFieldEditor(LineSeriesPreferenceConstants.P_PRIMARY_X_AXIS_LOG_SCALE_BASE, "Primary X-Axis Log Scale Base", getFieldEditorParent()));
 		addField(new IntegerFieldEditor(LineSeriesPreferenceConstants.P_PRIMARY_X_AXIS_EXTRA_SPACE_TITLE, "Primary X-Axis Extra Space Title:", getFieldEditorParent()));
-		//
+
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Y-Axis", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new StringFieldEditor(LineSeriesPreferenceConstants.P_PRIMARY_Y_AXIS_TITLE, "Primary Y-Axis Title:", getFieldEditorParent()));
 		addField(new StringFieldEditor(LineSeriesPreferenceConstants.P_PRIMARY_Y_AXIS_DESCRIPTION, "Primary Y-Axis Description:", getFieldEditorParent()));
 		addField(new StringFieldEditor(LineSeriesPreferenceConstants.P_PRIMARY_Y_AXIS_DECIMAL_FORMAT_PATTERN, "Primary Y-Axis Format Pattern:", getFieldEditorParent()));

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/LineSeriesSecondaryAxesPreferencePage.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/LineSeriesSecondaryAxesPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -39,7 +39,7 @@ public class LineSeriesSecondaryAxesPreferencePage extends FieldEditorPreference
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("X-Axis", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new StringFieldEditor(LineSeriesPreferenceConstants.P_SECONDARY_X_AXIS_TITLE, "Secondary X-Axis Title:", getFieldEditorParent()));
 		addField(new StringFieldEditor(LineSeriesPreferenceConstants.P_SECONDARY_X_AXIS_DESCRIPTION, "Secondary X-Axis Description:", getFieldEditorParent()));
 		addField(new StringFieldEditor(LineSeriesPreferenceConstants.P_SECONDARY_X_AXIS_DECIMAL_FORMAT_PATTERN, "Secondary X-Axis Format Pattern:", getFieldEditorParent()));
@@ -51,11 +51,11 @@ public class LineSeriesSecondaryAxesPreferencePage extends FieldEditorPreference
 		addField(new BooleanFieldEditor(LineSeriesPreferenceConstants.P_SECONDARY_X_AXIS_ENABLE_LOG_SCALE, "Secondary X-Axis Enable Log Scale", getFieldEditorParent()));
 		addField(new DoubleFieldEditor(LineSeriesPreferenceConstants.P_SECONDARY_X_AXIS_LOG_SCALE_BASE, "Secondary X-Axis Log Scale Base", getFieldEditorParent()));
 		addField(new IntegerFieldEditor(LineSeriesPreferenceConstants.P_SECONDARY_X_AXIS_EXTRA_SPACE_TITLE, "Secondary X-Axis Extra Space Title:", getFieldEditorParent()));
-		//
+
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Y-Axis", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new StringFieldEditor(LineSeriesPreferenceConstants.P_SECONDARY_Y_AXIS_TITLE, "Secondary Y-Axis Title:", getFieldEditorParent()));
 		addField(new StringFieldEditor(LineSeriesPreferenceConstants.P_SECONDARY_Y_AXIS_DESCRIPTION, "Secondary Y-Axis Description:", getFieldEditorParent()));
 		addField(new StringFieldEditor(LineSeriesPreferenceConstants.P_SECONDARY_Y_AXIS_DECIMAL_FORMAT_PATTERN, "Secondary Y-Axis Format Pattern:", getFieldEditorParent()));

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/ScatterSeriesDataPreferencePage.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/ScatterSeriesDataPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -36,37 +36,37 @@ public class ScatterSeriesDataPreferencePage extends FieldEditorPreferencePage i
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Scatter Series", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new IntegerFieldEditor(ScatterSeriesPreferenceConstants.P_SYMBOL_SIZE_SERIES, "Symbol Size:", getFieldEditorParent()));
-		//
+
 		addField(new ColorFieldEditor(ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_LEFT_TOP, "Symbol Color (Left Top):", getFieldEditorParent()));
 		addField(new ComboFieldEditor(ScatterSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_LEFT_TOP, "Symbol Type (Left Top):", PreferenceSupport.SYMBOL_TYPES, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_LEFT_TOP, "Visible (Left Top)", getFieldEditorParent()));
-		//
+
 		addField(new ColorFieldEditor(ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_RIGHT_TOP, "Symbol Color (Right Top):", getFieldEditorParent()));
 		addField(new ComboFieldEditor(ScatterSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_RIGHT_TOP, "Symbol Type (Right Top):", PreferenceSupport.SYMBOL_TYPES, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_RIGHT_TOP, "Visible (Right Top)", getFieldEditorParent()));
-		//
+
 		addField(new ColorFieldEditor(ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_LEFT_BOTTOM, "Symbol Color (Left Bottom):", getFieldEditorParent()));
 		addField(new ComboFieldEditor(ScatterSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_LEFT_BOTTOM, "Symbol Type (Left Bottom):", PreferenceSupport.SYMBOL_TYPES, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_LEFT_BOTTOM, "Visible (Left Bottom)", getFieldEditorParent()));
-		//
+
 		addField(new ColorFieldEditor(ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_RIGHT_BOTTOM, "Symbol Color (Right Bottom):", getFieldEditorParent()));
 		addField(new ComboFieldEditor(ScatterSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_RIGHT_BOTTOM, "Symbol Type (Right Bottom):", PreferenceSupport.SYMBOL_TYPES, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_RIGHT_BOTTOM, "Visible (Right Bottom)", getFieldEditorParent()));
-		//
+
 		addField(new ColorFieldEditor(ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_HIGHLIGHT_LEFT_TOP, "Symbol Color (Left Top):", getFieldEditorParent()));
 		addField(new ComboFieldEditor(ScatterSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_HIGHLIGHT_LEFT_TOP, "Symbol Type (Left Top):", PreferenceSupport.SYMBOL_TYPES, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_HIGHLIGHT_LEFT_TOP, "Visible (Left Top)", getFieldEditorParent()));
-		//
+
 		addField(new ColorFieldEditor(ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_HIGHLIGHT_RIGHT_TOP, "Symbol Color (Right Top):", getFieldEditorParent()));
 		addField(new ComboFieldEditor(ScatterSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_HIGHLIGHT_RIGHT_TOP, "Symbol Type (Right Top):", PreferenceSupport.SYMBOL_TYPES, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_HIGHLIGHT_RIGHT_TOP, "Visible (Right Top)", getFieldEditorParent()));
-		//
+
 		addField(new ColorFieldEditor(ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_HIGHLIGHT_LEFT_BOTTOM, "Symbol Color (Left Bottom):", getFieldEditorParent()));
 		addField(new ComboFieldEditor(ScatterSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_HIGHLIGHT_LEFT_BOTTOM, "Symbol Type (Left Bottom):", PreferenceSupport.SYMBOL_TYPES, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_HIGHLIGHT_LEFT_BOTTOM, "Visible (Left Bottom)", getFieldEditorParent()));
-		//
+
 		addField(new ColorFieldEditor(ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_HIGHLIGHT_RIGHT_BOTTOM, "Symbol Color (Right Bottom):", getFieldEditorParent()));
 		addField(new ComboFieldEditor(ScatterSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_HIGHLIGHT_RIGHT_BOTTOM, "Symbol Type (Right Bottom):", PreferenceSupport.SYMBOL_TYPES, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_HIGHLIGHT_RIGHT_BOTTOM, "Visible (Right Bottom)", getFieldEditorParent()));

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/ScatterSeriesPreferenceConstants.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/ScatterSeriesPreferenceConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,7 +23,7 @@ import org.eclipse.swtchart.extensions.core.RangeRestriction;
 public class ScatterSeriesPreferenceConstants {
 
 	public static final String POSTFIX = "ScatterSeries";
-	//
+
 	public static final String P_ENABLE_RANGE_SELECTOR = "enableRangeSelector" + POSTFIX;
 	public static final boolean DEF_ENABLE_RANGE_SELECTOR = true;
 	public static final String P_SHOW_RANGE_SELECTOR_INITIALLY = "showRangeSelectorInitially" + POSTFIX;
@@ -34,24 +34,24 @@ public class ScatterSeriesPreferenceConstants {
 	public static final int DEF_RANGE_SELECTOR_DEFAULT_AXIS_X = 0; // Index
 	public static final String P_RANGE_SELECTOR_DEFAULT_AXIS_Y = "rangeSelectorDefaultAxisY" + POSTFIX;
 	public static final int DEF_RANGE_SELECTOR_DEFAULT_AXIS_Y = 0; // Index
-	//
+
 	public static final String P_VERTICAL_SLIDER_VISIBLE = "verticalSliderVisible" + POSTFIX;
 	public static final boolean DEF_VERTICAL_SLIDER_VISIBLE = true;
 	public static final String P_HORIZONTAL_SLIDER_VISIBLE = "HorizontalSliderVisible" + POSTFIX;
 	public static final boolean DEF_HORIZONTALSLIDER_VISIBLE = true;
-	//
+
 	public static final String P_TITLE = "title" + POSTFIX;
 	public static final String DEF_TITLE = "Scatter Series";
 	public static final String P_TITLE_VISIBLE = "titleVisible" + POSTFIX;
 	public static final boolean DEF_TITLE_VISIBLE = false;
 	public static final String P_TITLE_COLOR = "titleColor" + POSTFIX;
 	public static final String DEF_TITLE_COLOR = "0,0,0";
-	//
+
 	public static final String P_LEGEND_POSITION = "legendPosition" + POSTFIX;
 	public static final int DEF_LEGEND_POSITION = SWT.RIGHT;
 	public static final String P_LEGEND_VISIBLE = "legendVisible" + POSTFIX;
 	public static final boolean DEF_LEGEND_VISIBLE = false;
-	//
+
 	public static final String P_ORIENTATION = "orientation" + POSTFIX;
 	public static final int DEF_ORIENTATION = SWT.HORIZONTAL;
 	public static final String P_BACKGROUND = "background" + POSTFIX;
@@ -60,7 +60,7 @@ public class ScatterSeriesPreferenceConstants {
 	public static final String DEF_BACKGROUND_CHART = "255,255,255";
 	public static final String P_BACKGROUND_PLOT_AREA = "backgroundPlotArea" + POSTFIX;
 	public static final String DEF_BACKGROUND_PLOT_AREA = "255,255,255";
-	//
+
 	public static final String P_ENABLE_COMPRESS = "enableCompress" + POSTFIX;
 	public static final boolean DEF_ENABLE_COMPRESS = true;
 	public static final String P_ZERO_Y = "zeroY" + POSTFIX;
@@ -87,7 +87,7 @@ public class ScatterSeriesPreferenceConstants {
 	public static final double DEF_EXTEND_MIN_Y = 0.1d;
 	public static final String P_EXTEND_MAX_Y = "extendMaxY" + POSTFIX;
 	public static final double DEF_EXTEND_MAX_Y = 0.1d;
-	//
+
 	public static final String P_SHOW_POSITION_MARKER = "showPositionMarker" + POSTFIX;
 	public static final boolean DEF_SHOW_POSITION_MARKER = true;
 	public static final String P_COLOR_POSITION_MARKER = "colorPositionMarker" + POSTFIX;
@@ -108,10 +108,10 @@ public class ScatterSeriesPreferenceConstants {
 	public static final boolean DEF_SHOW_SERIES_LABEL_MARKER = true;
 	public static final String P_COLOR_SERIES_LABEL_MARKER = "colorSeriesLabelMarker" + POSTFIX;
 	public static final String DEF_COLOR_SERIES_LABEL_MARKER = "0,0,0";
-	//
+
 	public static final String P_CREATE_MENU = "createMenu" + POSTFIX;
 	public static final boolean DEF_CREATE_MENU = true;
-	//
+
 	public static final String P_PRIMARY_X_AXIS_TITLE = "primaryXAxisTitle" + POSTFIX;
 	public static final String DEF_PRIMARY_X_AXIS_TITLE = "PC1";
 	public static final String P_PRIMARY_X_AXIS_DESCRIPTION = "primaryXAxisDescription" + POSTFIX;
@@ -134,7 +134,7 @@ public class ScatterSeriesPreferenceConstants {
 	public static final double DEF_PRIMARY_X_AXIS_LOG_SCALE_BASE = 10.0d;
 	public static final String P_PRIMARY_X_AXIS_EXTRA_SPACE_TITLE = "primaryXAxisExtraSpaceTitle" + POSTFIX;
 	public static final int DEF_PRIMARY_X_AXIS_EXTRA_SPACE_TITLE = 25;
-	//
+
 	public static final String P_PRIMARY_Y_AXIS_TITLE = "primaryYAxisTitle" + POSTFIX;
 	public static final String DEF_PRIMARY_Y_AXIS_TITLE = "PC2";
 	public static final String P_PRIMARY_Y_AXIS_DESCRIPTION = "primaryYAxisDescription" + POSTFIX;
@@ -157,59 +157,59 @@ public class ScatterSeriesPreferenceConstants {
 	public static final double DEF_PRIMARY_Y_AXIS_LOG_SCALE_BASE = 10.0d;
 	public static final String P_PRIMARY_Y_AXIS_EXTRA_SPACE_TITLE = "primaryYAxisExtraSpaceTitle" + POSTFIX;
 	public static final int DEF_PRIMARY_Y_AXIS_EXTRA_SPACE_TITLE = 25;
-	//
+
 	public static final String P_SYMBOL_SIZE_SERIES = "symbolSizeSeries" + POSTFIX;
 	public static final int DEF_SYMBOL_SIZE_SERIES = 8;
-	//
+
 	public static final String P_SYMBOL_COLOR_SERIES_LEFT_TOP = "symbolColorSeriesLeftTop" + POSTFIX;
 	public static final String DEF_SYMBOL_COLOR_SERIES_LEFT_TOP = "255,0,255";
 	public static final String P_SYMBOL_TYPE_SERIES_LEFT_TOP = "symbolTypeSeriesLeftTop" + POSTFIX;
 	public static final String DEF_SYMBOL_TYPE_SERIES_LEFT_TOP = PlotSymbolType.DIAMOND.toString();
 	public static final String P_VISIBLE_SERIES_LEFT_TOP = "visibleSeriesLeftTop" + POSTFIX;
 	public static final boolean DEF_VISIBLE_SERIES_LEFT_TOP = true;
-	//
+
 	public static final String P_SYMBOL_COLOR_SERIES_RIGHT_TOP = "symbolColorSeriesRightTop" + POSTFIX;
 	public static final String DEF_SYMBOL_COLOR_SERIES_RIGHT_TOP = "255,0,0";
 	public static final String P_SYMBOL_TYPE_SERIES_RIGHT_TOP = "symbolTypeSeriesRightTop" + POSTFIX;
 	public static final String DEF_SYMBOL_TYPE_SERIES_RIGHT_TOP = PlotSymbolType.SQUARE.toString();
 	public static final String P_VISIBLE_SERIES_RIGHT_TOP = "visibleSeriesRightTop" + POSTFIX;
 	public static final boolean DEF_VISIBLE_SERIES_RIGHT_TOP = true;
-	//
+
 	public static final String P_SYMBOL_COLOR_SERIES_LEFT_BOTTOM = "symbolColorSeriesLeftBottom" + POSTFIX;
 	public static final String DEF_SYMBOL_COLOR_SERIES_LEFT_BOTTOM = "0,255,255";
 	public static final String P_SYMBOL_TYPE_SERIES_LEFT_BOTTOM = "symbolTypeSeriesLeftBottom" + POSTFIX;
 	public static final String DEF_SYMBOL_TYPE_SERIES_LEFT_BOTTOM = PlotSymbolType.INVERTED_TRIANGLE.toString();
 	public static final String P_VISIBLE_SERIES_LEFT_BOTTOM = "visibleSeriesLeftBottom" + POSTFIX;
 	public static final boolean DEF_VISIBLE_SERIES_LEFT_BOTTOM = true;
-	//
+
 	public static final String P_SYMBOL_COLOR_SERIES_RIGHT_BOTTOM = "symbolColorSeriesRightBottom" + POSTFIX;
 	public static final String DEF_SYMBOL_COLOR_SERIES_RIGHT_BOTTOM = "0,0,255";
 	public static final String P_SYMBOL_TYPE_SERIES_RIGHT_BOTTOM = "symbolTypeSeriesRightBottom" + POSTFIX;
 	public static final String DEF_SYMBOL_TYPE_SERIES_RIGHT_BOTTOM = PlotSymbolType.TRIANGLE.toString();
 	public static final String P_VISIBLE_SERIES_RIGHT_BOTTOM = "visibleSeriesRightBottom" + POSTFIX;
 	public static final boolean DEF_VISIBLE_SERIES_RIGHT_BOTTOM = true;
-	//
+
 	public static final String P_SYMBOL_COLOR_SERIES_HIGHLIGHT_LEFT_TOP = "symbolColorSeriesHighlightLeftTop" + POSTFIX;
 	public static final String DEF_SYMBOL_COLOR_SERIES_HIGHLIGHT_LEFT_TOP = "255,0,255";
 	public static final String P_SYMBOL_TYPE_SERIES_HIGHLIGHT_LEFT_TOP = "symbolTypeSeriesHighlightLeftTop" + POSTFIX;
 	public static final String DEF_SYMBOL_TYPE_SERIES_HIGHLIGHT_LEFT_TOP = PlotSymbolType.DIAMOND.toString();
 	public static final String P_VISIBLE_SERIES_HIGHLIGHT_LEFT_TOP = "visibleSeriesHighlightLeftTop" + POSTFIX;
 	public static final boolean DEF_VISIBLE_SERIES_HIGHLIGHT_LEFT_TOP = true;
-	//
+
 	public static final String P_SYMBOL_COLOR_SERIES_HIGHLIGHT_RIGHT_TOP = "symbolColorSeriesHighlightRightTop" + POSTFIX;
 	public static final String DEF_SYMBOL_COLOR_SERIES_HIGHLIGHT_RIGHT_TOP = "255,0,0";
 	public static final String P_SYMBOL_TYPE_SERIES_HIGHLIGHT_RIGHT_TOP = "symbolTypeSeriesHighlightRightTop" + POSTFIX;
 	public static final String DEF_SYMBOL_TYPE_SERIES_HIGHLIGHT_RIGHT_TOP = PlotSymbolType.SQUARE.toString();
 	public static final String P_VISIBLE_SERIES_HIGHLIGHT_RIGHT_TOP = "visibleSeriesHighlightRightTop" + POSTFIX;
 	public static final boolean DEF_VISIBLE_SERIES_HIGHLIGHT_RIGHT_TOP = true;
-	//
+
 	public static final String P_SYMBOL_COLOR_SERIES_HIGHLIGHT_LEFT_BOTTOM = "symbolColorSeriesHighlightLeftBottom" + POSTFIX;
 	public static final String DEF_SYMBOL_COLOR_SERIES_HIGHLIGHT_LEFT_BOTTOM = "0,255,255";
 	public static final String P_SYMBOL_TYPE_SERIES_HIGHLIGHT_LEFT_BOTTOM = "symbolTypeSeriesHighlightLeftBottom" + POSTFIX;
 	public static final String DEF_SYMBOL_TYPE_SERIES_HIGHLIGHT_LEFT_BOTTOM = PlotSymbolType.INVERTED_TRIANGLE.toString();
 	public static final String P_VISIBLE_SERIES_HIGHLIGHT_LEFT_BOTTOM = "visibleSeriesHighlightLeftBottom" + POSTFIX;
 	public static final boolean DEF_VISIBLE_SERIES_HIGHLIGHT_LEFT_BOTTOM = true;
-	//
+
 	public static final String P_SYMBOL_COLOR_SERIES_HIGHLIGHT_RIGHT_BOTTOM = "symbolColorSeriesHighlightRightBottom" + POSTFIX;
 	public static final String DEF_SYMBOL_COLOR_SERIES_HIGHLIGHT_RIGHT_BOTTOM = "0,0,255";
 	public static final String P_SYMBOL_TYPE_SERIES_HIGHLIGHT_RIGHT_BOTTOM = "symbolTypeSeriesHighlightRightBottom" + POSTFIX;

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/ScatterSeriesPreferenceInitializer.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/ScatterSeriesPreferenceInitializer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -88,35 +88,35 @@ public class ScatterSeriesPreferenceInitializer extends AbstractPreferenceInitia
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_PRIMARY_Y_AXIS_LOG_SCALE_BASE, ScatterSeriesPreferenceConstants.DEF_PRIMARY_Y_AXIS_LOG_SCALE_BASE);
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_PRIMARY_Y_AXIS_EXTRA_SPACE_TITLE, ScatterSeriesPreferenceConstants.DEF_PRIMARY_Y_AXIS_EXTRA_SPACE_TITLE);
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_SYMBOL_SIZE_SERIES, ScatterSeriesPreferenceConstants.DEF_SYMBOL_SIZE_SERIES);
-		//
+
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_LEFT_TOP, ScatterSeriesPreferenceConstants.DEF_SYMBOL_COLOR_SERIES_LEFT_TOP);
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_LEFT_TOP, ScatterSeriesPreferenceConstants.DEF_SYMBOL_TYPE_SERIES_LEFT_TOP);
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_LEFT_TOP, ScatterSeriesPreferenceConstants.DEF_VISIBLE_SERIES_LEFT_TOP);
-		//
+
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_RIGHT_TOP, ScatterSeriesPreferenceConstants.DEF_SYMBOL_COLOR_SERIES_RIGHT_TOP);
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_RIGHT_TOP, ScatterSeriesPreferenceConstants.DEF_SYMBOL_TYPE_SERIES_RIGHT_TOP);
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_RIGHT_TOP, ScatterSeriesPreferenceConstants.DEF_VISIBLE_SERIES_RIGHT_TOP);
-		//
+
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_LEFT_BOTTOM, ScatterSeriesPreferenceConstants.DEF_SYMBOL_COLOR_SERIES_LEFT_BOTTOM);
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_LEFT_BOTTOM, ScatterSeriesPreferenceConstants.DEF_SYMBOL_TYPE_SERIES_LEFT_BOTTOM);
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_LEFT_BOTTOM, ScatterSeriesPreferenceConstants.DEF_VISIBLE_SERIES_LEFT_BOTTOM);
-		//
+
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_RIGHT_BOTTOM, ScatterSeriesPreferenceConstants.DEF_SYMBOL_COLOR_SERIES_RIGHT_BOTTOM);
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_RIGHT_BOTTOM, ScatterSeriesPreferenceConstants.DEF_SYMBOL_TYPE_SERIES_RIGHT_BOTTOM);
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_RIGHT_BOTTOM, ScatterSeriesPreferenceConstants.DEF_VISIBLE_SERIES_RIGHT_BOTTOM);
-		//
+
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_HIGHLIGHT_LEFT_TOP, ScatterSeriesPreferenceConstants.DEF_SYMBOL_COLOR_SERIES_HIGHLIGHT_LEFT_TOP);
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_HIGHLIGHT_LEFT_TOP, ScatterSeriesPreferenceConstants.DEF_SYMBOL_TYPE_SERIES_HIGHLIGHT_LEFT_TOP);
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_HIGHLIGHT_LEFT_TOP, ScatterSeriesPreferenceConstants.DEF_VISIBLE_SERIES_HIGHLIGHT_LEFT_TOP);
-		//
+
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_HIGHLIGHT_RIGHT_TOP, ScatterSeriesPreferenceConstants.DEF_SYMBOL_COLOR_SERIES_HIGHLIGHT_RIGHT_TOP);
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_HIGHLIGHT_RIGHT_TOP, ScatterSeriesPreferenceConstants.DEF_SYMBOL_TYPE_SERIES_HIGHLIGHT_RIGHT_TOP);
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_HIGHLIGHT_RIGHT_TOP, ScatterSeriesPreferenceConstants.DEF_VISIBLE_SERIES_HIGHLIGHT_RIGHT_TOP);
-		//
+
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_HIGHLIGHT_LEFT_BOTTOM, ScatterSeriesPreferenceConstants.DEF_SYMBOL_COLOR_SERIES_HIGHLIGHT_LEFT_BOTTOM);
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_HIGHLIGHT_LEFT_BOTTOM, ScatterSeriesPreferenceConstants.DEF_SYMBOL_TYPE_SERIES_HIGHLIGHT_LEFT_BOTTOM);
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_HIGHLIGHT_LEFT_BOTTOM, ScatterSeriesPreferenceConstants.DEF_VISIBLE_SERIES_HIGHLIGHT_LEFT_BOTTOM);
-		//
+
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_SYMBOL_COLOR_SERIES_HIGHLIGHT_RIGHT_BOTTOM, ScatterSeriesPreferenceConstants.DEF_SYMBOL_COLOR_SERIES_HIGHLIGHT_RIGHT_BOTTOM);
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_SYMBOL_TYPE_SERIES_HIGHLIGHT_RIGHT_BOTTOM, ScatterSeriesPreferenceConstants.DEF_SYMBOL_TYPE_SERIES_HIGHLIGHT_RIGHT_BOTTOM);
 		preferenceStore.setDefault(ScatterSeriesPreferenceConstants.P_VISIBLE_SERIES_HIGHLIGHT_RIGHT_BOTTOM, ScatterSeriesPreferenceConstants.DEF_VISIBLE_SERIES_HIGHLIGHT_RIGHT_BOTTOM);

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/ScatterSeriesPreferencePage.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/ScatterSeriesPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -37,7 +37,7 @@ public class ScatterSeriesPreferencePage extends FieldEditorPreferencePage imple
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Chart Settings", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new BooleanFieldEditor(ScatterSeriesPreferenceConstants.P_ENABLE_RANGE_SELECTOR, "Enable Range Selector", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(ScatterSeriesPreferenceConstants.P_SHOW_RANGE_SELECTOR_INITIALLY, "Show Range Selector Initially", getFieldEditorParent()));
 		addField(new ColorFieldEditor(ScatterSeriesPreferenceConstants.P_COLOR_HINT_RANGE_SELECTOR, "Color Hint Range Selector:", getFieldEditorParent()));

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/ScatterSeriesPrimaryAxesPreferencePage.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/preferences/ScatterSeriesPrimaryAxesPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -39,7 +39,7 @@ public class ScatterSeriesPrimaryAxesPreferencePage extends FieldEditorPreferenc
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("X-Axis", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new StringFieldEditor(ScatterSeriesPreferenceConstants.P_PRIMARY_X_AXIS_TITLE, "Primary X-Axis Title:", getFieldEditorParent()));
 		addField(new StringFieldEditor(ScatterSeriesPreferenceConstants.P_PRIMARY_X_AXIS_DESCRIPTION, "Primary X-Axis Description:", getFieldEditorParent()));
 		addField(new StringFieldEditor(ScatterSeriesPreferenceConstants.P_PRIMARY_X_AXIS_DECIMAL_FORMAT_PATTERN, "Primary X-Axis Format Pattern:", getFieldEditorParent()));
@@ -51,11 +51,11 @@ public class ScatterSeriesPrimaryAxesPreferencePage extends FieldEditorPreferenc
 		addField(new BooleanFieldEditor(ScatterSeriesPreferenceConstants.P_PRIMARY_X_AXIS_ENABLE_LOG_SCALE, "Primary X-Axis Enable Log Scale", getFieldEditorParent()));
 		addField(new DoubleFieldEditor(ScatterSeriesPreferenceConstants.P_PRIMARY_X_AXIS_LOG_SCALE_BASE, "Primary X-Axis Log Scale Base", getFieldEditorParent()));
 		addField(new IntegerFieldEditor(ScatterSeriesPreferenceConstants.P_PRIMARY_X_AXIS_EXTRA_SPACE_TITLE, "Primary X-Axis Extra Space Title:", getFieldEditorParent()));
-		//
+
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
 		addField(new LabelFieldEditor("Y-Axis", getFieldEditorParent()));
 		addField(new SpacerFieldEditor(getFieldEditorParent()));
-		//
+
 		addField(new StringFieldEditor(ScatterSeriesPreferenceConstants.P_PRIMARY_Y_AXIS_TITLE, "Primary Y-Axis Title:", getFieldEditorParent()));
 		addField(new StringFieldEditor(ScatterSeriesPreferenceConstants.P_PRIMARY_Y_AXIS_DESCRIPTION, "Primary Y-Axis Description:", getFieldEditorParent()));
 		addField(new StringFieldEditor(ScatterSeriesPreferenceConstants.P_PRIMARY_Y_AXIS_DECIMAL_FORMAT_PATTERN, "Primary Y-Axis Format Pattern:", getFieldEditorParent()));

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/support/SeriesConverter.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/support/SeriesConverter.java
@@ -26,7 +26,7 @@ public class SeriesConverter {
 
 	public static final String LINE_SERIES = "LineSeries";
 	public static final String SCATTER_SERIES = "ScatterSeries";
-	//
+
 	public static final String LINE_SERIES_1 = "LineSeries1";
 	public static final String LINE_SERIES_1A = "LineSeries1a";
 	public static final String LINE_SERIES_1_ACTIVE_PEAKS = "LineSeries1_ActivePeaks";
@@ -50,14 +50,14 @@ public class SeriesConverter {
 	public static final String LINE_SERIES_5_NEGATIVE = "LineSeries5_Negative";
 	public static final String LINE_SERIES_6 = "LineSeries6";
 	public static final String LINE_SERIES_7 = "LineSeries7";
-	//
+
 	public static final String BAR_SERIES_1 = "BarSeries1";
 	public static final String BAR_SERIES_2 = "BarSeries2";
 	public static final String BAR_SERIES_3_POSITIVE = "BarSeries3-Positive";
 	public static final String BAR_SERIES_3_NEGATIVE = "BarSeries3-Negative";
 	public static final String BAR_SERIES_4_POSITIVE = "BarSeries4-Positive";
 	public static final String BAR_SERIES_5_NEGATIVE = "BarSeries5-Negative";
-	//
+
 	public static final String SCATTER_SERIES_1 = "ScatterSeries1";
 	public static final String SCATTER_SERIES_2_1 = "ScatterSeries2_1";
 	public static final String SCATTER_SERIES_2_2 = "ScatterSeries2_2";
@@ -68,9 +68,9 @@ public class SeriesConverter {
 	public static final String SCATTER_SERIES_2_7 = "ScatterSeries2_7";
 	public static final String SCATTER_SERIES_2_8 = "ScatterSeries2_8";
 	public static final String SCATTER_SERIES_2_9 = "ScatterSeries2_9";
-	//
+
 	public static final String BOXPLOT_SERIES_1 = "BoxPlotSeries1";
-	//
+
 	public static final String MEASUREMENT_SERIES_1_READINGS = "Measurement1_Readings";
 	public static final String MEASUREMENT_SERIES_1_REGRESSION = "Measurement1_Regression";
 	public static final String MEASUREMENT_SERIES_2_READINGS_1 = "Measurement2_Readings_1";
@@ -92,7 +92,7 @@ public class SeriesConverter {
 		int size = getNumberOfLines(fileName);
 		double[] xSeries = new double[size];
 		double[] ySeries = new double[size];
-		//
+
 		try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(SeriesConverter.class.getResourceAsStream(fileName)))) {
 			String line;
 			int i = 0;
@@ -107,7 +107,7 @@ public class SeriesConverter {
 			}
 		} catch(Exception e) {
 		}
-		//
+
 		ISeriesData seriesData = new SeriesData(xSeries, ySeries, id);
 		return seriesData;
 	}
@@ -116,7 +116,7 @@ public class SeriesConverter {
 
 		int size = getNumberOfLines(fileName);
 		double[] ySeries = new double[size];
-		//
+
 		BufferedReader bufferedReader = null;
 		try {
 			String line;
@@ -126,17 +126,17 @@ public class SeriesConverter {
 				ySeries[i++] = Double.parseDouble(line.trim());
 			}
 		} catch(Exception e) {
-			//
+
 		} finally {
 			if(bufferedReader != null) {
 				try {
 					bufferedReader.close();
 				} catch(IOException e) {
-					//
+
 				}
 			}
 		}
-		//
+
 		ISeriesData seriesData = new SeriesData(ySeries, fileName);
 		return seriesData;
 	}
@@ -144,7 +144,7 @@ public class SeriesConverter {
 	public static List<ISeriesData> getSeriesScatter(String fileName) {
 
 		List<ISeriesData> scatterSeriesList = new ArrayList<ISeriesData>();
-		//
+
 		BufferedReader bufferedReader = null;
 		try {
 			String line;
@@ -158,13 +158,13 @@ public class SeriesConverter {
 				scatterSeriesList.add(seriesData);
 			}
 		} catch(Exception e) {
-			//
+
 		} finally {
 			if(bufferedReader != null) {
 				try {
 					bufferedReader.close();
 				} catch(IOException e) {
-					//
+
 				}
 			}
 		}
@@ -199,7 +199,7 @@ public class SeriesConverter {
 			}
 		} catch(Exception e) {
 		}
-		//
+
 		return scatterSeriesList;
 	}
 
@@ -213,13 +213,13 @@ public class SeriesConverter {
 				i++;
 			}
 		} catch(Exception e) {
-			//
+
 		} finally {
 			if(bufferedReader != null) {
 				try {
 					bufferedReader.close();
 				} catch(IOException e) {
-					//
+
 				}
 			}
 		}

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/swt/CustomLineChart1.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/swt/CustomLineChart1.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -38,7 +38,7 @@ import org.eclipse.swtchart.extensions.linecharts.LineSeriesData;
 public class CustomLineChart1 extends LineChart {
 
 	private static final int LENGTH_HINT_DATA_POINTS = 15000;
-	//
+
 	private boolean enableRangeSelector;
 	private boolean showAxisTitle;
 	private boolean enableHorizontalSlider;
@@ -70,7 +70,7 @@ public class CustomLineChart1 extends LineChart {
 			chartSettings.setVerticalSliderVisible(enableHorizontalSlider);
 			chartSettings.getRangeRestriction().setZeroX(true);
 			chartSettings.getRangeRestriction().setZeroY(true);
-			//
+
 			IPrimaryAxisSettings primaryAxisSettingsX = chartSettings.getPrimaryAxisSettingsX();
 			primaryAxisSettingsX.setTitle("Time [ms]");
 			primaryAxisSettingsX.setDecimalFormat(new DecimalFormat(("0.0##"), new DecimalFormatSymbols(Locale.ENGLISH)));
@@ -78,7 +78,7 @@ public class CustomLineChart1 extends LineChart {
 			primaryAxisSettingsX.setPosition(Position.Secondary);
 			primaryAxisSettingsX.setVisible(false);
 			primaryAxisSettingsX.setGridLineStyle(LineStyle.NONE);
-			//
+
 			IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
 			primaryAxisSettingsY.setTitle("Intensity [counts]");
 			primaryAxisSettingsY.setDecimalFormat(new DecimalFormat(("0.0#E0"), new DecimalFormatSymbols(Locale.ENGLISH)));
@@ -103,7 +103,7 @@ public class CustomLineChart1 extends LineChart {
 			secondaryAxisSettingsY1.setDecimalFormat(new DecimalFormat(("0.00"), new DecimalFormatSymbols(Locale.ENGLISH)));
 			secondaryAxisSettingsY1.setColor(getDisplay().getSystemColor(SWT.COLOR_BLACK));
 			chartSettings.getSecondaryAxisSettingsListY().add(secondaryAxisSettingsY1);
-			//
+
 			applySettings(chartSettings);
 		} catch(Exception e) {
 			e.printStackTrace();
@@ -114,7 +114,7 @@ public class CustomLineChart1 extends LineChart {
 
 		List<ILineSeriesData> lineSeriesDataList = new ArrayList<ILineSeriesData>();
 		ISeriesData seriesData = SeriesConverter.getSeriesXY(seriesXY);
-		//
+
 		ILineSeriesData lineSeriesData = new LineSeriesData(seriesData);
 		ILineSeriesSettings lineSeriesSettings = lineSeriesData.getSettings();
 		lineSeriesSettings.setEnableArea(true);

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/swt/CustomLinkedLineSeries1.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/swt/CustomLinkedLineSeries1.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,11 +32,11 @@ public class CustomLinkedLineSeries1 extends Composite {
 	public void setChartInfo(String trace, String sample, String reference) {
 
 		ITitle title;
-		//
+
 		title = sampleChart.getBaseChart().getTitle();
 		title.setText(sample + " (" + trace + ")");
 		title.setForeground(getDisplay().getSystemColor(SWT.COLOR_BLACK));
-		//
+
 		title = referenceChart.getBaseChart().getTitle();
 		title.setText(reference + " (" + trace + ")");
 		title.setForeground(getDisplay().getSystemColor(SWT.COLOR_BLACK));
@@ -45,10 +45,10 @@ public class CustomLinkedLineSeries1 extends Composite {
 	private void createControl() {
 
 		setLayout(new GridLayout(1, true));
-		//
+
 		sampleChart = new CustomLineChart1(this, SWT.NONE, true, false, false, SeriesConverter.LINE_SERIES_4_3);
 		sampleChart.setLayoutData(new GridData(GridData.FILL_BOTH));
-		//
+
 		referenceChart = new CustomLineChart1(this, SWT.NONE, false, true, true, SeriesConverter.LINE_SERIES_4_4);
 		referenceChart.setLayoutData(new GridData(GridData.FILL_BOTH));
 		/*

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/axisconverter/MillisecondsToScanNumberConverter.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/axisconverter/MillisecondsToScanNumberConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -37,11 +37,11 @@ public class MillisecondsToScanNumberConverter extends AbstractAxisScaleConverte
 		if(scanDelay < 0) {
 			throw new InvalidParameterException(Messages.getString(Messages.SCAN_MUST_BE_GE_0_KEY));
 		}
-		//
+
 		if(scanInterval <= 0) {
 			throw new InvalidParameterException(Messages.getString(Messages.SCAN_MUST_BE_G_0_KEY));
 		}
-		//
+
 		this.scanDelay = scanDelay;
 		this.scanInterval = scanInterval;
 	}

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/axisconverter/PercentageConverter.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/axisconverter/PercentageConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,7 @@ import org.eclipse.swtchart.extensions.core.IChartDataCoordinates;
 public class PercentageConverter extends AbstractAxisScaleConverter implements IAxisScaleConverter {
 
 	private static final double REFERENCE = 100.0d;
-	//
+
 	private int orientation;
 	private boolean isZeroBased;
 
@@ -70,7 +70,7 @@ public class PercentageConverter extends AbstractAxisScaleConverter implements I
 
 		double min;
 		double max;
-		//
+
 		if(orientation == SWT.VERTICAL) {
 			min = (isZeroBased) ? 0.0d : chartDataCoordinates.getMinY();
 			max = chartDataCoordinates.getMaxY();

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/barcharts/BarChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/barcharts/BarChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -77,7 +77,7 @@ public class BarChart extends ScrollableChart {
 						barSeries.setBarWidthStyle(barSeriesSettings.getBarWidthStyle());
 					}
 				} catch(SeriesException e) {
-					//
+
 				}
 			}
 			baseChart.suspendUpdate(false);

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/barcharts/BarSeriesSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/barcharts/BarSeriesSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -140,7 +140,7 @@ public class BarSeriesSettings extends AbstractSeriesSettings implements IBarSer
 			sink.setHighlight(source.isHighlight());
 			success = true;
 		}
-		//
+
 		return success;
 	}
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/charts/ChartOptions.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/charts/ChartOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Lablicate GmbH.
+ * Copyright (c) 2019, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -26,7 +26,7 @@ public class ChartOptions {
 			{Messages.getString(Messages.BOLD), Integer.toString(SWT.BOLD)}, //
 			{Messages.getString(Messages.ITALIC), Integer.toString(SWT.ITALIC)} //
 	};
-	//
+
 	public static final String[][] COMPRESSION_TYPES = new String[][]{ //
 			{ICompressionSupport.COMPRESSION_EXTREME, ICompressionSupport.COMPRESSION_EXTREME}, //
 			{ICompressionSupport.COMPRESSION_HIGH, ICompressionSupport.COMPRESSION_HIGH}, //
@@ -35,7 +35,7 @@ public class ChartOptions {
 			{ICompressionSupport.COMPRESSION_AUTO, ICompressionSupport.COMPRESSION_AUTO}, //
 			{ICompressionSupport.COMPRESSION_NONE, ICompressionSupport.COMPRESSION_NONE} //
 	};
-	//
+
 	public static final String[][] SYMBOL_TYPES = new String[][]{ //
 			{Messages.getString(Messages.NONE), PlotSymbolType.NONE.toString()}, //
 			{Messages.getString(Messages.CIRCLE), PlotSymbolType.CIRCLE.toString()}, //
@@ -47,12 +47,12 @@ public class ChartOptions {
 			{Messages.getString(Messages.TRIANGLE), PlotSymbolType.TRIANGLE.toString()}, //
 			{Messages.getString(Messages.EMOJI), PlotSymbolType.EMOJI.toString()} //
 	};
-	//
+
 	public static final String[][] POSITIONS = new String[][]{ //
 			{Messages.getString(Messages.PRIMARY), Position.Primary.toString()}, //
 			{Messages.getString(Messages.SECONDARY), Position.Secondary.toString()} //
 	};
-	//
+
 	public static final String[][] LINE_STYLES = new String[][]{ //
 			{Messages.getString(Messages.NONE), LineStyle.NONE.toString()}, //
 			{"-", LineStyle.DASH.toString()}, //

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/charts/InteractiveChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/charts/InteractiveChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SWTChart project.
+ * Copyright (c) 2008, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -263,7 +263,7 @@ public class InteractiveChart extends Chart implements PaintListener {
 				}
 			}
 		}
-		//
+
 		selection.dispose();
 		redraw();
 	}
@@ -492,7 +492,7 @@ public class InteractiveChart extends Chart implements PaintListener {
 		if(range == null) {
 			return;
 		}
-		//
+
 		double min = axis.getDataCoordinate(range.x);
 		double max = axis.getDataCoordinate(range.y);
 		axis.setRange(new Range(min, max));

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/charts/SelectionRectangle.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/charts/SelectionRectangle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 SWTChart project.
+ * Copyright (c) 2008, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -101,12 +101,12 @@ public class SelectionRectangle {
 		if(startPoint == null || endPoint == null) {
 			return;
 		}
-		//
+
 		int minX = Math.min(startPoint.x, endPoint.x);
 		int maxX = Math.max(startPoint.x, endPoint.x);
 		int minY = Math.min(startPoint.y, endPoint.y);
 		int maxY = Math.max(startPoint.y, endPoint.y);
-		//
+
 		gc.drawRectangle(minX, minY, maxX - minX, maxY - minY);
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/clipboard/ImageArrayTransfer.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/clipboard/ImageArrayTransfer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Lablicate GmbH.
+ * Copyright (c) 2022, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,10 +27,10 @@ public class ImageArrayTransfer extends ByteArrayTransfer {
 
 	private static final String TYPE_NAME_BMP = "image/bmp";
 	private static final String TYPE_NAME_PNG = "image/png";
-	//
+
 	private static final ImageArrayTransfer WINDOWS = new ImageArrayTransfer(TYPE_NAME_BMP);
 	private static final ImageArrayTransfer LINUX = new ImageArrayTransfer(TYPE_NAME_PNG);
-	//
+
 	private IImageClipboardSupplier clipboardSupplier = null;
 	private String[] typeNames;
 	private int[] typeIds;
@@ -115,7 +115,7 @@ public class ImageArrayTransfer extends ByteArrayTransfer {
 
 		int imageCode;
 		String typeName = typeNames[0];
-		//
+
 		switch(typeName) {
 			case TYPE_NAME_BMP:
 				imageCode = SWT.IMAGE_BMP;
@@ -127,7 +127,7 @@ public class ImageArrayTransfer extends ByteArrayTransfer {
 				imageCode = SWT.IMAGE_JPEG;
 				break;
 		}
-		//
+
 		return imageCode;
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/clipboard/ImageClipboardSupport.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/clipboard/ImageClipboardSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Lablicate GmbH.
+ * Copyright (c) 2022, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,7 +32,7 @@ public class ImageClipboardSupport {
 		 */
 		Object imageData = null;
 		IImageClipboardSupplier specificSupplier = null;
-		//
+
 		if(useSpecificSupplier) {
 			specificSupplier = baseChart.getImageClipboardSupplier();
 			if(specificSupplier != null) {

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/clipboard/TextClipboardSupport.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/clipboard/TextClipboardSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Lablicate GmbH.
+ * Copyright (c) 2022, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -34,7 +34,7 @@ public class TextClipboardSupport {
 		List<String> seriesIds = new ArrayList<>(baseChart.getSeriesIds());
 		Collections.sort(seriesIds);
 		ISeriesSet seriesSet = baseChart.getSeriesSet();
-		//
+
 		StringBuilder builder = new StringBuilder();
 		for(String seriesId : seriesIds) {
 			/*
@@ -56,7 +56,7 @@ public class TextClipboardSupport {
 				}
 			}
 		}
-		//
+
 		TextTransfer textTransfer = TextTransfer.getInstance();
 		Object[] data = new Object[]{builder.toString()};
 		Transfer[] dataTypes = new Transfer[]{textTransfer};

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/AbstractAxisSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/AbstractAxisSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -122,7 +122,7 @@ public abstract class AbstractAxisSettings implements IAxisSettings {
 				}
 			}
 		}
-		//
+
 		return label;
 	}
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/AbstractExtendedChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/AbstractExtendedChart.java
@@ -63,9 +63,9 @@ public abstract class AbstractExtendedChart extends AbstractHandledChart impleme
 	private double extendedMaxX;
 	private double extendedMinY;
 	private double extendedMaxY;
-	//
+
 	private boolean isCircularSeries;
-	//
+
 	private Map<Integer, IAxisSettings> xAxisSettingsMap = new HashMap<>();
 	private Map<Integer, IAxisSettings> yAxisSettingsMap = new HashMap<>();
 	/*
@@ -213,7 +213,7 @@ public abstract class AbstractExtendedChart extends AbstractHandledChart impleme
 			if(adjustMinMax) {
 				adjustMinMaxRange(axis);
 			}
-			//
+
 			if(axis.getDirection() == Direction.X) {
 				adjustSecondaryXAxes();
 			} else if(axis.getDirection() == Direction.Y) {
@@ -307,7 +307,7 @@ public abstract class AbstractExtendedChart extends AbstractHandledChart impleme
 				} else {
 					lowerCalculated = range.lower + lowerExtension;
 				}
-				//
+
 				if(lowerCalculated <= min) {
 					range.lower = min;
 				} else {
@@ -328,7 +328,7 @@ public abstract class AbstractExtendedChart extends AbstractHandledChart impleme
 				} else {
 					upperCalculated = range.upper - upperExtension;
 				}
-				//
+
 				if(upperCalculated >= max) {
 					range.upper = max;
 				} else {
@@ -352,7 +352,7 @@ public abstract class AbstractExtendedChart extends AbstractHandledChart impleme
 				ICircularSeriesData circularSeriesData = (ICircularSeriesData)seriesData;
 				ICircularSeriesSettings circularSeriesSettings = (ICircularSeriesSettings)seriesSettings;
 				NodeDataModel nodeDataModel = circularSeriesData.getDataModel();
-				//
+
 				isCircularSeries = true;
 				seriesType = circularSeriesSettings.getSeriesType();
 				/*
@@ -386,7 +386,7 @@ public abstract class AbstractExtendedChart extends AbstractHandledChart impleme
 						mapSeriesSettings(labels[i], seriesSettingsCopy);
 					}
 				}
-				//
+
 				return circularSeries;
 			} else {
 				/*
@@ -394,7 +394,7 @@ public abstract class AbstractExtendedChart extends AbstractHandledChart impleme
 				 */
 				double[] xSeries = seriesData.getXSeries();
 				double[] ySeries = seriesData.getYSeries();
-				//
+
 				if(xSeries.length == ySeries.length) {
 					/*
 					 * Put the settings to the map.
@@ -453,11 +453,11 @@ public abstract class AbstractExtendedChart extends AbstractHandledChart impleme
 		for(ISeries<?> series : seriesSet.getSeries()) {
 			ids.add(series.getId());
 		}
-		//
+
 		for(String id : ids) {
 			seriesSet.deleteSeries(id);
 		}
-		//
+
 		seriesSettingsMap.clear();
 		seriesSettingsMapReset.clear();
 	}
@@ -476,7 +476,7 @@ public abstract class AbstractExtendedChart extends AbstractHandledChart impleme
 				series.setXSeries(xSeriesNew);
 				double[] ySeriesNew = concatenateSeries(series.getYSeries(), seriesData.getYSeries());
 				series.setYSeries(ySeriesNew);
-				//
+
 				calculateCoordinates(series);
 			}
 		}
@@ -500,7 +500,7 @@ public abstract class AbstractExtendedChart extends AbstractHandledChart impleme
 	private SeriesType getSeriesType(ISeriesSettings seriesSettings) {
 
 		SeriesType seriesType;
-		//
+
 		if(seriesSettings instanceof ILineSeriesSettings) {
 			seriesType = SeriesType.LINE;
 		} else if(seriesSettings instanceof IScatterSeriesSettings) {
@@ -512,7 +512,7 @@ public abstract class AbstractExtendedChart extends AbstractHandledChart impleme
 		} else {
 			seriesType = null;
 		}
-		//
+
 		return seriesType;
 	}
 
@@ -626,7 +626,7 @@ public abstract class AbstractExtendedChart extends AbstractHandledChart impleme
 
 		double[] xSeries = series.getXSeries();
 		double[] ySeries = series.getYSeries();
-		//
+
 		if(xSeries.length != 0) {
 			double seriesMinX = Arrays.stream(xSeries).min().getAsDouble();
 			double seriesMaxX = Arrays.stream(xSeries).max().getAsDouble();
@@ -646,7 +646,7 @@ public abstract class AbstractExtendedChart extends AbstractHandledChart impleme
 		minY = (rangeRestriction.isZeroY() && minY < 0.0d) ? 0.0d : minY;
 		minY = (rangeRestriction.isForceZeroMinY()) ? 0.0d : minY;
 		maxY = Math.max(maxY, seriesMaxY);
-		//
+
 		calculateExtendedCoordinates();
 	}
 
@@ -711,7 +711,7 @@ public abstract class AbstractExtendedChart extends AbstractHandledChart impleme
 		} else {
 			extendType = rangeRestriction.getExtendTypeY();
 		}
-		//
+
 		double extensionValue = 0.0d;
 		switch(extendType) {
 			case RELATIVE:
@@ -721,7 +721,7 @@ public abstract class AbstractExtendedChart extends AbstractHandledChart impleme
 				extensionValue = extend;
 				break;
 		}
-		//
+
 		return extensionValue;
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/BaseChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/BaseChart.java
@@ -64,7 +64,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 	public static final int ID_PRIMARY_Y_AXIS = 0;
 	public static final String DEFAULT_TITLE_X_AXIS = Messages.getString(Messages.X_AXIS);
 	public static final String DEFAULT_TITLE_Y_AXIS = Messages.getString(Messages.Y_AXIS);
-	//
+
 	public static final String SELECTED_SERIES_NONE = Messages.getString(Messages.NONE);
 	/*
 	 * see: IHandledEventProcessor
@@ -93,12 +93,12 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 	 */
 	private int redrawFrequency = 1;
 	private int redrawCounter = 0;
-	//
+
 	private List<ICustomSelectionHandler> customRangeSelectionHandlers;
 	private List<ICustomSelectionHandler> customPointSelectionHandlers;
 	private List<ISeriesModificationListener> seriesModificationListeners;
 	private List<ISeriesStatusListener> seriesStatusListeners;
-	//
+
 	private UserSelection userSelection;
 	private long clickStartTime;
 	private Set<String> selectedSeriesIds;
@@ -118,9 +118,9 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 	public static final int SHIFT_CONSTRAINT_STRETCH_X = 1 << 4;
 	public static final int SHIFT_CONSTRAINT_BROADEN_X = 1 << 5;
 	public static final int SHIFT_CONSTRAINT_NARROW_X = 1 << 6;
-	//
+
 	private int shiftConstraints = SHIFT_CONSTRAINT_NONE;
-	//
+
 	public static final long DELTA_MOVE_TIME = 350;
 	private long moveStartTime = 0;
 	private int xMoveStart = 0;
@@ -134,15 +134,15 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 	 * Custom Paint Series (Experimental)
 	 */
 	private List<ICustomSeries> customSeriesList = new ArrayList<>();
-	//
+
 	private IPreferenceStore preferenceStore = ResourceSupport.getPreferenceStore();
-	//
+
 	private ClickBindingHelpDialog clickBindingPopup;
 
 	public BaseChart(Composite parent, int style) {
 
 		super(parent, style);
-		//
+
 		chartSettings = new ChartSettings();
 		/*
 		 * Rectangle range selection.
@@ -158,7 +158,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		 * Create the default x and y axis.
 		 */
 		IAxisSet axisSet = getAxisSet();
-		//
+
 		IAxis xAxisPrimary = axisSet.getXAxis(ID_PRIMARY_X_AXIS);
 		ITitle titleX = xAxisPrimary.getTitle();
 		titleX.setText(DEFAULT_TITLE_X_AXIS);
@@ -171,7 +171,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		xAxisPrimary.setDrawAxisLine(true);
 		xAxisPrimary.setCategorySeries(new String[]{});
 		xAxisPrimary.setIntegerDataPointAxis(false);
-		//
+
 		IAxis yAxisPrimary = axisSet.getYAxis(ID_PRIMARY_Y_AXIS);
 		ITitle titleY = yAxisPrimary.getTitle();
 		titleY.setText(DEFAULT_TITLE_Y_AXIS);
@@ -183,12 +183,12 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		yAxisPrimary.setReversed(false);
 		yAxisPrimary.setDrawAxisLine(true);
 		yAxisPrimary.setIntegerDataPointAxis(false);
-		//
+
 		handledSelectionEvents = new Stack<>();
 		redoSelection = null;
-		//
+
 		dataShiftHistory = new HashMap<>();
-		//
+
 		setData("org.eclipse.e4.ui.css.CssClassName", "BaseChart"); //$NON-NLS-1$ //$NON-NLS-2$
 		/*
 		 * Draw the custom paint series elements (Experimental).
@@ -222,7 +222,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		customSeries.setLabel(label);
 		customSeries.setDescription(description);
 		customSeriesList.add(customSeries);
-		//
+
 		return customSeries;
 	}
 
@@ -242,7 +242,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 				break exitloop;
 			}
 		}
-		//
+
 		if(customSeriesDelete != null) {
 			customSeriesList.remove(customSeriesDelete);
 		}
@@ -396,13 +396,13 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 			stop = axis.getRange().upper;
 			length = getPlotArea().getSize().y;
 		}
-		//
+
 		if(positionStart > 0 && positionStop > 0 && positionStart < length && positionStop < length) {
-			//
+
 			double delta = stop - start;
 			double percentageStart;
 			double percentageStop;
-			//
+
 			if(orientation.equals(IExtendedChart.X_AXIS)) {
 				percentageStart = ((100.0d / length) * positionStart) / 100.0d;
 				percentageStop = ((100.0d / length) * positionStop) / 100.0d;
@@ -410,7 +410,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 				percentageStart = (100.0d - ((100.0d / length) * positionStart)) / 100.0d;
 				percentageStop = (100.0d - ((100.0d / length) * positionStop)) / 100.0d;
 			}
-			//
+
 			shiftValue = (start + delta * percentageStop) - (start + delta * percentageStart);
 		}
 		return shiftValue;
@@ -463,7 +463,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		double start;
 		double stop;
 		int length;
-		//
+
 		if(orientation.equals(IExtendedChart.X_AXIS)) {
 			IAxis axis = getAxisSet().getXAxis(BaseChart.ID_PRIMARY_X_AXIS);
 			if(axis.isReversed()) {
@@ -485,7 +485,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 			}
 			length = getPlotArea().getSize().y;
 		}
-		//
+
 		if(position <= 0) {
 			primaryValue = start;
 		} else if(position > length) {
@@ -571,7 +571,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		for(ISeries<?> serie : series) {
 			seriesIds.add(serie.getId());
 		}
-		//
+
 		return seriesIds;
 	}
 
@@ -589,12 +589,12 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 			 */
 			int currentLineStyle = e.gc.getLineStyle();
 			e.gc.setLineStyle(SWT.LINE_DOT);
-			//
+
 			int xMin = Math.min(userSelection.getStartX(), userSelection.getStopX());
 			int xMax = Math.max(userSelection.getStartX(), userSelection.getStopX());
 			int yMin = Math.min(userSelection.getStartY(), userSelection.getStopY());
 			int yMax = Math.max(userSelection.getStartY(), userSelection.getStopY());
-			//
+
 			RangeRestriction rangeRestriction = getRangeRestriction();
 			if(isSelectXY(rangeRestriction)) {
 				/*
@@ -611,7 +611,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 					e.gc.drawLine(xMin, yMin, xMin, yMax);
 				}
 			}
-			//
+
 			e.gc.setLineStyle(currentLineStyle);
 		}
 	}
@@ -680,7 +680,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 					if(eventMask == SWT.NONE) {
 						continue;
 					}
-					//
+
 					if((event.stateMask & eventMask) == eventMask) {
 						List<IEventProcessor> eventProcessors = eventProcessorMap.get(eventMask);
 						handleEventProcessors(eventProcessors, event);
@@ -819,7 +819,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 			 */
 			String originalDescriptionSeries = seriesSettings.getDescription();
 			String originalDescriptionMapping = seriesSettingsMapping.getDescription();
-			//
+
 			if(seriesSettings.isHighlight()) {
 				/*
 				 * Highlight Series Settings
@@ -883,7 +883,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 				 * Pie Series
 				 */
 				applyCircularSeriesSettings(circularSeries, circularSeriesSettings);
-				//
+
 				String id = circularSeries.getId();
 				NodeDataModel nodeDataModel = circularSeries.getNodeDataModel();
 				if(nodeDataModel != null) {
@@ -949,12 +949,12 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 
 		applyBaseSeriesSettings(circularSeries, circularSeriesSettings);
 		this.getTitle().setText(circularSeriesSettings.getDescription());
-		//
+
 		circularSeries.setSliceColor(circularSeriesSettings.getSliceColor());
 		circularSeries.setBorderColor(circularSeriesSettings.getBorderColor());
 		circularSeries.setBorderWidth(circularSeriesSettings.getBorderWidth());
 		circularSeries.setBorderStyle(circularSeriesSettings.getBorderStyle().value());
-		//
+
 		ISeriesSettings seriesSettingsHighlight = circularSeriesSettings.getSeriesSettingsHighlight();
 		if(seriesSettingsHighlight instanceof ICircularSeriesSettings circularSeriesSettingsHighlight) {
 			circularSeries.setSliceColorHighlight(circularSeriesSettingsHighlight.getSliceColor());
@@ -1299,7 +1299,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 				series[i] = 0;
 			}
 		}
-		//
+
 		return series;
 	}
 
@@ -1325,7 +1325,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		if(series != null) {
 			double[] xSeries = series.getXSeries();
 			double[] ySeries = series.getYSeries();
-			//
+
 			if(IExtendedChart.X_AXIS.equals(axisId)) {
 				series.setXSeries(multiplySeries(xSeries, factor));
 			} else if(IExtendedChart.Y_AXIS.equals(axisId)) {
@@ -1349,7 +1349,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		List<IAxisSettings> axisSettingsList = getAxisSettings(axisOrientation);
 		int size = axisSettingsList.size();
 		String[] items = new String[size];
-		//
+
 		for(int i = 0; i < size; i++) {
 			IAxisSettings axisSettings = axisSettingsList.get(i);
 			String label;
@@ -1360,7 +1360,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 			}
 			items[i] = label;
 		}
-		//
+
 		return items;
 	}
 
@@ -1368,14 +1368,14 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 
 		List<IAxisSettings> axisSettingsList = new ArrayList<>();
 		IAxis[] axes = getAxes(axisOrientation);
-		//
+
 		for(int i = 0; i < axes.length; i++) {
 			IAxisSettings axisSettings = getAxisSettings(axisOrientation, i);
 			if(axisSettings != null) {
 				axisSettingsList.add(axisSettings);
 			}
 		}
-		//
+
 		return axisSettingsList;
 	}
 
@@ -1383,7 +1383,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 
 		DecimalFormat decimalFormat;
 		IAxisSettings axisSettings = getAxisSettings(axisOrientation, id);
-		//
+
 		if(axisSettings != null) {
 			decimalFormat = axisSettings.getDecimalFormat();
 		} else {
@@ -1408,17 +1408,17 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 
 		IAxisScaleConverter axisScaleConverter = null;
 		IAxisSettings axisSettings = null;
-		//
+
 		if(axisOrientation.equals(IExtendedChart.X_AXIS)) {
 			axisSettings = getXAxisSettings(id);
 		} else {
 			axisSettings = getYAxisSettings(id);
 		}
-		//
+
 		if(axisSettings instanceof ISecondaryAxisSettings secondaryAxisSettings) {
 			axisScaleConverter = secondaryAxisSettings.getAxisScaleConverter();
 		}
-		//
+
 		return axisScaleConverter;
 	}
 
@@ -1508,10 +1508,10 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 	public void zoomX(IAxis xAxis, Event event) {
 
 		trackUndoSelection();
-		//
+
 		boolean isZoomReferenceX0 = getChartSettings().getRangeRestriction().isReferenceZoomZeroX();
 		double coordinateX = isZoomReferenceX0 ? 0.0d : xAxis.getDataCoordinate(event.x);
-		//
+
 		if(event.count > 0) {
 			xAxis.zoomIn(coordinateX);
 		} else {
@@ -1521,17 +1521,17 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 				xAxis.zoomOut(coordinateX);
 			}
 		}
-		//
+
 		trackRedoSelection();
 	}
 
 	public void zoomY(IAxis yAxis, Event event) {
 
 		trackUndoSelection();
-		//
+
 		boolean isZoomReferenceY0 = getChartSettings().getRangeRestriction().isReferenceZoomZeroY();
 		double coordinateY = isZoomReferenceY0 ? 0.0d : yAxis.getDataCoordinate(event.y);
-		//
+
 		if(event.count > 0) {
 			yAxis.zoomIn(coordinateY);
 		} else {
@@ -1541,7 +1541,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 				yAxis.zoomOut(coordinateY);
 			}
 		}
-		//
+
 		trackRedoSelection();
 	}
 
@@ -1565,7 +1565,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 				}
 			}
 		}
-		//
+
 		return selectedSeriesId;
 	}
 
@@ -1585,7 +1585,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		int minSelectedHeight;
 		int deltaWidth;
 		int deltaHeight;
-		//
+
 		Point point = getPlotArea().getSize();
 		if((getOrientation() == SWT.HORIZONTAL)) {
 			minSelectedWidth = point.x / MIN_SELECTION_PERCENTAGE;
@@ -1611,7 +1611,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 				handleUserSelectionXY(event);
 			}
 		}
-		//
+
 		userSelection.reset();
 		redraw();
 	}
@@ -1701,7 +1701,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 
 		IAxis xAxis = getAxisSet().getXAxis(ID_PRIMARY_X_AXIS);
 		IAxis yAxis = getAxisSet().getYAxis(ID_PRIMARY_Y_AXIS);
-		//
+
 		if((getOrientation() == SWT.HORIZONTAL)) {
 			setHorizontalRange(xAxis, yAxis, xStart, xStop, yStart, yStop);
 		} else {
@@ -1754,7 +1754,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 	private IAxis[] getAxes(String axisOrientation) {
 
 		IAxisSet axisSet = getAxisSet();
-		//
+
 		if(axisOrientation.equals(IExtendedChart.X_AXIS)) {
 			return axisSet.getXAxes();
 		} else {
@@ -1793,7 +1793,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		} else if(rangeRestriction.isRestrictSelectX() && rangeRestriction.isRestrictSelectY()) {
 			enableAction = true;
 		}
-		//
+
 		return enableAction;
 	}
 
@@ -1805,7 +1805,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 		} else if(rangeRestriction.isRestrictZoomX() && rangeRestriction.isRestrictZoomY()) {
 			enableAction = true;
 		}
-		//
+
 		return enableAction;
 	}
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ChartSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ChartSettings.java
@@ -60,13 +60,13 @@ import org.eclipse.swtchart.extensions.preferences.PreferenceConstants;
 public class ChartSettings implements IChartSettings {
 
 	private boolean bufferSelection = false;
-	//
+
 	private boolean enableRangeSelector = false;
 	private boolean showRangeSelectorInitially = true;
 	private Color colorHintRangeSelector;
 	private int rangeSelectorDefaultAxisX = 0;
 	private int rangeSelectorDefaultAxisY = 0;
-	//
+
 	private boolean verticalSliderVisible = false;
 	private boolean horizontalSliderVisible = true;
 	/*
@@ -78,23 +78,23 @@ public class ChartSettings implements IChartSettings {
 	private boolean titleVisible = false;
 	private Color titleColor;
 	private Font titleFont;
-	//
+
 	private int legendPosition = SWT.RIGHT;
 	private boolean legendVisible = false;
 	private boolean legendExtendedVisible = false;
-	//
+
 	private IPrimaryAxisSettings primaryAxisSettingsX = new PrimaryAxisSettings(BaseChart.DEFAULT_TITLE_X_AXIS);
 	private IPrimaryAxisSettings primaryAxisSettingsY = new PrimaryAxisSettings(BaseChart.DEFAULT_TITLE_Y_AXIS);
 	private List<ISecondaryAxisSettings> secondaryAxisSettingsListX = new ArrayList<>();
 	private List<ISecondaryAxisSettings> secondaryAxisSettingsListY = new ArrayList<>();
-	//
+
 	private int orientation = SWT.HORIZONTAL;
 	private Color background;
 	private Color backgroundChart;
 	private Color backgroundPlotArea;
 	private boolean enableCompress = true;
 	private RangeRestriction rangeRestriction = new RangeRestriction();
-	//
+
 	private boolean showPositionMarker = false;
 	private Color colorPositionMarker;
 	private boolean showPlotCenterMarker = false;
@@ -106,11 +106,11 @@ public class ChartSettings implements IChartSettings {
 	private Color colorAxisZeroMarker;
 	private boolean showSeriesLabelMarker = false;
 	private Color colorSeriesLabelMarker;
-	//
+
 	private boolean createMenu = true;
 	private Set<IChartMenuEntry> menuEntries;
 	private Set<IHandledEventProcessor> handledEventProcessors;
-	//
+
 	private boolean supportDataShift = false;
 	private boolean enableTooltips = false; // It was set to true before, but this leads to some conflicts when performing selection operations.
 	/*
@@ -121,25 +121,25 @@ public class ChartSettings implements IChartSettings {
 	public ChartSettings() {
 
 		Display display = Display.getDefault();
-		//
+
 		IPreferenceStore preferenceStore = ResourceSupport.getPreferenceStore();
 		if(preferenceStore != null) {
 			setBufferSelection(preferenceStore.getBoolean(PreferenceConstants.P_BUFFER_SELECTION));
 		}
-		//
+
 		colorHintRangeSelector = display.getSystemColor(SWT.COLOR_RED);
-		//
+
 		if(Display.isSystemDarkTheme()) {
 			titleColor = display.getSystemColor(SWT.COLOR_WHITE);
 		} else {
 			titleColor = display.getSystemColor(SWT.COLOR_BLACK);
 		}
 		titleFont = defaultFont;
-		//
+
 		rangeRestriction.setZeroX(true);
 		rangeRestriction.setZeroY(true);
 		rangeRestriction.setRestrictFrame(true);
-		//
+
 		if(Display.isSystemDarkTheme()) {
 			colorPositionMarker = display.getSystemColor(SWT.COLOR_GRAY);
 			colorPlotCenterMarker = display.getSystemColor(SWT.COLOR_GRAY);
@@ -675,7 +675,7 @@ public class ChartSettings implements IChartSettings {
 				return chartMenuEntry;
 			}
 		}
-		//
+
 		return null;
 	}
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/CustomSeriesLabelProvider.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/CustomSeriesLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,14 +21,14 @@ public class CustomSeriesLabelProvider extends ColumnLabelProvider implements IT
 
 	public static final int INDEX_ID = 0;
 	public static final int INDEX_DRAW = 1;
-	//
+
 	public static final String[] TITLES = { //
 			Messages.getString(Messages.ID), //
 			Messages.getString(Messages.DRAW), //
 			Messages.getString(Messages.LABEL), //
 			Messages.getString(Messages.DESCRIPTION), //
 	};
-	//
+
 	public static final int[] BOUNDS = { //
 			24, //
 			30, //
@@ -74,7 +74,7 @@ public class CustomSeriesLabelProvider extends ColumnLabelProvider implements IT
 					break;
 			}
 		}
-		//
+
 		return text;
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/CustomSeriesListUI.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/CustomSeriesListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -36,14 +36,14 @@ public class CustomSeriesListUI extends AbstractSeriesListUI {
 
 	private static final String[] TITLES = CustomSeriesLabelProvider.TITLES;
 	private static final int[] BOUNDS = CustomSeriesLabelProvider.BOUNDS;
-	//
+
 	private static final String COLUMN_DELIMITER = " "; //$NON-NLS-1$
-	//
+
 	private CustomSeriesLabelProvider labelProvider = new CustomSeriesLabelProvider();
 	private IContentProvider contentProvider = ArrayContentProvider.getInstance();
 	private CustomSeriesComparator comparator = new CustomSeriesComparator();
 	private List<TableViewerColumn> columns = new ArrayList<>();
-	//
+
 	private IPreferenceStore preferenceStore = ResourceSupport.getPreferenceStore();
 
 	public CustomSeriesListUI(Composite parent, int style) {
@@ -183,7 +183,7 @@ public class CustomSeriesListUI extends AbstractSeriesListUI {
 				e.printStackTrace();
 			}
 		}
-		//
+
 		return columns;
 	}
 
@@ -194,7 +194,7 @@ public class CustomSeriesListUI extends AbstractSeriesListUI {
 			builder.append(i);
 			builder.append(COLUMN_DELIMITER);
 		}
-		//
+
 		return builder.toString().trim();
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ExtendedLegendUI.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ExtendedLegendUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -69,14 +69,14 @@ import org.eclipse.swtchart.model.NodeDataModel;
 public class ExtendedLegendUI extends Composite {
 
 	private static final String MENU_TEXT = Messages.getString(Messages.SERIES_POPUP_MENU);
-	//
+
 	private AtomicReference<Button> sortControl = new AtomicReference<>();
 	private AtomicReference<InChartLegendUI> toolbarInChartLegend = new AtomicReference<>();
 	private AtomicReference<SeriesListUI> listControl = new AtomicReference<>();
-	//
+
 	private ScrollableChart scrollableChart;
 	private ISeriesSet seriesSet;
-	//
+
 	private IPreferenceStore preferenceStore = ResourceSupport.getPreferenceStore();
 
 	public ExtendedLegendUI(Composite parent, int style) {
@@ -101,11 +101,11 @@ public class ExtendedLegendUI extends Composite {
 	private void createControl() {
 
 		setLayout(new GridLayout(1, true));
-		//
+
 		createToolbarMain(this);
 		createToolbarInChartLegend(this);
 		createListSection(this);
-		//
+
 		initialize();
 	}
 
@@ -123,7 +123,7 @@ public class ExtendedLegendUI extends Composite {
 		gridData.horizontalAlignment = SWT.END;
 		composite.setLayoutData(gridData);
 		composite.setLayout(new GridLayout(6, false));
-		//
+
 		createButtonToggleVisibility(composite);
 		createButtonToggleLegend(composite);
 		createButtonToggleSort(composite);
@@ -136,7 +136,7 @@ public class ExtendedLegendUI extends Composite {
 
 		InChartLegendUI inChartLegendUI = new InChartLegendUI(parent, SWT.NONE);
 		inChartLegendUI.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-		//
+
 		toolbarInChartLegend.set(inChartLegendUI);
 	}
 
@@ -160,13 +160,13 @@ public class ExtendedLegendUI extends Composite {
 					seriesSettings.setVisibleInLegend(selection);
 					applySettings(baseChart, series, seriesSettings, false);
 				}
-				//
+
 				scrollableChart.redraw();
 				button.setImage(getVisibilityIcon(!visible));
 				listControl.get().refresh();
 			}
 		});
-		//
+
 		return button;
 	}
 
@@ -206,7 +206,7 @@ public class ExtendedLegendUI extends Composite {
 				}
 			}
 		});
-		//
+
 		return button;
 	}
 
@@ -228,7 +228,7 @@ public class ExtendedLegendUI extends Composite {
 				updateSeriesTableSortStatus();
 			}
 		});
-		//
+
 		sortControl.set(button);
 	}
 
@@ -258,7 +258,7 @@ public class ExtendedLegendUI extends Composite {
 				}
 			}
 		});
-		//
+
 		return button;
 	}
 
@@ -281,7 +281,7 @@ public class ExtendedLegendUI extends Composite {
 				}
 			}
 		});
-		//
+
 		return button;
 	}
 
@@ -310,7 +310,7 @@ public class ExtendedLegendUI extends Composite {
 				}
 			}
 		});
-		//
+
 		return button;
 	}
 
@@ -343,7 +343,7 @@ public class ExtendedLegendUI extends Composite {
 		menuManager.addMenuListener(new MapSettingsAction(seriesListUI, false));
 		Menu menu = menuManager.createContextMenu(table);
 		table.setMenu(menu);
-		//
+
 		setClipboardCommand(seriesListUI);
 		table.addMouseListener(new MouseAdapter() {
 
@@ -382,7 +382,7 @@ public class ExtendedLegendUI extends Composite {
 				}
 			}
 		});
-		//
+
 		listControl.set(seriesListUI);
 	}
 
@@ -483,7 +483,7 @@ public class ExtendedLegendUI extends Composite {
 				}
 			}
 		}
-		//
+
 		return seriesList;
 	}
 
@@ -498,7 +498,7 @@ public class ExtendedLegendUI extends Composite {
 				}
 			}
 		}
-		//
+
 		return circularSeries;
 	}
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/IKeyboardSupport.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/IKeyboardSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Lablicate GmbH.
+ * Copyright (c) 2019, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,7 +16,7 @@ public interface IKeyboardSupport extends IMouseSupport {
 
 	int EVENT_KEY_DOWN = 6;
 	int EVENT_KEY_UP = 7;
-	//
+
 	int KEY_CODE_UC_A = 65;
 	int KEY_CODE_UC_B = 66;
 	int KEY_CODE_UC_C = 67;
@@ -43,7 +43,7 @@ public interface IKeyboardSupport extends IMouseSupport {
 	int KEY_CODE_UC_X = 88;
 	int KEY_CODE_UC_Y = 89;
 	int KEY_CODE_UC_Z = 90;
-	//
+
 	int KEY_CODE_LC_A = 97;
 	int KEY_CODE_LC_B = 98;
 	int KEY_CODE_LC_C = 99;

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/IMouseSupport.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/IMouseSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Lablicate GmbH.
+ * Copyright (c) 2019, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,7 @@ public interface IMouseSupport {
 	int EVENT_MOUSE_DOWN = 3;
 	int EVENT_MOUSE_MOVE = 4;
 	int EVENT_MOUSE_UP = 5;
-	//
+
 	int MOUSE_BUTTON_LEFT = 1;
 	int MOUSE_BUTTON_MIDDLE = 2;
 	int MOUSE_BUTTON_RIGHT = 3; // Used by the menu

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/InChartLegendUI.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/InChartLegendUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -42,10 +42,10 @@ public class InChartLegendUI extends Composite {
 	private ScrollableChart scrollableChart;
 	private EmbeddedLegend embeddedLegend;
 	private boolean capturePosition = false;
-	//
+
 	private Text textX;
 	private Text textY;
-	//
+
 	private List<Control> controls = new ArrayList<>();
 	private IPreferenceStore preferenceStore = ResourceSupport.getPreferenceStore();
 
@@ -78,14 +78,14 @@ public class InChartLegendUI extends Composite {
 			 */
 			draw = !embeddedLegend.isDraw();
 			embeddedLegend.setDraw(draw);
-			//
+
 			if(scrollableChart != null) {
 				scrollableChart.redraw();
 			}
-			//
+
 			updateControls();
 		}
-		//
+
 		return draw;
 	}
 
@@ -96,7 +96,7 @@ public class InChartLegendUI extends Composite {
 		gridLayout.marginLeft = 0;
 		gridLayout.marginRight = 0;
 		setLayout(gridLayout);
-		//
+
 		createToolbarInChartLegend(this);
 		initialize();
 	}
@@ -112,7 +112,7 @@ public class InChartLegendUI extends Composite {
 		gridData.horizontalAlignment = SWT.END;
 		composite.setLayoutData(gridData);
 		composite.setLayout(new GridLayout(7, false));
-		//
+
 		add(createButtonMove(composite, ResourceSupport.ARROW_LEFT, Messages.getString(Messages.MOVE_LEGEND_LEFT)));
 		add(createButtonMove(composite, ResourceSupport.ARROW_UP, Messages.getString(Messages.MOVE_LEGEND_UP)));
 		add(createButtonMove(composite, ResourceSupport.ARROW_DOWN, Messages.getString(Messages.MOVE_LEGEND_DOWN)));
@@ -170,7 +170,7 @@ public class InChartLegendUI extends Composite {
 				}
 			}
 		});
-		//
+
 		return button;
 	}
 
@@ -183,10 +183,10 @@ public class InChartLegendUI extends Composite {
 		gridData.grabExcessHorizontalSpace = true;
 		gridData.minimumWidth = 60;
 		text.setLayoutData(gridData);
-		//
+
 		PositionValidator validator = new PositionValidator();
 		ControlDecoration controlDecoration = new ControlDecoration(text, SWT.LEFT | SWT.TOP);
-		//
+
 		text.addKeyListener(new KeyAdapter() {
 
 			@Override
@@ -201,7 +201,7 @@ public class InChartLegendUI extends Composite {
 				}
 			}
 		});
-		//
+
 		return text;
 	}
 
@@ -214,10 +214,10 @@ public class InChartLegendUI extends Composite {
 		gridData.grabExcessHorizontalSpace = true;
 		gridData.minimumWidth = 60;
 		text.setLayoutData(gridData);
-		//
+
 		PositionValidator validator = new PositionValidator();
 		ControlDecoration controlDecoration = new ControlDecoration(text, SWT.LEFT | SWT.TOP);
-		//
+
 		text.addKeyListener(new KeyAdapter() {
 
 			@Override
@@ -232,7 +232,7 @@ public class InChartLegendUI extends Composite {
 				}
 			}
 		});
-		//
+
 		return text;
 	}
 
@@ -250,7 +250,7 @@ public class InChartLegendUI extends Composite {
 				capturePosition = MessageDialog.openConfirm(e.display.getActiveShell(), Messages.getString(Messages.LEGEND_POSITION), Messages.getString(Messages.POSITION_USING_MOUSE));
 			}
 		});
-		//
+
 		return button;
 	}
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/MappedSeriesSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/MappedSeriesSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,7 @@ public class MappedSeriesSettings {
 	public static final String FILE_NAME = DESCRIPTION.replaceAll("\\s", "") + FILE_EXTENSION; //$NON-NLS-1$ //$NON-NLS-2$
 	public static final String FILTER_EXTENSION = "*" + FILE_EXTENSION; //$NON-NLS-1$
 	public static final String FILTER_NAME = DESCRIPTION + " (*" + FILE_EXTENSION + ")"; //$NON-NLS-1$ //$NON-NLS-2$
-	//
+
 	private MappingsType mappingsType = null;
 	private String identifier = ""; //$NON-NLS-1$
 	private ISeriesSettings seriesSettings = null;

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/MappingsDialog.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/MappingsDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -83,14 +83,14 @@ public class MappingsDialog extends Dialog {
 	protected Control createDialogArea(Composite parent) {
 
 		Composite composite = (Composite)super.createDialogArea(parent);
-		//
+
 		createToolbarMain(composite);
 		createMappingsList(composite);
 		createToolbarInfo(composite);
-		//
+
 		updateInput();
 		updateToolbarInfo(""); //$NON-NLS-1$
-		//
+
 		return composite;
 	}
 
@@ -99,7 +99,7 @@ public class MappingsDialog extends Dialog {
 		MappingsListUI mappingsListUI = new MappingsListUI(parent, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION | SWT.BORDER);
 		Table table = mappingsListUI.getTable();
 		table.setLayoutData(new GridData(GridData.FILL_BOTH));
-		//
+
 		table.addMouseListener(new MouseAdapter() {
 
 			@Override
@@ -138,7 +138,7 @@ public class MappingsDialog extends Dialog {
 				}
 			}
 		});
-		//
+
 		listControl.set(mappingsListUI);
 	}
 
@@ -149,7 +149,7 @@ public class MappingsDialog extends Dialog {
 		gridData.horizontalAlignment = SWT.END;
 		composite.setLayoutData(gridData);
 		composite.setLayout(new GridLayout(6, false));
-		//
+
 		createButtonAdd(composite);
 		createButtonDelete(composite);
 		createButtonDeleteAll(composite);
@@ -190,7 +190,7 @@ public class MappingsDialog extends Dialog {
 				}
 			}
 		});
-		//
+
 		return button;
 	}
 
@@ -218,13 +218,13 @@ public class MappingsDialog extends Dialog {
 							SeriesMapper.remove(mappingsKey);
 						}
 					}
-					//
+
 					updateInput();
 					updateToolbarInfo(Messages.getString(Messages.SELECTED_MAPPING_DELETED));
 				}
 			}
 		});
-		//
+
 		return button;
 	}
 
@@ -250,7 +250,7 @@ public class MappingsDialog extends Dialog {
 				}
 			}
 		});
-		//
+
 		return button;
 	}
 
@@ -279,13 +279,13 @@ public class MappingsDialog extends Dialog {
 					for(Map.Entry<MappingsKey, ISeriesSettings> mapping : mappings.entrySet()) {
 						SeriesMapper.put(mapping.getKey(), mapping.getValue());
 					}
-					//
+
 					updateInput();
 					updateToolbarInfo(Messages.getString(Messages.MAPPINGS_IMPORTED));
 				}
 			}
 		});
-		//
+
 		return button;
 	}
 
@@ -317,7 +317,7 @@ public class MappingsDialog extends Dialog {
 				}
 			}
 		});
-		//
+
 		return button;
 	}
 
@@ -336,7 +336,7 @@ public class MappingsDialog extends Dialog {
 				updateToolbarInfo(Messages.getString(Messages.MAPPINGS_SAVED));
 			}
 		});
-		//
+
 		return button;
 	}
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/MappingsKey.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/MappingsKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,7 +17,7 @@ import java.util.Objects;
 public class MappingsKey {
 
 	private static final String KEY_DELIMITER = "_"; //$NON-NLS-1$
-	//
+
 	private MappingsType mappingsType = MappingsType.NONE;
 	private String id = ""; //$NON-NLS-1$
 	private String key = ""; //$NON-NLS-1$

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/MappingsListUI.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/MappingsListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -34,12 +34,12 @@ public class MappingsListUI extends TableViewer {
 
 	private static final String[] TITLES = MappingsLabelProvider.TITLES;
 	private static final int[] BOUNDS = MappingsLabelProvider.BOUNDS;
-	//
+
 	private ILabelProvider labelProvider = new MappingsLabelProvider();
 	private IContentProvider contentProvider = ArrayContentProvider.getInstance();
 	private MappingsComparator comparator = new MappingsComparator();
 	private MappingsFilter filter = new MappingsFilter();
-	//
+
 	private List<TableViewerColumn> columns = new ArrayList<>();
 
 	public MappingsListUI(Composite parent, int style) {

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/MappingsSupport.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/MappingsSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Lablicate GmbH.
+ * Copyright (c) 2021, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -79,7 +79,7 @@ public class MappingsSupport {
 				seriesSettings = null;
 				break;
 		}
-		//
+
 		return seriesSettings;
 	}
 
@@ -114,7 +114,7 @@ public class MappingsSupport {
 				success = transfer(seriesSettingsSource.getSeriesSettingsHighlight(), seriesSettingsSink.getSeriesSettingsHighlight());
 			}
 		}
-		//
+
 		return success;
 	}
 
@@ -124,7 +124,7 @@ public class MappingsSupport {
 		if(seriesSettingsSource != null && seriesSettingsSink != null) {
 			success = seriesSettingsSource.transfer(seriesSettingsSink);
 		}
-		//
+
 		return success;
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/Messages.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWT Chart Project
+ * Copyright (c) 2020, 2025 SWT Chart Project
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,7 @@ public class Messages {
 
 	private static final String BUNDLE_NAME = "org.eclipse.swtchart.extensions.core.messages"; //$NON-NLS-1$
 	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
-	//
+
 	public static final String ADD_MAPPING = "ADD_MAPPING";
 	public static final String ALL_MAPPINGS_DELETED = "ALL_MAPPINGS_DELETED";
 	public static final String BAR = "BAR";

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/RangeRestriction.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/RangeRestriction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,14 +30,14 @@ public class RangeRestriction {
 	public static final int REFERENCE_ZOOM_ZERO_X = 1 << 8; // 0 is the base when doing an x zoomIn/zoomOut action.
 	public static final int RESTRICT_ZOOM_X = 1 << 9; // When doing a zoom action, only do the zoom on the x axis.
 	public static final int RESTRICT_ZOOM_Y = 1 << 10; // When doing a zoom action, only do the zoom on the y axis.
-	//
+
 	private ExtendType extendTypeX;
 	private double extendMinX;
 	private double extendMaxX;
 	private ExtendType extendTypeY;
 	private double extendMinY;
 	private double extendMaxY;
-	//
+
 	private int selection;
 
 	public RangeRestriction() {

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/RangeSelector.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/RangeSelector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,7 +32,7 @@ import org.eclipse.swtchart.extensions.widgets.ExtendedCombo;
 public class RangeSelector extends Composite {
 
 	private ScrollableChart scrollableChart;
-	//
+
 	private Text textStartX;
 	private Text textStopX;
 	private Combo comboScaleX;
@@ -82,17 +82,17 @@ public class RangeSelector extends Composite {
 	public void adjustRanges(boolean redraw) {
 
 		BaseChart baseChart = scrollableChart.getBaseChart();
-		//
+
 		int indexX = (comboScaleX.getSelectionIndex() >= 0) ? comboScaleX.getSelectionIndex() : BaseChart.ID_PRIMARY_X_AXIS;
 		int indexY = (comboScaleY.getSelectionIndex() >= 0) ? comboScaleY.getSelectionIndex() : BaseChart.ID_PRIMARY_Y_AXIS;
 		IAxis xAxis = baseChart.getAxisSet().getXAxis(indexX);
 		IAxis yAxis = baseChart.getAxisSet().getYAxis(indexY);
 		Range rangeX = xAxis.getRange();
 		Range rangeY = yAxis.getRange();
-		//
+
 		DecimalFormat decimalFormatX = baseChart.getDecimalFormat(IExtendedChart.X_AXIS, indexX);
 		DecimalFormat decimalFormatY = baseChart.getDecimalFormat(IExtendedChart.Y_AXIS, indexY);
-		//
+
 		if(rangeX != null && rangeY != null) {
 			/*
 			 * Update the text boxes.
@@ -113,15 +113,15 @@ public class RangeSelector extends Composite {
 	private void createControl() {
 
 		setLayout(new GridLayout(9, false));
-		//
+
 		textStartX = new Text(this, SWT.BORDER);
 		textStartX.setText(""); //$NON-NLS-1$
 		textStartX.setLayoutData(getTextGridData());
-		//
+
 		textStopX = new Text(this, SWT.BORDER);
 		textStopX.setText(""); //$NON-NLS-1$
 		textStopX.setLayoutData(getTextGridData());
-		//
+
 		comboScaleX = ExtendedCombo.create(this, SWT.READ_ONLY);
 		comboScaleX.setLayoutData(getComboGridData());
 		comboScaleX.addSelectionListener(new SelectionAdapter() {
@@ -140,15 +140,15 @@ public class RangeSelector extends Composite {
 				}
 			}
 		});
-		//
+
 		textStartY = new Text(this, SWT.BORDER);
 		textStartY.setText(""); //$NON-NLS-1$
 		textStartY.setLayoutData(getTextGridData());
-		//
+
 		textStopY = new Text(this, SWT.BORDER);
 		textStopY.setText(""); //$NON-NLS-1$
 		textStopY.setLayoutData(getTextGridData());
-		//
+
 		comboScaleY = ExtendedCombo.create(this, SWT.READ_ONLY);
 		comboScaleY.setLayoutData(getComboGridData());
 		comboScaleY.addSelectionListener(new SelectionAdapter() {
@@ -167,7 +167,7 @@ public class RangeSelector extends Composite {
 				}
 			}
 		});
-		//
+
 		Button buttonSetRange = new Button(this, SWT.PUSH);
 		buttonSetRange.setText(""); //$NON-NLS-1$
 		buttonSetRange.setImage(ResourceSupport.getImage(ResourceSupport.ICON_SET_RANGE));
@@ -185,7 +185,7 @@ public class RangeSelector extends Composite {
 				}
 			}
 		});
-		//
+
 		Button buttonResetRange = new Button(this, SWT.PUSH);
 		buttonResetRange.setText(""); //$NON-NLS-1$
 		buttonResetRange.setImage(ResourceSupport.getImage(ResourceSupport.ICON_RESET));
@@ -203,7 +203,7 @@ public class RangeSelector extends Composite {
 				}
 			}
 		});
-		//
+
 		Button buttonHide = new Button(this, SWT.PUSH);
 		buttonHide.setText(""); //$NON-NLS-1$
 		buttonHide.setImage(ResourceSupport.getImage(ResourceSupport.ICON_HIDE));
@@ -265,7 +265,7 @@ public class RangeSelector extends Composite {
 		BaseChart baseChart = scrollableChart.getBaseChart();
 		DecimalFormat decimalFormat;
 		int selectedAxis;
-		//
+
 		if(axis.equals(IExtendedChart.X_AXIS)) {
 			selectedAxis = comboScaleX.getSelectionIndex();
 			decimalFormat = baseChart.getDecimalFormat(IExtendedChart.X_AXIS, selectedAxis);
@@ -278,7 +278,7 @@ public class RangeSelector extends Composite {
 		 */
 		double valueStart;
 		double valueStop;
-		//
+
 		if(axis.equals(IExtendedChart.X_AXIS)) {
 			valueStart = decimalFormat.parse(textStartX.getText().trim()).doubleValue();
 			valueStop = decimalFormat.parse(textStopX.getText().trim()).doubleValue();
@@ -300,7 +300,7 @@ public class RangeSelector extends Composite {
 				range = new Range(valueStart, valueStop);
 			}
 		}
-		//
+
 		return range;
 	}
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ResourceSupport.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ResourceSupport.java
@@ -72,7 +72,7 @@ public class ResourceSupport extends Resources {
 	public static final String ICON_TRANSFER = "transfer.png"; // $NON-NLS-1$
 	public static final String ICON_SAVE = "save.gif"; // $NON-NLS-1$
 	public static final String ICON_ADD = "add.gif"; // $NON-NLS-1$
-	//
+
 	private static ResourceManager resourceManager = new LocalResourceManager(JFaceResources.getResources());
 	private static IPreferenceStore preferenceStore = null;
 	private static ImageRegistry imageRegistry = null;
@@ -136,7 +136,7 @@ public class ResourceSupport extends Resources {
 		if(imageRegistry == null) {
 			imageRegistry = initializeImageRegistry();
 		}
-		//
+
 		return resourceManager.createImageWithDefault(imageRegistry.getDescriptor(key));
 	}
 
@@ -159,7 +159,7 @@ public class ResourceSupport extends Resources {
 		} else {
 			imageRegistry = new ImageRegistry();
 		}
-		//
+
 		Set<String> imageSet = new HashSet<>();
 		imageSet.add(ICON_SET_RANGE);
 		imageSet.add(ICON_RESTRICT_RANGE);
@@ -199,11 +199,11 @@ public class ResourceSupport extends Resources {
 		imageSet.add(ICON_TRANSFER);
 		imageSet.add(ICON_SAVE);
 		imageSet.add(ICON_ADD);
-		//
+
 		for(String image : imageSet) {
 			imageRegistry.put(image, createImageDescriptor(image));
 		}
-		//
+
 		return imageRegistry;
 	}
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ScrollableChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ScrollableChart.java
@@ -97,10 +97,10 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 	 */
 	private static final String EXTENSION_POINT_MENU_ITEMS = "org.eclipse.swtchart.extensions.menuitems"; //$NON-NLS-1$
 	private static final String EXTENSION_POINT_MENU_ENTRY = "MenuEntry"; //$NON-NLS-1$
-	//
+
 	private Map<String, Set<IChartMenuEntry>> categoryMenuEntriesMap = new HashMap<>();
 	private Map<String, IChartMenuEntry> menuEntryMap = new HashMap<>();
-	//
+
 	private AtomicReference<Slider> sliderVerticalControl = new AtomicReference<>();
 	private AtomicReference<Slider> sliderHorizontalControl = new AtomicReference<>();
 	private RangeSelector rangeSelector;
@@ -109,7 +109,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 	private Composite compositeChart;
 	private BaseChart baseChart;
 	private ExtendedLegendUI extendedLegendUI;
-	//
+
 	private static final int MILLISECONDS_SHOW_RANGE_INFO_HINT = 1000;
 	private boolean showRangeSelectorHint = false;
 	private RangeHintPaintListener rangeHintPaintListener;
@@ -118,7 +118,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 	 * that are linked with the current editor.
 	 */
 	private List<ScrollableChart> linkedScrollableCharts = new ArrayList<>();
-	//
+
 	private PositionMarker positionMarker;
 	private PlotCenterMarker plotCenterMarker;
 	private LegendMarker legendMarker;
@@ -130,11 +130,11 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 	 */
 	private static final int HORIZONTAL_SCROLL_LENGTH = 1000000;
 	private static final int VERTICAL_SCROLL_LENGTH = 1000000;
-	//
+
 	private static final int MAX_WEIGHT = 1000;
 	private static final int MIN_WEIGHT = 0;
 	private static final int[] DEFAULT_WEIGHTS = new int[]{MAX_WEIGHT, MIN_WEIGHT};
-	//
+
 	private int[] currentWeights = new int[]{700, 300};
 	/*
 	 * The chart type is automatically set in most cases, see setChartType();
@@ -179,13 +179,13 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 		if(color == null) {
 			return;
 		}
-		//
+
 		super.setBackground(color);
 		sashForm.setBackground(color);
 		if(chartSection != null) {
 			chartSection.setBackground(color);
 		}
-		//
+
 		if(compositeChart != null) {
 			compositeChart.setBackground(color);
 		}
@@ -241,7 +241,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 					e.gc.setLineWidth(lineWidth);
 					Rectangle rectangleInfo = new Rectangle(0, 0, width, 26);
 					e.gc.drawRectangle(rectangleInfo);
-					//
+
 					ITitle title = getBaseChart().getTitle();
 					if(title.getForeground().equals(baseChart.getBackground())) {
 						/*
@@ -351,9 +351,9 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 		if(!wasSuspend) {
 			baseChart.suspendUpdate(true);
 		}
-		//
+
 		baseChart.deleteSeries();
-		//
+
 		if(!wasSuspend) {
 			baseChart.suspendUpdate(false);
 		}
@@ -463,12 +463,12 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 	public void handleMouseMoveEvent(Event event) {
 
 		baseChart.handleMouseMoveEvent(event);
-		//
+
 		if(positionMarker.isDraw()) {
 			positionMarker.setActualPosition(event.x, event.y);
 			redrawPlotArea();
 		}
-		//
+
 		if(legendMarker.isDraw()) {
 			legendMarker.setActualPosition(event.x, event.y);
 			redrawPlotArea();
@@ -605,7 +605,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 		double[] xSeries = seriesData.getXSeries();
 		double[] ySeries = seriesData.getYSeries();
 		int seriesLength = ySeries.length;
-		//
+
 		if(seriesLength > compressToLength) {
 			/*
 			 * Capture the compressed data.
@@ -618,7 +618,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 			 */
 			xSeriesCompressed.add(xSeries[0]);
 			ySeriesCompressed.add(ySeries[0]);
-			//
+
 			int moduloValue = seriesLength / compressToLength;
 			for(int i = 1; i < ySeries.length - 1; i++) {
 				/*
@@ -626,11 +626,11 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 				 */
 				double y = ySeries[i];
 				boolean addValue = false;
-				//
+
 				if(moduloValue > 0 && i % moduloValue == 0) {
 					addValue = true;
 				}
-				//
+
 				if(addValue) {
 					xSeriesCompressed.add(xSeries[i]);
 					ySeriesCompressed.add(y);
@@ -646,7 +646,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 			 */
 			double[] xCompressed = xSeriesCompressed.stream().mapToDouble(d -> d).toArray();
 			double[] yCompressed = ySeriesCompressed.stream().mapToDouble(d -> d).toArray();
-			//
+
 			return new SeriesData(xCompressed, yCompressed, seriesData.getId());
 		} else {
 			/*
@@ -731,18 +731,18 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 		IChartSettings chartSettings = baseChart.getChartSettings();
 		setSliderVisibility(chartSettings);
 		setRangeInfoVisibility(chartSettings);
-		//
+
 		ITitle title = baseChart.getTitle();
 		title.setText(chartSettings.getTitle());
 		title.setVisible(chartSettings.isTitleVisible());
 		title.setForeground(chartSettings.getTitleColor());
 		title.setFont(chartSettings.getTitleFont());
-		//
+
 		ILegend legend = baseChart.getLegend();
 		legend.setPosition(chartSettings.getLegendPosition());
 		legend.setVisible(chartSettings.isLegendVisible());
 		setLegendExtendedVisible(chartSettings.isLegendExtendedVisible());
-		//
+
 		setBackground(chartSettings.getBackground());
 		baseChart.setOrientation(chartSettings.getOrientation());
 		baseChart.setBackground(chartSettings.getBackgroundChart());
@@ -821,15 +821,15 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 
 		IPlotArea plotArea = baseChart.getPlotArea();
 		IChartSettings chartSettings = baseChart.getChartSettings();
-		//
+
 		if(positionMarker != null) {
 			plotArea.removeCustomPaintListener(positionMarker);
 		}
-		//
+
 		positionMarker = new PositionMarker(baseChart);
 		positionMarker.setForegroundColor(chartSettings.getColorPositionMarker());
 		plotArea.addCustomPaintListener(positionMarker);
-		//
+
 		if(chartSettings.isShowPositionMarker()) {
 			positionMarker.setDraw(true);
 		} else {
@@ -841,15 +841,15 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 
 		IPlotArea plotArea = baseChart.getPlotArea();
 		IChartSettings chartSettings = baseChart.getChartSettings();
-		//
+
 		if(plotCenterMarker != null) {
 			plotArea.removeCustomPaintListener(plotCenterMarker);
 		}
-		//
+
 		plotCenterMarker = new PlotCenterMarker(baseChart);
 		plotCenterMarker.setForegroundColor(chartSettings.getColorPlotCenterMarker());
 		plotArea.addCustomPaintListener(plotCenterMarker);
-		//
+
 		if(chartSettings.isShowPlotCenterMarker()) {
 			plotCenterMarker.setDraw(true);
 		} else {
@@ -861,15 +861,15 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 
 		IPlotArea plotArea = baseChart.getPlotArea();
 		IChartSettings chartSettings = baseChart.getChartSettings();
-		//
+
 		if(legendMarker != null) {
 			plotArea.removeCustomPaintListener(legendMarker);
 		}
-		//
+
 		legendMarker = new LegendMarker(baseChart);
 		legendMarker.setForegroundColor(chartSettings.getColorLegendMarker());
 		plotArea.addCustomPaintListener(legendMarker);
-		//
+
 		if(chartSettings.isShowLegendMarker()) {
 			legendMarker.setDraw(true);
 		} else {
@@ -881,15 +881,15 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 
 		IPlotArea plotArea = baseChart.getPlotArea();
 		IChartSettings chartSettings = baseChart.getChartSettings();
-		//
+
 		if(axisZeroMarker != null) {
 			plotArea.removeCustomPaintListener(axisZeroMarker);
 		}
-		//
+
 		axisZeroMarker = new AxisZeroMarker(baseChart);
 		axisZeroMarker.setForegroundColor(chartSettings.getColorAxisZeroMarker());
 		plotArea.addCustomPaintListener(axisZeroMarker);
-		//
+
 		if(chartSettings.isShowAxisZeroMarker()) {
 			axisZeroMarker.setDraw(true);
 		} else {
@@ -901,16 +901,16 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 
 		IPlotArea plotArea = baseChart.getPlotArea();
 		IChartSettings chartSettings = baseChart.getChartSettings();
-		//
+
 		if(seriesLabelMarker != null) {
 			plotArea.removeCustomPaintListener(seriesLabelMarker);
 		}
-		//
+
 		seriesLabelMarker = new SeriesLabelMarker(baseChart);
 		seriesLabelMarker.setForegroundColor(chartSettings.getColorSeriesLabelMarker());
 		seriesLabelMarker.setUseDescription(chartSettings.isUseSeriesLabelDescription());
 		plotArea.addCustomPaintListener(seriesLabelMarker);
-		//
+
 		if(chartSettings.isShowSeriesLabelMarker()) {
 			seriesLabelMarker.setDraw(true);
 		} else {
@@ -924,7 +924,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 		if(userRestrictionMarker != null) {
 			plotArea.removeCustomPaintListener(userRestrictionMarker);
 		}
-		//
+
 		userRestrictionMarker = new UserRestrictionMarker(baseChart);
 		plotArea.addCustomPaintListener(userRestrictionMarker);
 		userRestrictionMarker.setDraw(true);
@@ -1011,12 +1011,12 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 		GridData gridDataVertical = (GridData)sliderVertical.getLayoutData();
 		gridDataVertical.exclude = !chartSettings.isVerticalSliderVisible();
 		sliderVertical.setVisible(chartSettings.isVerticalSliderVisible());
-		//
+
 		Slider sliderHorizontal = sliderHorizontalControl.get();
 		GridData gridDataHorizontal = (GridData)sliderHorizontal.getLayoutData();
 		gridDataHorizontal.exclude = !chartSettings.isHorizontalSliderVisible();
 		sliderHorizontal.setVisible(chartSettings.isHorizontalSliderVisible());
-		//
+
 		layout(false);
 	}
 
@@ -1025,7 +1025,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 		if(rangeHintPaintListener != null) {
 			baseChart.removePaintListener(rangeHintPaintListener);
 		}
-		//
+
 		rangeHintPaintListener = new RangeHintPaintListener();
 		baseChart.addPaintListener(rangeHintPaintListener);
 	}
@@ -1059,24 +1059,24 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 
 		IAxis xAxis = baseChart.getAxisSet().getXAxis(BaseChart.ID_PRIMARY_X_AXIS);
 		IAxis yAxis = baseChart.getAxisSet().getYAxis(BaseChart.ID_PRIMARY_Y_AXIS);
-		//
+
 		if(xAxis != null && yAxis != null) {
 			/*
 			 * Relative binding to Integer.MAX_VALUE.
 			 */
 			int maxX = HORIZONTAL_SCROLL_LENGTH;
 			int maxY = VERTICAL_SCROLL_LENGTH;
-			//
+
 			double deltaX = baseChart.getMaxX() - baseChart.getMinX();
 			double deltaY = baseChart.getMaxY() - baseChart.getMinY();
-			//
+
 			if(deltaX > 0 && deltaY > 0) {
 				/*
 				 * Coefficients
 				 */
 				double coeffX = maxX / deltaX;
 				double coeffY = maxY / deltaY;
-				//
+
 				double minRangeX = (xAxis.getRange().lower - baseChart.getMinX()) * coeffX;
 				double maxRangeX = (xAxis.getRange().upper - baseChart.getMinX()) * coeffX;
 				double thumbRangeX = maxRangeX - minRangeX;
@@ -1086,7 +1086,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 				if(Double.isNaN(minRangeX) || Double.isNaN(maxRangeX)) {
 					return;
 				}
-				//
+
 				double maxRangeY = (baseChart.getMaxY() - yAxis.getRange().upper) * coeffY;
 				double minRangeY = (baseChart.getMaxY() - yAxis.getRange().lower) * coeffY;
 				double thumbRangeY = Math.abs(minRangeY - maxRangeY);
@@ -1101,18 +1101,18 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 				 */
 				int minSelectionX = (minRangeX < 0) ? 0 : (int)minRangeX;
 				int thumbSelectionX = (thumbRangeX < 1) ? 1 : (int)thumbRangeX;
-				//
+
 				int maxSelectionY = (maxRangeY < 0) ? 0 : (int)maxRangeY;
 				int thumbSelectionY = (thumbRangeY < 1) ? 1 : (int)thumbRangeY;
-				//
+
 				boolean isHorizontal = RangeSupport.isOrientationHorizontal(baseChart);
-				//
+
 				Slider sliderVertical = sliderVerticalControl.get();
 				sliderVertical.setMinimum(0);
 				sliderVertical.setMaximum((isHorizontal) ? maxY : maxX);
 				sliderVertical.setThumb((isHorizontal) ? thumbSelectionY : thumbSelectionX);
 				sliderVertical.setSelection((isHorizontal) ? maxSelectionY : minSelectionX);
-				//
+
 				Slider sliderHorizontal = sliderHorizontalControl.get();
 				sliderHorizontal.setMinimum(0);
 				sliderHorizontal.setMaximum((isHorizontal) ? maxX : maxY);
@@ -1216,21 +1216,21 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 	private void setAxisSettings(IAxis axis, IAxisSettings axisSettings) {
 
 		if(axis != null && axisSettings != null) {
-			//
+
 			String axisText = axisSettings.getTitle();
 			ITitle title = axis.getTitle();
 			title.setText(axisText);
 			title.setVisible(axisSettings.isVisible() && axisSettings.isTitleVisible());
 			title.setFont(axisSettings.getTitleFont());
-			//
+
 			IAxisTick axisTick = axis.getTick();
 			axisTick.setFormat(axisSettings.getDecimalFormat());
 			axisTick.setVisible(axisSettings.isVisible());
-			//
+
 			IGrid grid = axis.getGrid();
 			grid.setForeground(axisSettings.getGridColor());
 			grid.setStyle(axisSettings.getGridLineStyle());
-			//
+
 			axis.setPosition(axisSettings.getPosition());
 			/*
 			 * Set the color on demand.
@@ -1251,7 +1251,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 			styleRange.font = font;
 			styleRange.rise = getAxisExtraSpaceTitle(axis, axisSettings);
 			title.setStyleRanges(new StyleRange[]{styleRange});
-			//
+
 			axis.enableLogScale(axisSettings.isEnableLogScale());
 			axis.setLogScaleBase(axisSettings.getLogScaleBase());
 			axis.setReversed(axisSettings.isReversed());
@@ -1306,7 +1306,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 		if(orientation == SWT.VERTICAL) {
 			extraSpaceTitle *= -1;
 		}
-		//
+
 		return extraSpaceTitle;
 	}
 
@@ -1325,7 +1325,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 
 		this.setLayout(new FillLayout());
 		sashForm = new SashForm(this, SWT.HORIZONTAL);
-		//
+
 		chartSection = createChartSection(sashForm);
 		extendedLegendUI = createLegendSection(sashForm);
 		/*
@@ -1353,7 +1353,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 		createSliderVertical(composite);
 		compositeChart = createChart(composite);
 		createSliderHorizontal(composite);
-		//
+
 		return composite;
 	}
 
@@ -1362,7 +1362,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 		ExtendedLegendUI extendedLegendUI = new ExtendedLegendUI(parent, SWT.NONE);
 		extendedLegendUI.setScrollableChart(this);
 		extendedLegendUI.setLayout(new GridLayout(1, true));
-		//
+
 		return extendedLegendUI;
 	}
 
@@ -1372,7 +1372,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 		slider.setLayoutData(new GridData(GridData.FILL_VERTICAL));
 		slider.setOrientation(SWT.RIGHT_TO_LEFT); // See Bug #511257
 		slider.setVisible(true);
-		//
+
 		slider.addListener(SWT.Selection, new Listener() {
 
 			@Override
@@ -1380,7 +1380,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 
 				IAxis xAxis = baseChart.getAxisSet().getXAxis(BaseChart.ID_PRIMARY_X_AXIS);
 				IAxis yAxis = baseChart.getAxisSet().getYAxis(BaseChart.ID_PRIMARY_Y_AXIS);
-				//
+
 				if(xAxis != null && yAxis != null) {
 					Range range = RangeSupport.calculateShiftedRange(baseChart, yAxis.getRange(), slider.getSelection(), SWT.VERTICAL);
 					if(RangeSupport.applyVerticalSlide(baseChart, xAxis, yAxis, range, event)) {
@@ -1390,7 +1390,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 				}
 			}
 		});
-		//
+
 		sliderVerticalControl.set(slider);
 	}
 
@@ -1399,10 +1399,10 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 		Composite composite = new Composite(parent, SWT.NONE);
 		composite.setLayoutData(new GridData(GridData.FILL_BOTH));
 		composite.setLayout(new GridLayout(1, true));
-		//
+
 		createRangeInfoUI(composite);
 		createBaseChart(composite);
-		//
+
 		return composite;
 	}
 
@@ -1445,7 +1445,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 				int x = e.x;
 				int y = e.y;
 				Rectangle boundsPlotArea = baseChart.getPlotArea().getBounds();
-				//
+
 				if(x >= boundsPlotArea.x && x <= (boundsPlotArea.x + boundsPlotArea.width)) {
 					if(y >= boundsPlotArea.y + boundsPlotArea.height) {
 						/*
@@ -1493,7 +1493,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 		slider.setLayoutData(gridData);
 		slider.setOrientation(SWT.LEFT_TO_RIGHT);
 		slider.setVisible(true);
-		//
+
 		slider.addListener(SWT.Selection, new Listener() {
 
 			@Override
@@ -1501,7 +1501,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 
 				IAxis xAxis = baseChart.getAxisSet().getXAxis(BaseChart.ID_PRIMARY_X_AXIS);
 				IAxis yAxis = baseChart.getAxisSet().getYAxis(BaseChart.ID_PRIMARY_Y_AXIS);
-				//
+
 				if(xAxis != null && yAxis != null) {
 					Range range = RangeSupport.calculateShiftedRange(baseChart, xAxis.getRange(), slider.getSelection(), SWT.HORIZONTAL);
 					if(RangeSupport.applyHorizontalSlide(baseChart, xAxis, yAxis, range, event)) {
@@ -1511,7 +1511,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 				}
 			}
 		});
-		//
+
 		sliderHorizontalControl.set(slider);
 	}
 
@@ -1553,7 +1553,7 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 			}
 			plotArea.setMenu(menu);
 			createMenuItems(menu);
-			//
+
 			menu.addMenuListener(new MenuListener() {
 
 				@Override

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/SeriesData.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/SeriesData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -43,11 +43,11 @@ public class SeriesData implements ISeriesData {
 
 		assert (ySeries != null);
 		assert (id != null);
-		//
+
 		xSeries = new double[ySeries.length];
 		this.ySeries = ySeries;
 		this.id = id;
-		//
+
 		for(int i = 0; i < ySeries.length; i++) {
 			xSeries[i] = xStart++;
 		}
@@ -65,7 +65,7 @@ public class SeriesData implements ISeriesData {
 		assert (xSeries != null);
 		assert (ySeries != null);
 		assert (id != null);
-		//
+
 		this.xSeries = xSeries;
 		this.ySeries = ySeries;
 		this.id = id;

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/SeriesLabelProvider.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/SeriesLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,9 +30,9 @@ public class SeriesLabelProvider extends ColumnLabelProvider implements ITableLa
 	public static final int INDEX_VISIBLE_IN_LEGEND = 3;
 	public static final int INDEX_COLOR = 4;
 	public static final int INDEX_DESCRIPTION = 5;
-	//
+
 	private BaseChart baseChart = null;
-	//
+
 	public static final String[] TITLES = { //
 			Messages.getString(Messages.ID), //
 			Messages.getString(Messages.MAPPING_STATUS), //
@@ -41,7 +41,7 @@ public class SeriesLabelProvider extends ColumnLabelProvider implements ITableLa
 			Messages.getString(Messages.COLOR), //
 			Messages.getString(Messages.DESCRIPTION), //
 	};
-	//
+
 	public static final int[] BOUNDS = { //
 			24, //
 			30, //
@@ -60,7 +60,7 @@ public class SeriesLabelProvider extends ColumnLabelProvider implements ITableLa
 	public static Color getColor(ISeriesSettings seriesSettings) {
 
 		Color color = null;
-		//
+
 		if(seriesSettings instanceof IBarSeriesSettings barSeriesSettings) {
 			color = barSeriesSettings.getBarColor();
 		} else if(seriesSettings instanceof ILineSeriesSettings lineSeriesSettings) {
@@ -70,7 +70,7 @@ public class SeriesLabelProvider extends ColumnLabelProvider implements ITableLa
 		} else if(seriesSettings instanceof ICircularSeriesSettings circularSeriesSettings) {
 			color = circularSeriesSettings.getSliceColor();
 		}
-		//
+
 		return color;
 	}
 
@@ -112,7 +112,7 @@ public class SeriesLabelProvider extends ColumnLabelProvider implements ITableLa
 			Image checked = ResourceSupport.getImage(ResourceSupport.ICON_CHECKED);
 			Image unchecked = ResourceSupport.getImage(ResourceSupport.ICON_UNCHECKED);
 			Image mappings = ResourceSupport.getImage(ResourceSupport.ICON_MAPPINGS);
-			//
+
 			if(columnIndex == INDEX_ID) {
 				return seriesMarker;
 			} else if(columnIndex == INDEX_VISIBLE) {

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/SeriesListUI.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/SeriesListUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -41,15 +41,15 @@ public class SeriesListUI extends AbstractSeriesListUI {
 
 	private static final String[] TITLES = SeriesLabelProvider.TITLES;
 	private static final int[] BOUNDS = SeriesLabelProvider.BOUNDS;
-	//
+
 	private static final String COLUMN_DELIMITER = " "; //$NON-NLS-1$
-	//
+
 	private SeriesLabelProvider labelProvider = new SeriesLabelProvider();
 	private IContentProvider contentProvider = new SeriesContentProvider();
 	private SeriesComparator comparator = new SeriesComparator();
 	private SeriesFilter filter = new SeriesFilter();
 	private List<TableViewerColumn> columns = new ArrayList<>();
-	//
+
 	private IPreferenceStore preferenceStore = ResourceSupport.getPreferenceStore();
 	private BaseChart baseChart = null;
 
@@ -234,7 +234,7 @@ public class SeriesListUI extends AbstractSeriesListUI {
 				e.printStackTrace();
 			}
 		}
-		//
+
 		return columns;
 	}
 
@@ -250,7 +250,7 @@ public class SeriesListUI extends AbstractSeriesListUI {
 			builder.append(i);
 			builder.append(COLUMN_DELIMITER);
 		}
-		//
+
 		return builder.toString().trim();
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/SeriesMapper.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/SeriesMapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -65,7 +65,7 @@ public class SeriesMapper {
 	public static ISeriesSettings get(ISeries<?> series, BaseChart baseChart) {
 
 		ISeriesSettings seriesSettingsMapped = null;
-		//
+
 		if(baseChart != null) {
 			String id = series.getId();
 			ISeriesSettings seriesSettings = baseChart.getSeriesSettings(id);
@@ -84,7 +84,7 @@ public class SeriesMapper {
 				}
 			}
 		}
-		//
+
 		return seriesSettingsMapped;
 	}
 
@@ -100,7 +100,7 @@ public class SeriesMapper {
 		String id = series.getId();
 		ISeriesSettings seriesSettings = baseChart.getSeriesSettings(id);
 		ISeriesSettings seriesSettingsCopy = MappingsSupport.copySettings(seriesSettings);
-		//
+
 		if(seriesSettingsCopy != null) {
 			MappingsType mappingsType = MappingsSupport.getMappingsType(seriesSettings);
 			if(isValidMappingsType(mappingsType)) {
@@ -141,7 +141,7 @@ public class SeriesMapper {
 				mappings.add(new MappedSeriesSettings(mappingsType, id, seriesSettings));
 			}
 		}
-		//
+
 		return mappings;
 	}
 
@@ -200,7 +200,7 @@ public class SeriesMapper {
 				// Not a valid regular expression.
 			}
 		}
-		//
+
 		return null;
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/UserSelection.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/UserSelection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,7 @@ package org.eclipse.swtchart.extensions.core;
 public class UserSelection {
 
 	private static final int NO_SELECTION = 0;
-	//
+
 	private int startX = NO_SELECTION;
 	private int startY = NO_SELECTION;
 	private int stopX = NO_SELECTION;
@@ -96,7 +96,7 @@ public class UserSelection {
 	public void setStartCoordinate(int startX, int startY) {
 
 		active = false;
-		//
+
 		this.startX = startX;
 		this.startY = startY;
 	}
@@ -110,7 +110,7 @@ public class UserSelection {
 	public void setStopCoordinate(int stopX, int stopY) {
 
 		active = true;
-		//
+
 		this.stopX = stopX;
 		this.stopY = stopY;
 	}
@@ -118,7 +118,7 @@ public class UserSelection {
 	public void reset() {
 
 		active = false;
-		//
+
 		startX = NO_SELECTION;
 		stopX = NO_SELECTION;
 		startY = NO_SELECTION;

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/dialogs/AbstractPointSeriesSettingsDialog.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/dialogs/AbstractPointSeriesSettingsDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Lablicate GmbH.
+ * Copyright (c) 2022, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -62,7 +62,7 @@ public abstract class AbstractPointSeriesSettingsDialog<T extends IPointSeriesSe
 
 		String title = "Symbol Type";
 		createSectionLabel(parent, title);
-		//
+
 		ComboViewer comboViewer = createComboViewer(parent, title, PlotSymbolType.values(), PlotSymbolType.NONE, getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<Object>() {
 
 			@Override
@@ -76,7 +76,7 @@ public abstract class AbstractPointSeriesSettingsDialog<T extends IPointSeriesSe
 				}
 			}
 		});
-		//
+
 		symbolTypeControl.set(comboViewer);
 	}
 
@@ -84,7 +84,7 @@ public abstract class AbstractPointSeriesSettingsDialog<T extends IPointSeriesSe
 
 		String title = "Symbol Size";
 		createSectionLabel(parent, title);
-		//
+
 		Spinner spinner = createSpinner(parent, title, 1, 50, 1, getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<Integer>() {
 
 			@Override
@@ -96,7 +96,7 @@ public abstract class AbstractPointSeriesSettingsDialog<T extends IPointSeriesSe
 				}
 			}
 		});
-		//
+
 		symbolSizeControl.set(spinner);
 	}
 
@@ -104,7 +104,7 @@ public abstract class AbstractPointSeriesSettingsDialog<T extends IPointSeriesSe
 
 		String title = "Symbol Color";
 		createSectionLabel(parent, title);
-		//
+
 		Text text = createColorChoser(parent, title, getGridData(GridData.FILL_HORIZONTAL, 1), new Consumer<Color>() {
 
 			@Override
@@ -116,7 +116,7 @@ public abstract class AbstractPointSeriesSettingsDialog<T extends IPointSeriesSe
 				}
 			}
 		});
-		//
+
 		symbolColorControl.set(text);
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/dialogs/AbstractSeriesSettingsDialog.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/dialogs/AbstractSeriesSettingsDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Lablicate GmbH.
+ * Copyright (c) 2022, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -53,7 +53,7 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 	private AtomicReference<Text> descriptionControl = new AtomicReference<>();
 	private AtomicReference<Button> visibleControl = new AtomicReference<>();
 	private AtomicReference<Button> visibleInLegendControl = new AtomicReference<>();
-	//
+
 	private String title = "";
 	private T settingsNormal = null;
 	private T settingsHighlight = null;
@@ -63,11 +63,11 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 	public AbstractSeriesSettingsDialog(Shell parentShell, T settings) {
 
 		super(parentShell);
-		//
+
 		this.settingsNormal = settings;
 		this.settingsHighlight = (T)settings.getSeriesSettingsHighlight();
 		this.settingsSelected = this.settingsNormal;
-		//
+
 		String type;
 		if(settings instanceof IBarSeriesSettings) {
 			type = "Bar";
@@ -80,7 +80,7 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 		} else {
 			type = "";
 		}
-		//
+
 		this.title = (type + " Series Settings").trim();
 	}
 
@@ -102,14 +102,14 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 	protected Control createDialogArea(Composite parent) {
 
 		Composite container = (Composite)super.createDialogArea(parent);
-		//
+
 		Composite composite = new Composite(container, SWT.NONE);
 		composite.setLayoutData(getGridData(GridData.FILL_BOTH, 1));
 		GridLayout layout = new GridLayout(3, false);
 		composite.setLayout(layout);
-		//
+
 		createInputSection(composite);
-		//
+
 		initialize();
 		return container;
 	}
@@ -134,7 +134,7 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 		Label label = new Label(parent, SWT.NONE);
 		label.setText(title);
 		label.setLayoutData(getGridData(GridData.FILL_HORIZONTAL, 1));
-		//
+
 		return label;
 	}
 
@@ -151,11 +151,11 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 				if(element instanceof IEnumLabel) {
 					return ((IEnumLabel)element).label();
 				}
-				//
+
 				return null;
 			}
 		});
-		//
+
 		Combo combo = comboViewer.getCombo();
 		combo.setToolTipText(tooltip);
 		combo.setLayoutData(gridData);
@@ -167,11 +167,11 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 				consumer.accept(comboViewer.getStructuredSelection().getFirstElement());
 			}
 		});
-		//
+
 		if(selection != null) {
 			comboViewer.setSelection(new StructuredSelection(selection));
 		}
-		//
+
 		return comboViewer;
 	}
 
@@ -189,7 +189,7 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 				consumer.accept(text.getText().trim());
 			}
 		});
-		//
+
 		return text;
 	}
 
@@ -199,7 +199,7 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 		text.setText("");
 		text.setToolTipText("");
 		text.setLayoutData(getGridData(GridData.FILL_HORIZONTAL, 1));
-		//
+
 		Button button = new Button(parent, SWT.PUSH);
 		button.setText("...");
 		button.setToolTipText("Select the " + title);
@@ -218,7 +218,7 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 				}
 			}
 		});
-		//
+
 		return text;
 	}
 
@@ -228,7 +228,7 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 		button.setText(title);
 		button.setToolTipText(tooltip);
 		button.setLayoutData(gridData);
-		//
+
 		button.addSelectionListener(new SelectionAdapter() {
 
 			@Override
@@ -237,7 +237,7 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 				consumer.accept(button.getSelection());
 			}
 		});
-		//
+
 		return button;
 	}
 
@@ -257,7 +257,7 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 				consumer.accept(spinner.getSelection());
 			}
 		});
-		//
+
 		return spinner;
 	}
 
@@ -265,7 +265,7 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 
 		GridData gridData = new GridData(style);
 		gridData.horizontalSpan = horizontalSpan;
-		//
+
 		return gridData;
 	}
 
@@ -273,7 +273,7 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 
 		String title = "Setting Status";
 		createSectionLabel(parent, title);
-		//
+
 		ComboViewer comboViewer = createComboViewer(parent, title, SettingsStatus.values(), SettingsStatus.NORMAL, getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<Object>() {
 
 			@Override
@@ -292,7 +292,7 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 				}
 			}
 		});
-		//
+
 		settingStatusControl.set(comboViewer);
 	}
 
@@ -300,7 +300,7 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 
 		String title = "Description";
 		createSectionLabel(parent, title);
-		//
+
 		Text text = createText(parent, "", "The series description can be modified here.", getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<String>() {
 
 			@Override
@@ -311,14 +311,14 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 				}
 			}
 		});
-		//
+
 		descriptionControl.set(text);
 	}
 
 	private void createVisibleSection(Composite parent) {
 
 		createSectionLabel(parent, "");
-		//
+
 		Button button = createCheckBox(parent, "Visible", "Show or hide the series in the chart.", getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<Boolean>() {
 
 			@Override
@@ -329,14 +329,14 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 				}
 			}
 		});
-		//
+
 		visibleControl.set(button);
 	}
 
 	private void createVisibleInLegendSection(Composite parent) {
 
 		createSectionLabel(parent, "");
-		//
+
 		Button button = createCheckBox(parent, "Visible in Legend", "Show or hide the series in the chart legend.", getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<Boolean>() {
 
 			@Override
@@ -347,7 +347,7 @@ public abstract class AbstractSeriesSettingsDialog<T extends ISeriesSettings> ex
 				}
 			}
 		});
-		//
+
 		visibleInLegendControl.set(button);
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/dialogs/BarSeriesSettingsDialog.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/dialogs/BarSeriesSettingsDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Lablicate GmbH.
+ * Copyright (c) 2022, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -72,7 +72,7 @@ public class BarSeriesSettingsDialog extends AbstractSeriesSettingsDialog<IBarSe
 
 		String title = "Bar Color";
 		createSectionLabel(parent, title);
-		//
+
 		Text text = createColorChoser(parent, title, getGridData(GridData.FILL_HORIZONTAL, 1), new Consumer<Color>() {
 
 			@Override
@@ -84,14 +84,14 @@ public class BarSeriesSettingsDialog extends AbstractSeriesSettingsDialog<IBarSe
 				}
 			}
 		});
-		//
+
 		barColorControl.set(text);
 	}
 
 	private void createBarOverlaySection(Composite parent) {
 
 		createSectionLabel(parent, "");
-		//
+
 		Button button = createCheckBox(parent, "Bar Overlay", "Enable or disable to display the bar overlay.", getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<Boolean>() {
 
 			@Override
@@ -103,7 +103,7 @@ public class BarSeriesSettingsDialog extends AbstractSeriesSettingsDialog<IBarSe
 				}
 			}
 		});
-		//
+
 		barOverlayControl.set(button);
 	}
 
@@ -111,7 +111,7 @@ public class BarSeriesSettingsDialog extends AbstractSeriesSettingsDialog<IBarSe
 
 		String title = "Bar Padding";
 		createSectionLabel(parent, title);
-		//
+
 		Spinner spinner = createSpinner(parent, title, 1, 50, 1, getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<Integer>() {
 
 			@Override
@@ -123,7 +123,7 @@ public class BarSeriesSettingsDialog extends AbstractSeriesSettingsDialog<IBarSe
 				}
 			}
 		});
-		//
+
 		barPaddingControl.set(spinner);
 	}
 
@@ -131,7 +131,7 @@ public class BarSeriesSettingsDialog extends AbstractSeriesSettingsDialog<IBarSe
 
 		String title = "Bar Width";
 		createSectionLabel(parent, title);
-		//
+
 		Spinner spinner = createSpinner(parent, title, 1, 50, 1, getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<Integer>() {
 
 			@Override
@@ -143,7 +143,7 @@ public class BarSeriesSettingsDialog extends AbstractSeriesSettingsDialog<IBarSe
 				}
 			}
 		});
-		//
+
 		barWidthControl.set(spinner);
 	}
 
@@ -151,7 +151,7 @@ public class BarSeriesSettingsDialog extends AbstractSeriesSettingsDialog<IBarSe
 
 		String title = "Bar Width Style";
 		createSectionLabel(parent, title);
-		//
+
 		ComboViewer comboViewer = createComboViewer(parent, title, BarWidthStyle.values(), BarWidthStyle.STRETCHED, getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<Object>() {
 
 			@Override
@@ -165,14 +165,14 @@ public class BarSeriesSettingsDialog extends AbstractSeriesSettingsDialog<IBarSe
 				}
 			}
 		});
-		//
+
 		barWidthStyleControl.set(comboViewer);
 	}
 
 	private void createEnableStackSection(Composite parent) {
 
 		createSectionLabel(parent, "");
-		//
+
 		Button button = createCheckBox(parent, "Enable Stack", "Enable or disable the stack modus.", getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<Boolean>() {
 
 			@Override
@@ -184,7 +184,7 @@ public class BarSeriesSettingsDialog extends AbstractSeriesSettingsDialog<IBarSe
 				}
 			}
 		});
-		//
+
 		enableStackControl.set(button);
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/dialogs/ChartRangeDialog.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/dialogs/ChartRangeDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -37,14 +37,14 @@ import org.eclipse.swtchart.extensions.widgets.ExtendedCombo;
 public class ChartRangeDialog extends TitleAreaDialog {
 
 	private ScrollableChart scrollableChart;
-	//
+
 	private Text textStartX;
 	private Text textStopX;
 	private Combo comboScaleX;
 	private Text textStartY;
 	private Text textStopY;
 	private Combo comboScaleY;
-	//
+
 	private ChartRangeValues chartRangeValues = new ChartRangeValues();
 
 	public ChartRangeDialog(Shell parent, ScrollableChart scrollableChart) {
@@ -70,17 +70,17 @@ public class ChartRangeDialog extends TitleAreaDialog {
 	protected Control createDialogArea(Composite parent) {
 
 		Composite container = (Composite)super.createDialogArea(parent);
-		//
+
 		Composite composite = new Composite(container, SWT.NONE);
 		composite.setLayoutData(new GridData(GridData.FILL_BOTH));
 		GridLayout layout = new GridLayout(3, false);
 		composite.setLayout(layout);
-		//
+
 		createSectionAxisX(composite);
 		createSectionAxisY(composite);
-		//
+
 		initialize();
-		//
+
 		return container;
 	}
 
@@ -101,11 +101,11 @@ public class ChartRangeDialog extends TitleAreaDialog {
 		textStartX = new Text(parent, SWT.BORDER);
 		textStartX.setText(""); //$NON-NLS-1$
 		textStartX.setLayoutData(getTextGridData());
-		//
+
 		textStopX = new Text(parent, SWT.BORDER);
 		textStopX.setText(""); //$NON-NLS-1$
 		textStopX.setLayoutData(getTextGridData());
-		//
+
 		comboScaleX = ExtendedCombo.create(parent, SWT.READ_ONLY);
 		comboScaleX.setLayoutData(getComboGridData());
 		comboScaleX.addSelectionListener(new SelectionAdapter() {
@@ -131,11 +131,11 @@ public class ChartRangeDialog extends TitleAreaDialog {
 		textStartY = new Text(parent, SWT.BORDER);
 		textStartY.setText(""); //$NON-NLS-1$
 		textStartY.setLayoutData(getTextGridData());
-		//
+
 		textStopY = new Text(parent, SWT.BORDER);
 		textStopY.setText(""); //$NON-NLS-1$
 		textStopY.setLayoutData(getTextGridData());
-		//
+
 		comboScaleY = ExtendedCombo.create(parent, SWT.READ_ONLY);
 		comboScaleY.setLayoutData(getComboGridData());
 		comboScaleY.addSelectionListener(new SelectionAdapter() {
@@ -209,14 +209,14 @@ public class ChartRangeDialog extends TitleAreaDialog {
 	private void setCurrentValues() {
 
 		BaseChart baseChart = scrollableChart.getBaseChart();
-		//
+
 		int indexX = (comboScaleX.getSelectionIndex() >= 0) ? comboScaleX.getSelectionIndex() : BaseChart.ID_PRIMARY_X_AXIS;
 		int indexY = (comboScaleY.getSelectionIndex() >= 0) ? comboScaleY.getSelectionIndex() : BaseChart.ID_PRIMARY_Y_AXIS;
 		IAxis xAxis = baseChart.getAxisSet().getXAxis(indexX);
 		IAxis yAxis = baseChart.getAxisSet().getYAxis(indexY);
 		Range rangeX = xAxis.getRange();
 		Range rangeY = yAxis.getRange();
-		//
+
 		DecimalFormat decimalFormatX = baseChart.getDecimalFormat(IExtendedChart.X_AXIS, indexX);
 		DecimalFormat decimalFormatY = baseChart.getDecimalFormat(IExtendedChart.Y_AXIS, indexY);
 		/*

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/dialogs/CircularSeriesSettingsDialog.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/dialogs/CircularSeriesSettingsDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Lablicate GmbH.
+ * Copyright (c) 2022, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -65,7 +65,7 @@ public class CircularSeriesSettingsDialog extends AbstractSeriesSettingsDialog<I
 
 		String title = "Slice Color";
 		createSectionLabel(parent, title);
-		//
+
 		Text text = createColorChoser(parent, title, getGridData(GridData.FILL_HORIZONTAL, 1), new Consumer<Color>() {
 
 			@Override
@@ -77,7 +77,7 @@ public class CircularSeriesSettingsDialog extends AbstractSeriesSettingsDialog<I
 				}
 			}
 		});
-		//
+
 		sliceColorControl.set(text);
 	}
 
@@ -85,7 +85,7 @@ public class CircularSeriesSettingsDialog extends AbstractSeriesSettingsDialog<I
 
 		String title = "Border Color";
 		createSectionLabel(parent, title);
-		//
+
 		Text text = createColorChoser(parent, title, getGridData(GridData.FILL_HORIZONTAL, 1), new Consumer<Color>() {
 
 			@Override
@@ -97,7 +97,7 @@ public class CircularSeriesSettingsDialog extends AbstractSeriesSettingsDialog<I
 				}
 			}
 		});
-		//
+
 		borderColorControl.set(text);
 	}
 
@@ -105,7 +105,7 @@ public class CircularSeriesSettingsDialog extends AbstractSeriesSettingsDialog<I
 
 		String title = "Border Width";
 		createSectionLabel(parent, title);
-		//
+
 		Spinner spinner = createSpinner(parent, title, 1, 50, 1, getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<Integer>() {
 
 			@Override
@@ -117,7 +117,7 @@ public class CircularSeriesSettingsDialog extends AbstractSeriesSettingsDialog<I
 				}
 			}
 		});
-		//
+
 		borderWidthControl.set(spinner);
 	}
 
@@ -125,7 +125,7 @@ public class CircularSeriesSettingsDialog extends AbstractSeriesSettingsDialog<I
 
 		String title = "Border Style";
 		createSectionLabel(parent, title);
-		//
+
 		ComboViewer comboViewer = createComboViewer(parent, title, LineStyle.values(), LineStyle.NONE, getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<Object>() {
 
 			@Override
@@ -139,7 +139,7 @@ public class CircularSeriesSettingsDialog extends AbstractSeriesSettingsDialog<I
 				}
 			}
 		});
-		//
+
 		borderStyleControl.set(comboViewer);
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/dialogs/CreateSeriesMappingDialog.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/dialogs/CreateSeriesMappingDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -74,16 +74,16 @@ public class CreateSeriesMappingDialog extends TitleAreaDialog {
 	protected Control createDialogArea(Composite parent) {
 
 		Composite container = (Composite)super.createDialogArea(parent);
-		//
+
 		Composite composite = new Composite(container, SWT.NONE);
 		composite.setLayoutData(new GridData(GridData.FILL_BOTH));
 		GridLayout layout = new GridLayout(2, false);
 		composite.setLayout(layout);
-		//
+
 		createSectionDescription(composite);
 		createSectionType(composite);
 		createSectionRegex(composite);
-		//
+
 		initialize();
 		return container;
 	}
@@ -125,7 +125,7 @@ public class CreateSeriesMappingDialog extends TitleAreaDialog {
 				validate();
 			}
 		});
-		//
+
 		return text;
 	}
 
@@ -142,11 +142,11 @@ public class CreateSeriesMappingDialog extends TitleAreaDialog {
 				if(element instanceof IEnumLabel) {
 					return ((IEnumLabel)element).label();
 				}
-				//
+
 				return null;
 			}
 		});
-		//
+
 		Combo combo = comboViewer.getCombo();
 		combo.setToolTipText("Select the mappings type.");
 		combo.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
@@ -162,9 +162,9 @@ public class CreateSeriesMappingDialog extends TitleAreaDialog {
 				validate();
 			}
 		});
-		//
+
 		comboViewer.setSelection(new StructuredSelection(mappingsType));
-		//
+
 		return comboViewer;
 	}
 
@@ -182,7 +182,7 @@ public class CreateSeriesMappingDialog extends TitleAreaDialog {
 				validate();
 			}
 		});
-		//
+
 		return text;
 	}
 
@@ -198,7 +198,7 @@ public class CreateSeriesMappingDialog extends TitleAreaDialog {
 		if(MappingsType.NONE.equals(mappingsType)) {
 			message = "Please select a valid mappings type.";
 		}
-		//
+
 		if(regularExpression == null || regularExpression.isEmpty()) {
 			message = "Please type in a regular expression.";
 		} else {
@@ -208,7 +208,7 @@ public class CreateSeriesMappingDialog extends TitleAreaDialog {
 				message = "The regular expression is not valid.";
 			}
 		}
-		//
+
 		setErrorMessage(message);
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/dialogs/LineSeriesSettingsDialog.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/dialogs/LineSeriesSettingsDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 Lablicate GmbH.
+ * Copyright (c) 2022, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -76,7 +76,7 @@ public class LineSeriesSettingsDialog extends AbstractPointSeriesSettingsDialog<
 
 		String title = "Line Style";
 		createSectionLabel(parent, title);
-		//
+
 		ComboViewer comboViewer = createComboViewer(parent, title, LineStyle.values(), LineStyle.NONE, getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<Object>() {
 
 			@Override
@@ -90,7 +90,7 @@ public class LineSeriesSettingsDialog extends AbstractPointSeriesSettingsDialog<
 				}
 			}
 		});
-		//
+
 		lineStyleControl.set(comboViewer);
 	}
 
@@ -98,7 +98,7 @@ public class LineSeriesSettingsDialog extends AbstractPointSeriesSettingsDialog<
 
 		String title = "Line Width";
 		createSectionLabel(parent, title);
-		//
+
 		Spinner spinner = createSpinner(parent, title, 1, 50, 1, getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<Integer>() {
 
 			@Override
@@ -110,7 +110,7 @@ public class LineSeriesSettingsDialog extends AbstractPointSeriesSettingsDialog<
 				}
 			}
 		});
-		//
+
 		lineWidthControl.set(spinner);
 	}
 
@@ -118,7 +118,7 @@ public class LineSeriesSettingsDialog extends AbstractPointSeriesSettingsDialog<
 
 		String title = "Line Color";
 		createSectionLabel(parent, title);
-		//
+
 		Text text = createColorChoser(parent, title, getGridData(GridData.FILL_HORIZONTAL, 1), new Consumer<Color>() {
 
 			@Override
@@ -130,7 +130,7 @@ public class LineSeriesSettingsDialog extends AbstractPointSeriesSettingsDialog<
 				}
 			}
 		});
-		//
+
 		lineColorControl.set(text);
 	}
 
@@ -138,7 +138,7 @@ public class LineSeriesSettingsDialog extends AbstractPointSeriesSettingsDialog<
 
 		String title = "Antialias";
 		createSectionLabel(parent, title);
-		//
+
 		ComboViewer comboViewer = createComboViewer(parent, title, Antialias.values(), Antialias.ON, getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<Object>() {
 
 			@Override
@@ -152,14 +152,14 @@ public class LineSeriesSettingsDialog extends AbstractPointSeriesSettingsDialog<
 				}
 			}
 		});
-		//
+
 		antialiasControl.set(comboViewer);
 	}
 
 	private void createEnableAreaSection(Composite parent) {
 
 		createSectionLabel(parent, "");
-		//
+
 		Button button = createCheckBox(parent, "Enable Area", "Enable or disable to display the area.", getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<Boolean>() {
 
 			@Override
@@ -171,14 +171,14 @@ public class LineSeriesSettingsDialog extends AbstractPointSeriesSettingsDialog<
 				}
 			}
 		});
-		//
+
 		enableAreaControl.set(button);
 	}
 
 	private void createEnableStackSection(Composite parent) {
 
 		createSectionLabel(parent, "");
-		//
+
 		Button button = createCheckBox(parent, "Enable Stack", "Enable or disable the stack modus.", getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<Boolean>() {
 
 			@Override
@@ -190,14 +190,14 @@ public class LineSeriesSettingsDialog extends AbstractPointSeriesSettingsDialog<
 				}
 			}
 		});
-		//
+
 		enableStackControl.set(button);
 	}
 
 	private void createEnableStepSection(Composite parent) {
 
 		createSectionLabel(parent, "");
-		//
+
 		Button button = createCheckBox(parent, "Enable Step", "Enable or disable the step modus.", getGridData(GridData.FILL_HORIZONTAL, 2), new Consumer<Boolean>() {
 
 			@Override
@@ -209,7 +209,7 @@ public class LineSeriesSettingsDialog extends AbstractPointSeriesSettingsDialog<
 				}
 			}
 		});
-		//
+
 		enableStepControl.set(button);
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/AbstractHandledEventProcessor.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/AbstractHandledEventProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -45,7 +45,7 @@ public abstract class AbstractHandledEventProcessor implements IHandledEventProc
 		} else if((getStateMask() & SWT.MOD3) == SWT.MOD3) {
 			modifier = "ALT";
 		}
-		//
+
 		String button = "";
 		switch(getButton()) {
 			case IMouseSupport.MOUSE_BUTTON_LEFT:
@@ -58,7 +58,7 @@ public abstract class AbstractHandledEventProcessor implements IHandledEventProc
 				button = "Right";
 				break;
 		}
-		//
+
 		String event = "";
 		switch(getEvent()) {
 			case IMouseSupport.EVENT_MOUSE_DOUBLE_CLICK:

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/AbstractMouseEvent.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/AbstractMouseEvent.java
@@ -48,7 +48,7 @@ public abstract class AbstractMouseEvent extends AbstractHandledEventProcessor i
 	protected void postValidateZoom(BaseChart baseChart) {
 
 		RangeRestriction rangeRestriction = baseChart.getRangeRestriction();
-		//
+
 		IAxisSet axisSet = baseChart.getAxisSet();
 		IAxis xAxis = axisSet.getXAxis(BaseChart.ID_PRIMARY_X_AXIS);
 		IAxis yAxis = axisSet.getYAxis(BaseChart.ID_PRIMARY_Y_AXIS);

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/CircularMouseDownEvent.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/CircularMouseDownEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -75,7 +75,7 @@ public class CircularMouseDownEvent extends AbstractHandledEventProcessor implem
 				double primaryValueX = baseChart.getSelectedPrimaryAxisValue(event.x, IExtendedChart.X_AXIS);
 				double primaryValueY = baseChart.getSelectedPrimaryAxisValue(event.y, IExtendedChart.Y_AXIS);
 				Node node = circularSeries.getPieSliceFromPosition(primaryValueX, primaryValueY);
-				//
+
 				if(!redrawOnClick) {
 					circularSeries.setHighlightedNode(node);
 					if(!scrollableChart.getLinkedScrollableCharts().isEmpty()) {
@@ -83,7 +83,7 @@ public class CircularMouseDownEvent extends AbstractHandledEventProcessor implem
 						if(node != null) {
 							nodeId = node.getId();
 						}
-						//
+
 						for(ScrollableChart linkedChart : scrollableChart.getLinkedScrollableCharts()) {
 							for(ISeries<?> linkedSeries : (ISeries<?>[])linkedChart.getBaseChart().getSeriesSet().getSeries()) {
 								if(linkedSeries instanceof CircularSeries) {

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseMoveCursorEvent.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseMoveCursorEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -47,11 +47,11 @@ public class MouseMoveCursorEvent extends AbstractHandledEventProcessor implemen
 			if(defaultCursor == null) {
 				defaultCursor = display.getSystemCursor(SWT.CURSOR_ARROW);
 			}
-			//
+
 			if(tooltip == null) {
 				tooltip = new ToolTip(display.getActiveShell(), SWT.NONE);
 			}
-			//
+
 			String selectedSeriesId = baseChart.getSelectedseriesId(event);
 			if(selectedSeriesId.equals("")) { //$NON-NLS-1$
 				baseChart.setCursor(defaultCursor);

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseMoveShiftEvent.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseMoveShiftEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -66,10 +66,10 @@ public class MouseMoveShiftEvent extends AbstractHandledEventProcessor implement
 						 */
 						showClickbindingHelp(baseChart, "Shift series", "Shift the selected series.");
 						baseChart.setMoveStartTime(System.currentTimeMillis());
-						//
+
 						double shiftX = baseChart.getShiftValue(baseChart.getXMoveStart(), event.x, IExtendedChart.X_AXIS);
 						double shiftY = baseChart.getShiftValue(baseChart.getYMoveStart(), event.y, IExtendedChart.Y_AXIS);
-						//
+
 						for(String selectedSeriesId : selectedSeriesIds) {
 							ISeries<?> dataSeries = baseChart.getSeriesSet().getSeries(selectedSeriesId);
 							if(dataSeries != null) {
@@ -77,7 +77,7 @@ public class MouseMoveShiftEvent extends AbstractHandledEventProcessor implement
 							}
 						}
 						baseChart.redraw();
-						//
+
 						baseChart.setXMoveStart(event.x);
 						baseChart.setYMoveStart(event.y);
 					} else {

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseWheelZoomEvent.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseWheelZoomEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,7 +33,7 @@ public class MouseWheelZoomEvent extends AbstractMouseEvent {
 		IAxisSet axisSet = baseChart.getAxisSet();
 		IAxis xAxis = axisSet.getXAxis(BaseChart.ID_PRIMARY_X_AXIS);
 		IAxis yAxis = axisSet.getYAxis(BaseChart.ID_PRIMARY_Y_AXIS);
-		//
+
 		if(baseChart.isZoomXY(rangeRestriction)) {
 			/*
 			 * X and Y zoom.

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/mappings/MappingsIO.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/mappings/MappingsIO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Lablicate GmbH.
+ * Copyright (c) 2021, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -52,7 +52,7 @@ public class MappingsIO {
 					break;
 			}
 		}
-		//
+
 		return mappings;
 	}
 
@@ -79,7 +79,7 @@ public class MappingsIO {
 		} catch(IOException e) {
 			e.printStackTrace();
 		}
-		//
+
 		return mappings;
 	}
 
@@ -92,7 +92,7 @@ public class MappingsIO {
 		} catch(Exception e) {
 			e.printStackTrace();
 		}
-		//
+
 		return success;
 	}
 
@@ -137,7 +137,7 @@ public class MappingsIO {
 		} else {
 			version = Mappings_v1000.VERSION_NUMBER;
 		}
-		//
+
 		return version;
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/mappings/Mappings_v1000.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/mappings/Mappings_v1000.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Lablicate GmbH.
+ * Copyright (c) 2021, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -51,7 +51,7 @@ public class Mappings_v1000 {
 				e.printStackTrace();
 			}
 		}
-		//
+
 		return mappings;
 	}
 
@@ -59,7 +59,7 @@ public class Mappings_v1000 {
 
 		StringBuilder builder = new StringBuilder();
 		MappingsIO.appendVersion(builder, VERSION_NUMBER);
-		//
+
 		for(MappedSeriesSettings mapping : mappings) {
 			/*
 			 * Always use the latest version to save the settings.
@@ -68,7 +68,7 @@ public class Mappings_v1000 {
 			exportMapping(values, mapping);
 			builder.append(create(values));
 		}
-		//
+
 		return builder.toString();
 	}
 
@@ -108,7 +108,7 @@ public class Mappings_v1000 {
 		values.add(seriesSettings.isVisible());
 		values.add(seriesSettings.isVisibleInLegend());
 		values.add(ResourceSupport.getColor(SeriesLabelProvider.getColor(seriesSettings)));
-		//
+
 		if(seriesSettings instanceof IBarSeriesSettings) {
 			exportBarSeriesSetting(values, (IBarSeriesSettings)seriesSettings);
 		} else if(seriesSettings instanceof ICircularSeriesSettings) {
@@ -128,7 +128,7 @@ public class Mappings_v1000 {
 			seriesSettings.setVisibleInLegend(Boolean.parseBoolean(values[index++]));
 			SeriesLabelProvider.setColor(seriesSettings, ResourceSupport.getColor(values[index++]));
 		}
-		//
+
 		if(seriesSettings instanceof IBarSeriesSettings) {
 			index = importBarSeriesSetting(values, index, (IBarSeriesSettings)seriesSettings);
 		} else if(seriesSettings instanceof ICircularSeriesSettings) {
@@ -138,7 +138,7 @@ public class Mappings_v1000 {
 		} else if(seriesSettings instanceof IScatterSeriesSettings) {
 			index = importScatterSeriesSetting(values, index, (IScatterSeriesSettings)seriesSettings);
 		}
-		//
+
 		return index;
 	}
 
@@ -162,7 +162,7 @@ public class Mappings_v1000 {
 			barSeriesSettings.setBarWidthStyle(BarWidthStyle.valueOf(values[index++]));
 			barSeriesSettings.setEnableStack(Boolean.parseBoolean(values[index++]));
 		}
-		//
+
 		return index;
 	}
 
@@ -182,7 +182,7 @@ public class Mappings_v1000 {
 			circularSeriesSettings.setBorderWidth(Integer.parseInt(values[index++]));
 			circularSeriesSettings.setBorderStyle(LineStyle.valueOf(values[index++]));
 		}
-		//
+
 		return index;
 	}
 
@@ -210,7 +210,7 @@ public class Mappings_v1000 {
 			lineSeriesSettings.setEnableStack(Boolean.valueOf(values[index++]));
 			lineSeriesSettings.setEnableStep(Boolean.valueOf(values[index++]));
 		}
-		//
+
 		return index;
 	}
 
@@ -222,7 +222,7 @@ public class Mappings_v1000 {
 	private int importScatterSeriesSetting(String[] values, int index, IScatterSeriesSettings scatterSeriesSettings) {
 
 		index = importPointSeriesSetting(values, index, scatterSeriesSettings);
-		//
+
 		return index;
 	}
 
@@ -240,7 +240,7 @@ public class Mappings_v1000 {
 			pointSeriesSettings.setSymbolSize(Integer.valueOf(values[index++]));
 			pointSeriesSettings.setSymbolColor(ResourceSupport.getColor(values[index++]));
 		}
-		//
+
 		return index;
 	}
 
@@ -255,7 +255,7 @@ public class Mappings_v1000 {
 			}
 		}
 		builder.append(MappingsIO.LINE_DELIMITER);
-		//
+
 		return builder.toString();
 	}
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/marker/EmbeddedLegend.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/marker/EmbeddedLegend.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -63,12 +63,12 @@ public class EmbeddedLegend extends AbstractBaseChartPaintListener implements IB
 			GC gc = e.gc;
 			int lineStyle = gc.getLineStyle();
 			Color colorForeground = gc.getForeground();
-			//
+
 			BaseChart baseChart = getBaseChart();
 			ISeriesSet seriesSet = baseChart.getSeriesSet();
 			int x0 = x;
 			int y0 = y;
-			//
+
 			for(ISeries<?> series : seriesSet.getSeries()) {
 				if(series.isVisible()) {
 					if(series.isVisibleInLegend()) {

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/marker/LegendMarker.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/marker/LegendMarker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -38,7 +38,7 @@ public class LegendMarker extends AbstractPositionPaintListener implements IPosi
 	public LegendMarker(BaseChart baseChart) {
 
 		super(baseChart);
-		//
+
 		stringBuilder = new StringBuilder();
 		axisLabelsX = baseChart.getAxisLabels(IExtendedChart.X_AXIS);
 		decimalFormatX = baseChart.getDecimalFormat(IExtendedChart.X_AXIS, BaseChart.ID_PRIMARY_X_AXIS);
@@ -53,7 +53,7 @@ public class LegendMarker extends AbstractPositionPaintListener implements IPosi
 			stringBuilder.delete(0, stringBuilder.length());
 			e.gc.setForeground(getForegroundColor());
 			e.gc.setBackground(getBackgroundColor());
-			//
+
 			BaseChart baseChart = getBaseChart();
 			double primaryValueX = baseChart.getSelectedPrimaryAxisValue(getX(), IExtendedChart.X_AXIS);
 			double primaryValueY = baseChart.getSelectedPrimaryAxisValue(getY(), IExtendedChart.Y_AXIS);
@@ -79,7 +79,7 @@ public class LegendMarker extends AbstractPositionPaintListener implements IPosi
 		String id = "---";
 		String value = "---";
 		String percentage = "---";
-		//
+
 		Node node = series.getPieSliceFromPosition(primaryValueX, primaryValueY);
 		if(node != null) {
 			id = node.getDescription().isEmpty() ? node.getId() : node.getDescription();
@@ -88,12 +88,12 @@ public class LegendMarker extends AbstractPositionPaintListener implements IPosi
 			value = decimalFormat.format(node.getValue());
 			percentage = decimalFormat.format(percent);
 		}
-		//
+
 		String nodeClass = getBaseChart().getAxisSet().getXAxis(0).getTitle().getText();
 		String valueClass = getBaseChart().getAxisSet().getYAxis(0).getTitle().getText();
 		stringBuilder.append(nodeClass + " : " + id + "\n");
 		stringBuilder.append(valueClass + " : " + value + "\n");
-		//
+
 		if(node != null) {
 			stringBuilder.append("Percent of " + node.getDataModel().getRootPointer().getId() + " : " + percentage + "%\n");
 		}
@@ -111,7 +111,7 @@ public class LegendMarker extends AbstractPositionPaintListener implements IPosi
 			stringBuilder.append(": "); //$NON-NLS-1$
 			stringBuilder.append(decimalFormatX.format(primaryValueX));
 		}
-		//
+
 		for(int id : baseChart.getAxisSet().getXAxisIds()) {
 			if(id != BaseChart.ID_PRIMARY_X_AXIS) {
 				IAxisSettings axisSettings = baseChart.getXAxisSettings(id);
@@ -145,7 +145,7 @@ public class LegendMarker extends AbstractPositionPaintListener implements IPosi
 			stringBuilder.append(": "); //$NON-NLS-1$
 			stringBuilder.append(decimalFormatY.format(primaryValueY));
 		}
-		//
+
 		for(int id : baseChart.getAxisSet().getYAxisIds()) {
 			if(id != BaseChart.ID_PRIMARY_Y_AXIS) {
 				IAxisSettings axisSettings = baseChart.getYAxisSettings(id);

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/CustomSeriesComparator.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/CustomSeriesComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,7 @@ import org.eclipse.swtchart.extensions.model.ICustomSeries;
 public class CustomSeriesComparator extends ViewerComparator {
 
 	private static final int DESCENDING = 1;
-	//
+
 	private int propertyIndex = 0;
 	private int direction = DESCENDING;
 
@@ -44,7 +44,7 @@ public class CustomSeriesComparator extends ViewerComparator {
 
 		int sortOrder = 0;
 		if(e1 instanceof ICustomSeries customSeries1 && e2 instanceof ICustomSeries customSeries2) {
-			//
+
 			switch(propertyIndex) {
 				case 0:
 					sortOrder = customSeries1.getId().compareTo(customSeries2.getId());
@@ -63,11 +63,11 @@ public class CustomSeriesComparator extends ViewerComparator {
 					break;
 			}
 		}
-		//
+
 		if(direction == DESCENDING) {
 			sortOrder = -sortOrder;
 		}
-		//
+
 		return sortOrder;
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/CustomSeriesEditingSupport.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/CustomSeriesEditingSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -94,7 +94,7 @@ public class CustomSeriesEditingSupport extends EditingSupport {
 					customSeries.setDraw(Boolean.valueOf(object.toString()));
 					break;
 			}
-			//
+
 			refresh();
 		}
 	}

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/MappingsComparator.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/MappingsComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,7 @@ import org.eclipse.swtchart.extensions.core.MappedSeriesSettings;
 public class MappingsComparator extends ViewerComparator {
 
 	private static final int DESCENDING = 1;
-	//
+
 	private int propertyIndex = 0;
 	private int direction = DESCENDING;
 
@@ -46,7 +46,7 @@ public class MappingsComparator extends ViewerComparator {
 		if(e1 instanceof MappedSeriesSettings && e2 instanceof MappedSeriesSettings) {
 			MappedSeriesSettings mappedSeriesSettings1 = (MappedSeriesSettings)e1;
 			MappedSeriesSettings mappedSeriesSettings2 = (MappedSeriesSettings)e2;
-			//
+
 			switch(propertyIndex) {
 				case 0:
 					sortOrder = mappedSeriesSettings1.getMappingsType().compareTo(mappedSeriesSettings2.getMappingsType());
@@ -62,7 +62,7 @@ public class MappingsComparator extends ViewerComparator {
 					break;
 			}
 		}
-		//
+
 		if(direction == DESCENDING) {
 			sortOrder = -sortOrder;
 		}

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/MappingsFilter.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/MappingsFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,33 +33,33 @@ public class MappingsFilter extends ViewerFilter {
 		if(searchText == null || searchText.equals("")) {
 			return true;
 		}
-		//
+
 		if(element instanceof MappedSeriesSettings) {
 			MappedSeriesSettings mappedSeriesSettings = (MappedSeriesSettings)element;
 			String mappingsType = mappedSeriesSettings.getMappingsType().label();
 			String identifier = mappedSeriesSettings.getIdentifier();
 			String description = mappedSeriesSettings.getDescription();
-			//
+
 			if(!caseSensitive) {
 				searchText = searchText.toLowerCase();
 				mappingsType = mappingsType.toLowerCase();
 				identifier = identifier.toLowerCase();
 				description = description.toLowerCase();
 			}
-			//
+
 			if(mappingsType.contains(searchText)) {
 				return true;
 			}
-			//
+
 			if(identifier.contains(searchText)) {
 				return true;
 			}
-			//
+
 			if(description.contains(searchText)) {
 				return true;
 			}
 		}
-		//
+
 		return false;
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/MappingsLabelProvider.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/MappingsLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,13 +23,13 @@ public class MappingsLabelProvider extends ColumnLabelProvider implements ITable
 	public static final String MAPPINGS_TYPE = "Mappings Type";
 	public static final String ID = "Identifier";
 	public static final String DESCRIPTION = "Description";
-	//
+
 	public static final String[] TITLES = { //
 			MAPPINGS_TYPE, //
 			ID, //
 			DESCRIPTION //
 	};
-	//
+
 	public static final int[] BOUNDS = { //
 			150, //
 			150, //
@@ -51,7 +51,7 @@ public class MappingsLabelProvider extends ColumnLabelProvider implements ITable
 		String text = "";
 		if(element instanceof MappedSeriesSettings) {
 			MappedSeriesSettings mappedSeriesSettings = (MappedSeriesSettings)element;
-			//
+
 			switch(columnIndex) {
 				case 0:
 					text = mappedSeriesSettings.getMappingsType().label();

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/PositionValidator.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/PositionValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Lablicate GmbH.
+ * Copyright (c) 2020, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,14 +19,14 @@ import org.eclipse.core.runtime.IStatus;
 public class PositionValidator implements IValidator<String> {
 
 	private static final String ERROR = "Please enter a position as integer, e.g.: 100.";
-	//
+
 	private int position = 0;
 
 	public IStatus validate(String value) {
 
 		this.position = 0;
 		boolean parseError = true;
-		//
+
 		if(value != null) {
 			try {
 				position = Integer.parseInt(((String)value).trim());
@@ -35,7 +35,7 @@ public class PositionValidator implements IValidator<String> {
 				// Don't catch it here.
 			}
 		}
-		//
+
 		if(parseError) {
 			return ValidationStatus.error(ERROR);
 		} else {

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/SeriesComparator.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/SeriesComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -26,7 +26,7 @@ import org.eclipse.swtchart.extensions.core.SeriesMapper;
 public class SeriesComparator extends ViewerComparator {
 
 	private static final int DESCENDING = 1;
-	//
+
 	private int propertyIndex = 0;
 	private int direction = DESCENDING;
 
@@ -58,7 +58,7 @@ public class SeriesComparator extends ViewerComparator {
 			ISeries<?> series2 = (ISeries<?>)e2;
 			ISeriesSettings seriesSettings2 = baseChart.getSeriesSettings(series2.getId());
 			Color color2 = SeriesLabelProvider.getColor(seriesSettings2);
-			//
+
 			switch(propertyIndex) {
 				case 0:
 					sortOrder = series1.getId().compareTo(series2.getId());
@@ -93,7 +93,7 @@ public class SeriesComparator extends ViewerComparator {
 					break;
 			}
 		}
-		//
+
 		if(direction == DESCENDING) {
 			sortOrder = -sortOrder;
 		}

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/SeriesEditingSupport.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/SeriesEditingSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -104,7 +104,7 @@ public class SeriesEditingSupport extends EditingSupport {
 			ISeries<?> series = (ISeries<?>)element;
 			BaseChart baseChart = seriesListUI.getBaseChart();
 			ISeriesSettings seriesSettings = baseChart.getSeriesSettings(series.getId());
-			//
+
 			switch(columnIndex) {
 				case SeriesLabelProvider.INDEX_VISIBLE:
 					object = seriesSettings.isVisible();
@@ -140,7 +140,7 @@ public class SeriesEditingSupport extends EditingSupport {
 			ISeries<?> series = (ISeries<?>)element;
 			BaseChart baseChart = getBaseChart();
 			ISeriesSettings seriesSettings = baseChart.getSeriesSettings(series.getId());
-			//
+
 			switch(columnIndex) {
 				case SeriesLabelProvider.INDEX_VISIBLE:
 					seriesSettings.setVisible(Boolean.valueOf(object.toString()));
@@ -166,7 +166,7 @@ public class SeriesEditingSupport extends EditingSupport {
 					}
 					break;
 			}
-			//
+
 			baseChart.applySeriesSettings(series, seriesSettings, true);
 			refresh();
 		}

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/SeriesFilter.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/internal/support/SeriesFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Lablicate GmbH.
+ * Copyright (c) 2020, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -39,17 +39,17 @@ public class SeriesFilter extends ViewerFilter {
 		if(searchText == null || searchText.equals("")) {
 			return true;
 		}
-		//
+
 		if(element instanceof ISeries<?>) {
 			ISeries<?> series = (ISeries<?>)element;
-			//
+
 			if(preparedTerm(series.getId()).contains(searchText)) {
 				return true;
 			} else if(preparedTerm(series.getDescription()).contains(searchText)) {
 				return true;
 			}
 		}
-		//
+
 		return false;
 	}
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/linecharts/LineChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/linecharts/LineChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -71,7 +71,7 @@ public class LineChart extends ScrollableChart implements ICompressionSupport {
 					ILineSeries<?> lineSeries = (ILineSeries<?>)createSeries(optimizedSeriesData, lineSeriesSettings);
 					baseChart.applySeriesSettings(lineSeries, lineSeriesSettings);
 				} catch(SeriesException e) {
-					//
+
 				}
 			}
 			baseChart.suspendUpdate(false);

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/linecharts/LineSeriesSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/linecharts/LineSeriesSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -173,7 +173,7 @@ public class LineSeriesSettings extends AbstractPointSeriesSettings implements I
 			sink.setHighlight(source.isHighlight());
 			success = true;
 		}
-		//
+
 		return success;
 	}
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/linecharts/Messages.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/linecharts/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWT Chart Project
+ * Copyright (c) 2020, 2025 SWT Chart Project
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,7 @@ public class Messages {
 
 	private static final String BUNDLE_NAME = "org.eclipse.swtchart.extensions.linecharts.messages"; //$NON-NLS-1$
 	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
-	//
+
 	public static final String AUTO = "AUTO";
 	public static final String EXTREME = "EXTREME";
 	public static final String HIGH = "HIGH";

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/linecharts/StepChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/linecharts/StepChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -77,7 +77,7 @@ public class StepChart extends ScrollableChart implements ICompressionSupport {
 					ILineSeries<?> lineSeries = (ILineSeries<?>)createSeries(optimizedSeriesData, lineSeriesSettings);
 					baseChart.applySeriesSettings(lineSeries, lineSeriesSettings);
 				} catch(SeriesException e) {
-					//
+
 				}
 			}
 			baseChart.suspendUpdate(false);

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/marker/LabelMarker.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/marker/LabelMarker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -75,24 +75,24 @@ public class LabelMarker extends AbstractBaseChartPaintListener implements IBase
 			if(serie == null) {
 				return;
 			}
-			//
+
 			BaseChart baseChart = getBaseChart();
 			IPlotArea plotArea = baseChart.getPlotArea();
-			//
+
 			Rectangle rectangle;
 			if(plotArea instanceof Scrollable) {
 				rectangle = ((Scrollable)plotArea).getClientArea();
 			} else {
 				rectangle = plotArea.getBounds();
 			}
-			//
+
 			int size = serie.getXSeries().length;
 			Transform transform = null;
 			if(orientation == SWT.VERTICAL) {
 				transform = new Transform(e.gc.getDevice());
 				transform.rotate(-90);
 			}
-			//
+
 			try {
 				for(int index : labels.keySet()) {
 					if(index < size) {
@@ -105,7 +105,7 @@ public class LabelMarker extends AbstractBaseChartPaintListener implements IBase
 							continue;
 						}
 						Point point = serie.getPixelCoordinates(index);
-						//
+
 						if(point.x > 0 && rectangle.contains(point)) {
 							/*
 							 * Calculate x and y

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/Messages.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWT Chart Project
+ * Copyright (c) 2020, 2025 SWT Chart Project
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,7 @@ public class Messages {
 
 	private static final String BUNDLE_NAME = "org.eclipse.swtchart.extensions.menu.messages"; //$NON-NLS-1$
 	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
-	//
+
 	public static final String EXPORT_CHART_SELECTION = "EXPORT_CHART_SELECTION";
 	public static final String RANGE_SELECTION = "RANGE_SELECTION";
 	public static final String REDO_SELECTION = "REDO_SELECTION";

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/SetRangeChartHandler.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/SetRangeChartHandler.java
@@ -102,7 +102,7 @@ public class SetRangeChartHandler extends AbstractChartMenuEntry implements ICha
 		BaseChart baseChart = scrollableChart.getBaseChart();
 		DecimalFormat decimalFormat;
 		int selectedAxis;
-		//
+
 		if(axis.equals(IExtendedChart.X_AXIS)) {
 			selectedAxis = chartRangeValues.getAxisX();
 			decimalFormat = baseChart.getDecimalFormat(IExtendedChart.X_AXIS, selectedAxis);
@@ -115,7 +115,7 @@ public class SetRangeChartHandler extends AbstractChartMenuEntry implements ICha
 		 */
 		double valueStart;
 		double valueStop;
-		//
+
 		if(axis.equals(IExtendedChart.X_AXIS)) {
 			valueStart = decimalFormat.parse(chartRangeValues.getStartX()).doubleValue();
 			valueStop = decimalFormat.parse(chartRangeValues.getStopX()).doubleValue();
@@ -137,7 +137,7 @@ public class SetRangeChartHandler extends AbstractChartMenuEntry implements ICha
 				range = new Range(valueStart, valueStop);
 			}
 		}
-		//
+
 		return range;
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/legend/AbstractMenuListener.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/legend/AbstractMenuListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Lablicate GmbH.
+ * Copyright (c) 2021, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -48,7 +48,7 @@ public abstract class AbstractMenuListener implements IMenuListener {
 				}
 			}
 		}
-		//
+
 		return selectedSeries;
 	}
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/legend/MapSettingsAction.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/legend/MapSettingsAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -60,7 +60,7 @@ public class MapSettingsAction extends AbstractMenuListener {
 						SeriesMapper.unmap(series, baseChart);
 					}
 				}
-				//
+
 				refresh();
 			}
 		});

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/legend/Messages.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/legend/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,7 @@ public class Messages {
 
 	private static final String BUNDLE_NAME = "org.eclipse.swtchart.extensions.menu.legend.messages"; //$NON-NLS-1$
 	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
-	//
+
 	public static final String ADD_SERIES_MAPPING = "ADD_SERIES_MAPPING";
 	public static final String REMOVE_SERIES_MAPPING = "REMOVE_SERIES_MAPPING";
 	public static final String ADD_REMOVE_SERIES_MAPPING = "ADD_REMOVE_SERIES_MAPPING";

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/legend/SeriesVisibilityAction.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/legend/SeriesVisibilityAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Lablicate GmbH.
+ * Copyright (c) 2021, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -58,7 +58,7 @@ public class SeriesVisibilityAction extends AbstractMenuListener {
 			public void run() {
 
 				BaseChart baseChart = getBaseChart();
-				//
+
 				List<ISeries<?>> selectedSeries = getSelectedSeries();
 				for(ISeries<?> series : selectedSeries) {
 					ISeriesSettings seriesSettings = baseChart.getSeriesSettings(series.getId());
@@ -69,7 +69,7 @@ public class SeriesVisibilityAction extends AbstractMenuListener {
 					}
 					baseChart.applySeriesSettings(series, seriesSettings, true);
 				}
-				//
+
 				refresh();
 			}
 		});

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/legend/SetColorAction.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/legend/SetColorAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Lablicate GmbH.
+ * Copyright (c) 2021, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -58,7 +58,7 @@ public class SetColorAction extends AbstractMenuListener {
 				SeriesListUI seriesListUI = getSeriesListUI();
 				Table table = seriesListUI.getTable();
 				List<ISeries<?>> selectedSeries = getSelectedSeries();
-				//
+
 				if(!selectedSeries.isEmpty()) {
 					ColorDialog colorDialog = new ColorDialog(table.getShell());
 					colorDialog.setText(Messages.getString(Messages.SET_SERIES_COLOR));

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/legend/SetDescriptionAction.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/legend/SetDescriptionAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Lablicate GmbH.
+ * Copyright (c) 2021, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -56,7 +56,7 @@ public class SetDescriptionAction extends AbstractMenuListener {
 				SeriesListUI seriesListUI = getSeriesListUI();
 				Table table = seriesListUI.getTable();
 				List<ISeries<?>> selectedSeries = getSelectedSeries();
-				//
+
 				if(!selectedSeries.isEmpty()) {
 					String firstDescription = selectedSeries.get(0).getDescription();
 					InputDialog dialog = new InputDialog(table.getShell(), Messages.getString(Messages.DESCRIPTION), Messages.getString(Messages.SET_DESCRIPTION), firstDescription, new IInputValidator() {
@@ -72,11 +72,11 @@ public class SetDescriptionAction extends AbstractMenuListener {
 									return Messages.DESCRIPTION_MUST_NOT_BE_EMPTY;
 								}
 							}
-							//
+
 							return null;
 						}
 					});
-					//
+
 					if(IDialogConstants.OK_ID == dialog.open()) {
 						String description = dialog.getValue();
 						for(ISeries<?> series : selectedSeries) {

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/toggle/Messages.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/menu/toggle/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWT Chart Project
+ * Copyright (c) 2020, 2025 SWT Chart Project
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,7 @@ public class Messages {
 
 	private static final String BUNDLE_NAME = "org.eclipse.swtchart.extensions.menu.toggle.messages"; //$NON-NLS-1$
 	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
-	//
+
 	public static final String AXIS_ZERO_MARKER = "AXIS_ZERO_MARKER";
 	public static final String LEGEND_MARKER = "LEGEND_MARKER";
 	public static final String PLOT_CENTER_MARKER = "PLOT_CENTER_MARKER";

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/model/CustomSeries.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/model/CustomSeries.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,7 +23,7 @@ public class CustomSeries implements ICustomSeries {
 	private String label = "";
 	private String description = "";
 	private boolean draw = true;
-	//
+
 	private Set<ITextElement> textElements = new HashSet<>();
 	private Set<IGraphicElement> graphicElements = new HashSet<>();
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/CircularSeriesData.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/CircularSeriesData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Lablicate GmbH.
+ * Copyright (c) 2020, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,7 +22,7 @@ import org.eclipse.swtchart.model.NodeDataModel;
 public class CircularSeriesData extends SeriesData implements ICircularSeriesData {
 
 	public static final String ID = "Circular Series";
-	//
+
 	private NodeDataModel nodeDataModel;
 	private Node rootNode;
 	private ICircularSeriesSettings seriesSettings;

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/CircularSeriesSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/CircularSeriesSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -158,7 +158,7 @@ public class CircularSeriesSettings extends AbstractSeriesSettings implements IC
 			sink.setHighlight(source.isHighlight());
 			success = true;
 		}
-		//
+
 		return success;
 	}
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/PieChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/piecharts/PieChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -79,7 +79,7 @@ public class PieChart extends ScrollableChart {
 				ICircularSeries<?> circularSeries = createCircularSeries(seriesData, seriesSettings);
 				baseChart.applySeriesSettings(circularSeries, seriesSettings);
 			} catch(SeriesException e) {
-				//
+
 			}
 			/*
 			 * Finish
@@ -116,11 +116,11 @@ public class PieChart extends ScrollableChart {
 				break;
 			}
 		}
-		//
+
 		if(handledEventProcessor != null) {
 			chartSettings.removeHandledEventProcessor(handledEventProcessor);
 		}
-		//
+
 		IHandledEventProcessor circularHandledEventProcessor = new CircularMouseDownEvent(this);
 		chartSettings.addHandledEventProcessor(circularHandledEventProcessor);
 	}

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/preferences/Messages.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/preferences/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWT Chart Project
+ * Copyright (c) 2020, 2025 SWT Chart Project
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,7 @@ public class Messages {
 
 	private static final String BUNDLE_NAME = "org.eclipse.swtchart.extensions.preferences.messages"; //$NON-NLS-1$
 	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
-	//
+
 	public static final String ABSOLUTE = "ABSOLUTE";
 	public static final String BITMAP_EXPORT_CUSTOM_SIZE = "BITMAP_EXPORT_CUSTOM_SIZE";
 	public static final String BITMAP_EXPORT_WIDTH = "BITMAP_EXPORT_WIDTH";

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/preferences/PreferenceConstants.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/preferences/PreferenceConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 Lablicate GmbH.
+ * Copyright (c) 2020, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,49 +16,49 @@ public class PreferenceConstants {
 
 	public static final int MIN_MOVE_LEGEND = 1;
 	public static final int MAX_MOVE_LEGEND = 100;
-	//
+
 	public static final String P_BUFFER_SELECTION = "bufferSelection";
 	public static final boolean DEF_BUFFER_SELECTION = true;
 	public static final String P_KEEP_SERIES_DESCRIPTION = "keepSeriesDescription";
 	public static final boolean DEF_KEEP_SERIES_DESCRIPTION = false;
-	//
+
 	public static final String P_MOVE_LEGEND_X = "moveLegendX";
 	public static final int DEF_MOVE_LEGEND_X = 10;
 	public static final String P_MOVE_LEGEND_Y = "moveLegendY";
 	public static final int DEF_MOVE_LEGEND_Y = 5;
-	//
+
 	public static final String P_LEGEND_POSITION_X = "legendPositionX";
 	public static final int DEF_LEGEND_POSITION_X = 100;
 	public static final String P_LEGEND_POSITION_Y = "legendPositionY";
 	public static final int DEF_LEGEND_POSITION_Y = 100;
-	//
+
 	public static final String P_SORT_LEGEND_TABLE = "sortLegendTable";
 	public static final boolean DEF_SORT_LEGEND_TABLE = false;
-	//
+
 	public static final String P_LEGEND_COLUMN_ORDER = "legendColumnOrder";
 	public static final String DEF_LEGEND_COLUMN_ORDER = "";
 	public static final String P_CUSTOM_SERIES_COLUMN_ORDER = "customSeriesColumnOrder";
 	public static final String DEF_CUSTOM_SERIES_COLUMN_ORDER = "";
-	//
+
 	public static final String P_SERIES_MAPPINGS = "seriesMappings";
 	public static final String DEF_SERIES_MAPPINGS = "";
 	public static final String P_PATH_MAPPINGS_IMPORT = "pathMappingsImport";
 	public static final String DEF_PATH_MAPPINGS_IMPORT = "";
 	public static final String P_PATH_MAPPINGS_EXPORT = "pathMappingsExport";
 	public static final String DEF_PATH_MAPPINGS_EXPORT = "";
-	//
+
 	public static final String P_BITMAP_EXPORT_CUSTOM_SIZE = "bitmapExportCustomSize";
 	public static final boolean DEF_BITMAP_EXPORT_CUSTOM_SIZE = false;
 	public static final String P_BITMAP_EXPORT_WIDTH = "bitmapExportWidth";
 	public static final int DEF_BITMAP_EXPORT_WIDTH = 512;
 	public static final String P_BITMAP_EXPORT_HEIGHT = "bitmapExportHeight";
 	public static final int DEF_BITMAP_EXPORT_HEIGHT = 512;
-	//
+
 	public static final String P_SHOW_HELP_FOR_EVENTS = "showHelpForEvents";
 	public static final boolean DEF_SHOW_HELP_FOR_EVENTS = false;
 	public static final String P_HELP_POPUP_TIME_TO_CLOSE = "showHelpForEvents_timeToClose";
 	public static final int DEF_HELP_POPUP_TIME_TO_CLOSE = 6000;
-	//
+
 	public static final String P_EXPORT_INDEX_AXIS_X = "exportIndexAxisX_";
 	public static final int DEF_EXPORT_INDEX_AXIS_X = 0;
 	public static final String P_EXPORT_INDEX_AXIS_Y = "exportIndexAxisY_";

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/preferences/PreferenceSupport.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/preferences/PreferenceSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,23 +32,23 @@ public class PreferenceSupport {
 			{Messages.getString(Messages.TOP), Integer.toString(SWT.TOP)}, //
 			{Messages.getString(Messages.BOTTOM), Integer.toString(SWT.BOTTOM)} //
 	};
-	//
+
 	public static final String[][] ORIENTATIONS = new String[][]{ //
 			{Messages.getString(Messages.HORIZONTAL), Integer.toString(SWT.HORIZONTAL)}, //
 			{Messages.getString(Messages.VERTICAL), Integer.toString(SWT.VERTICAL)} //
 	};
-	//
+
 	public static final String[][] AXIS_POSITIONS = new String[][]{ //
 			{Messages.getString(Messages.PRIMARY), Position.Primary.toString()}, //
 			{Messages.getString(Messages.SECONDARY), Position.Secondary.toString()} //
 	};
-	//
+
 	public static final String[][] LOCALES = new String[][]{ //
 			{Messages.getString(Messages.ENGLISH), Locale.ENGLISH.getLanguage()}, //
 			{Messages.getString(Messages.US), Locale.US.getLanguage()}, //
 			{Messages.getString(Messages.GERMAN), Locale.GERMAN.getLanguage()} //
 	};
-	//
+
 	public static final String[][] LINE_STYLES = new String[][]{ //
 			{Messages.getString(Messages.NONE), LineStyle.NONE.toString()}, //
 			{Messages.getString(Messages.SOLID), LineStyle.SOLID.toString()}, //
@@ -57,13 +57,13 @@ public class PreferenceSupport {
 			{Messages.getString(Messages.DASH_DOT), LineStyle.DASHDOT.toString()}, //
 			{Messages.getString(Messages.DASH_DOT_DOT), LineStyle.DASHDOTDOT.toString()} //
 	};
-	//
+
 	public static final String[][] ANTIALIAS_OPTIONS = new String[][]{ //
 			{Messages.getString(Messages.DEFAULT), Integer.toString(SWT.DEFAULT)}, //
 			{Messages.getString(Messages.ON), Integer.toString(SWT.ON)}, //
 			{Messages.getString(Messages.OFF), Integer.toString(SWT.OFF)} //
 	};
-	//
+
 	public static final String[][] SYMBOL_TYPES = new String[][]{//
 			{Messages.getString(Messages.NONE), PlotSymbolType.NONE.toString()}, //
 			{Messages.getString(Messages.CIRCLE), PlotSymbolType.CIRCLE.toString()}, //
@@ -75,12 +75,12 @@ public class PreferenceSupport {
 			{Messages.getString(Messages.TRIANGLE), PlotSymbolType.TRIANGLE.toString()}, //
 			{Messages.getString(Messages.EMOJI), PlotSymbolType.EMOJI.toString()} //
 	};
-	//
+
 	public static final String[][] BAR_WIDTH_STYLES = new String[][]{//
 			{Messages.getString(Messages.FIXED), BarWidthStyle.FIXED.toString()}, //
 			{Messages.getString(Messages.STRETCHED), BarWidthStyle.STRETCHED.toString()} //
 	};
-	//
+
 	public static final String[][] EXTEND_TYPES = new String[][]{//
 			{Messages.getString(Messages.RELATIVE), RangeRestriction.ExtendType.RELATIVE.toString()}, //
 			{Messages.getString(Messages.ABSOLUTE), RangeRestriction.ExtendType.ABSOLUTE.toString()} //

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/Messages.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWT Chart Project
+ * Copyright (c) 2020, 2025 SWT Chart Project
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,7 @@ public class Messages {
 
 	private static final String BUNDLE_NAME = "org.eclipse.swtchart.extensions.properties.messages"; //$NON-NLS-1$
 	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
-	//
+
 	public static final String AXES = "AXES";
 	public static final String BACKGROUND = "BACKGROUND";
 	public static final String BACKGROUND_PLOT_AREA = "BACKGROUND_PLOT_AREA";

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/SeriesLabelPage.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/SeriesLabelPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SWTChart project.
+ * Copyright (c) 2008, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -136,7 +136,7 @@ public class SeriesLabelPage extends AbstractSelectorPage {
 				setControlsEnable(visible);
 			}
 		});
-		//
+
 		colorLabel = createLabelControl(group, Messages.getString(Messages.COLOR));
 		colorButton = createColorButtonControl(group);
 		colorButton.addListener(new IPropertyChangeListener() {
@@ -147,7 +147,7 @@ public class SeriesLabelPage extends AbstractSelectorPage {
 				colors[selectedIndex] = colorButton.getColorValue();
 			}
 		});
-		//
+
 		fontSizeLabel = createLabelControl(group, Messages.getString(Messages.FONT_SIZE));
 		fontSizeSpinner = createSpinnerControl(group, 8, 30);
 		fontSizeSpinner.addModifyListener(new ModifyListener() {

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/SeriesPage.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/properties/SeriesPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SWTChart project.
+ * Copyright (c) 2008, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -414,15 +414,15 @@ public class SeriesPage extends AbstractSelectorPage {
 		lineColorButton.setEnabled(enabled);
 		lineStyleCombo.setEnabled(enabled);
 		stackedButton.setEnabled(enabled);
-		//
+
 		if(xAxisIdCombo != null) {
 			xAxisIdCombo.setEnabled(enabled);
 		}
-		//
+
 		if(yAxisIdCombo != null) {
 			yAxisIdCombo.setEnabled(enabled);
 		}
-		//
+
 		barColorButton.setEnabled(enabled);
 		paddingSizeSpinner.setEnabled(enabled);
 	}
@@ -456,7 +456,7 @@ public class SeriesPage extends AbstractSelectorPage {
 				stackedStates[i] = false;
 				stackedButton.setSelection(false);
 			}
-			//
+
 			series[i].setXAxisId(xAxisIds[i]);
 			series[i].setYAxisId(yAxisIds[i]);
 		}
@@ -470,11 +470,11 @@ public class SeriesPage extends AbstractSelectorPage {
 		if(xAxisIdCombo != null) {
 			xAxisIds[selectedIndex] = 0;
 		}
-		//
+
 		if(yAxisIdCombo != null) {
 			yAxisIds[selectedIndex] = 0;
 		}
-		//
+
 		if(series[selectedIndex] instanceof ILineSeries) {
 			lineStyles[selectedIndex] = LineStyle.SOLID;
 			lineColors[selectedIndex] = Display.getDefault().getSystemColor(SWT.COLOR_BLUE).getRGB();
@@ -485,7 +485,7 @@ public class SeriesPage extends AbstractSelectorPage {
 			barColors[selectedIndex] = Display.getDefault().getSystemColor(SWT.COLOR_BLUE).getRGB();
 			paddings[selectedIndex] = 20;
 		}
-		//
+
 		updateControlSelections();
 		super.performDefaults();
 	}

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/scattercharts/ScatterChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/scattercharts/ScatterChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -58,7 +58,7 @@ public class ScatterChart extends ScrollableChart {
 					ILineSeries<?> scatterSeries = (ILineSeries<?>)createSeries(optimizedSeriesData, scatterSeriesSettings);
 					baseChart.applySeriesSettings(scatterSeries, scatterSeriesSettings);
 				} catch(SeriesException e) {
-					//
+
 				}
 			}
 			baseChart.suspendUpdate(false);

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/scattercharts/ScatterSeriesSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/scattercharts/ScatterSeriesSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -57,7 +57,7 @@ public class ScatterSeriesSettings extends AbstractPointSeriesSettings implement
 			sink.setHighlight(source.isHighlight());
 			success = true;
 		}
-		//
+
 		return success;
 	}
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/support/ElementSupport.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/support/ElementSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -37,7 +37,7 @@ public class ElementSupport {
 	private double factorY = 0;
 	private double partX = 0;
 	private double partY = 0;
-	//
+
 	private boolean coversNegativeRangeY = false;
 	private double fullRangeNegativeY = 0;
 	private double factorUpperRangeY = 0;
@@ -49,7 +49,7 @@ public class ElementSupport {
 		this.rangeY = rangeY;
 		this.widthChart = widthChart;
 		this.heightChart = heightChart;
-		//
+
 		initialize();
 	}
 
@@ -67,7 +67,7 @@ public class ElementSupport {
 
 		double primaryX = rangeX.lower + partX * (factorX * x);
 		double primaryY = 0;
-		//
+
 		if(coversNegativeRangeY) {
 			if(y <= upperPartY) {
 				primaryY = rangeY.upper * (1.0d - (factorY * y));
@@ -82,7 +82,7 @@ public class ElementSupport {
 			 */
 			primaryY = rangeY.lower + partY * (1.0d - (factorY * y));
 		}
-		//
+
 		return new PointPrimary(primaryX, primaryY);
 	}
 
@@ -90,10 +90,10 @@ public class ElementSupport {
 
 		PointPrimary primaryStart = convertPoint(x, y);
 		PointPrimary primaryStop = convertPoint(x + width, y + height);
-		//
+
 		double widthPrimary = primaryStop.getX() - primaryStart.getX();
 		double heightPrimary = 0;
-		//
+
 		if(coversNegativeRangeY) {
 			if(y <= upperPartY) {
 				heightPrimary = (primaryStart.getY() - primaryStop.getY()) * (1 / factorUpperRangeY);
@@ -103,7 +103,7 @@ public class ElementSupport {
 		} else {
 			heightPrimary = primaryStart.getY() - primaryStop.getY();
 		}
-		//
+
 		return new RectanglePrimary(primaryStart.getX(), primaryStart.getY(), widthPrimary, heightPrimary);
 	}
 
@@ -113,10 +113,10 @@ public class ElementSupport {
 			factorX = 1.0d / widthChart;
 			factorY = 1.0d / heightChart;
 		}
-		//
+
 		partX = rangeX.upper - rangeX.lower;
 		partY = rangeY.upper - rangeY.lower;
-		//
+
 		coversNegativeRangeY = rangeY.lower < 0;
 		if(coversNegativeRangeY) {
 			fullRangeNegativeY = Math.abs(rangeY.lower) + rangeY.upper;

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/support/RangeSupport.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/support/RangeSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Lablicate GmbH.
+ * Copyright (c) 2024, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,7 +30,7 @@ public class RangeSupport {
 
 		IAxis xAxis = baseChart.getAxisSet().getXAxis(BaseChart.ID_PRIMARY_X_AXIS);
 		IAxis yAxis = baseChart.getAxisSet().getYAxis(BaseChart.ID_PRIMARY_Y_AXIS);
-		//
+
 		if(xAxis != null && yAxis != null) {
 			/*
 			 * Slide to the previous or next block.
@@ -40,7 +40,7 @@ public class RangeSupport {
 			double delta = (xAxis.getRange().upper - xAxis.getRange().lower) * factor;
 			double lower;
 			double upper;
-			//
+
 			if(slidePrevious) {
 				/*
 				 * Previous
@@ -72,7 +72,7 @@ public class RangeSupport {
 
 		IAxis xAxis = baseChart.getAxisSet().getXAxis(BaseChart.ID_PRIMARY_X_AXIS);
 		IAxis yAxis = baseChart.getAxisSet().getYAxis(BaseChart.ID_PRIMARY_Y_AXIS);
-		//
+
 		if(xAxis != null && yAxis != null) {
 			/*
 			 * Slide to the previous or next block.
@@ -82,7 +82,7 @@ public class RangeSupport {
 			double delta = (yAxis.getRange().upper - yAxis.getRange().lower) * factor;
 			double lower;
 			double upper;
-			//
+
 			if(slidePrevious) {
 				/*
 				 * Previous
@@ -127,7 +127,7 @@ public class RangeSupport {
 		 */
 		double deltaX = baseChart.getMaxX() - baseChart.getMinX();
 		double deltaY = baseChart.getMaxY() - baseChart.getMinY();
-		//
+
 		if(deltaX > 0 && deltaY > 0) {
 			/*
 			 * Shift calculation
@@ -153,13 +153,13 @@ public class RangeSupport {
 					max = (!isChartHorizontal ? (selection - shiftX) / coeffX : (shiftY - selection) / coeffY);
 					min = (!isChartHorizontal ? max + (range.upper - range.lower) : max - (range.upper - range.lower));
 				}
-				//
+
 				if(!Double.isNaN(min) && !Double.isNaN(max)) {
 					return new Range(min, max);
 				}
 			}
 		}
-		//
+
 		return null;
 	}
 
@@ -185,12 +185,12 @@ public class RangeSupport {
 						adjustSecondaryYAxes(baseChart);
 					}
 				}
-				//
+
 				baseChart.redraw();
 				return true;
 			}
 		}
-		//
+
 		return false;
 	}
 
@@ -210,11 +210,11 @@ public class RangeSupport {
 					adjustSecondaryXAxes(baseChart);
 				}
 			}
-			//
+
 			baseChart.redraw();
 			return true;
 		}
-		//
+
 		return false;
 	}
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/widgets/ExtendedCombo.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/widgets/ExtendedCombo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Lablicate GmbH.
+ * Copyright (c) 2023, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,7 +22,7 @@ public class ExtendedCombo {
 
 		Combo combo = new Combo(parent, style);
 		initialize(combo);
-		//
+
 		return combo;
 	}
 

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/suite/AllTests.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/suite/AllTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 SWTChart project.
+ * Copyright (c) 2008, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,5 +32,5 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({ChartTest.class, ChartTitleTest.class, LegendTest.class, AxisSetTest.class, AxisTest.class, AxisTickTest.class, AxisTitleTest.class, GridTest.class, SeriesLabelTest.class, SeriesSetTest.class, LineSeriesTest.class, BarSeriesTest.class, ErrorBarTest.class,})
 public class AllTests {
-	//
+
 }

--- a/org.eclipse.swtchart.vectorgraphics2d/src/org/eclipse/swtchart/vectorgraphics2d/pdf/PDFDocument.java
+++ b/org.eclipse.swtchart.vectorgraphics2d/src/org/eclipse/swtchart/vectorgraphics2d/pdf/PDFDocument.java
@@ -58,7 +58,7 @@ class PDFDocument extends SizedDocument {
 	private static final float POINTS_PER_INCH = 72; // DPI
 	private static final float POINTS_PER_MM = 1 / (10 * 2.54f) * POINTS_PER_INCH;
 	private static final float BEZIER_CONSTANT = 0.552284749831f;
-	//
+
 	private PDDocument document = null;
 
 	private class Scale {
@@ -107,11 +107,11 @@ class PDFDocument extends SizedDocument {
 		PDPage page = new PDPage(rectangle);
 		document.addPage(page);
 		float height = rectangle.getHeight();
-		//
+
 		Matrix matrixScale = Matrix.getScaleInstance(1, -1);
 		Matrix matrixTranslate = Matrix.getTranslateInstance(0, -(float)height);
 		Matrix matrixFlip = Matrix.concatenate(matrixScale, matrixTranslate);
-		//
+
 		AffineTransform affineTransform = null;
 		boolean useAffineTransform = false;
 		Color colorBackground = Color.WHITE;
@@ -119,7 +119,7 @@ class PDFDocument extends SizedDocument {
 		PDFont font = PDType1Font.HELVETICA;
 		float fontSize = 8.0f;
 		Map<Integer, PDExtendedGraphicsState> opacityMap = new HashMap<>();
-		//
+
 		try (PDPageContentStream contentStream = new PDPageContentStream(document, page)) {
 			for(Command<?> command : commands) {
 				if(command instanceof AffineTransformCommand c) {
@@ -270,13 +270,13 @@ class PDFDocument extends SizedDocument {
 					 */
 				}
 			}
-			//
+
 			contentStream.close();
 			scaleToTargetSize(pageSize, document, page);
 		} catch(IOException e) {
 			// System.out.println(e);
 		}
-		//
+
 		return document;
 	}
 
@@ -298,7 +298,7 @@ class PDFDocument extends SizedDocument {
 		double scaleX = affineTransform.getScaleX();
 		double shearY = affineTransform.getShearY();
 		double theta = Math.atan2(shearY, scaleX);
-		//
+
 		return Math.toDegrees(theta) - 180;
 	}
 
@@ -324,7 +324,7 @@ class PDFDocument extends SizedDocument {
 
 		float width = (float)(pageSize.getWidth() * scale.getX());
 		float height = (float)(pageSize.getHeight() * scale.getY());
-		//
+
 		return new PDRectangle(width, height);
 	}
 
@@ -332,7 +332,7 @@ class PDFDocument extends SizedDocument {
 
 		double scaleX = 1.0d;
 		double scaleY = 1.0d;
-		//
+
 		for(Command<?> command : commands) {
 			if(command instanceof AffineTransformCommand affineTransformCommand) {
 				AffineTransform affineTransform = affineTransformCommand.getValue();
@@ -340,10 +340,10 @@ class PDFDocument extends SizedDocument {
 				scaleY = affineTransform.getScaleY();
 			}
 		}
-		//
+
 		double x = (scaleX != 0) ? (1 / scaleX) : 1.0d;
 		double y = (scaleY != 0) ? (1 / scaleY) : 1.0d;
-		//
+
 		return new Scale(x, y);
 	}
 }

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/Chart.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/Chart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 SWTChart project.
+ * Copyright (c) 2008, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -57,7 +57,7 @@ public class Chart extends Composite implements Listener {
 	 * Data Series
 	 */
 	protected SeriesSet seriesSet;
-	//
+
 	private final Title title;
 	private final Legend legend;
 	private final AxisSet axisSet;
@@ -65,7 +65,7 @@ public class Chart extends Composite implements Listener {
 	private int orientation; // SWT.HORIZONTAL or SWT.VERTICAL
 	private boolean compressEnabled;
 	private boolean updateSuspended;
-	//
+
 	private final List<PaintListener> paintListener = new ArrayList<>();
 
 	public Chart(Composite parent, int style) {

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/Resources.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/Resources.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 Lablicate GmbH.
+ * Copyright (c) 2008, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -31,12 +31,12 @@ public class Resources {
 	 * other systems than Microsoft and looks similar.
 	 */
 	public static final String DEFAULT_FONT_NAME = "Verdana";
-	//
+
 	public static final int LARGE_FONT_SIZE = 13;
 	public static final int MEDIUM_FONT_SIZE = 11;
 	public static final int SMALL_FONT_SIZE = 9;
 	public static final String RGB_DELIMITER = ",";
-	//
+
 	private static final Map<RGB, Color> colorMap = new HashMap<>();
 	private static final Map<String, Font> fontMap = new HashMap<>();
 	private static final Map<String, TextLayout> textLayoutMap = new HashMap<>();
@@ -61,11 +61,11 @@ public class Resources {
 				int red = Integer.parseInt(values[0]);
 				int green = Integer.parseInt(values[1]);
 				int blue = Integer.parseInt(values[2]);
-				//
+
 				return getColor(new RGB(red, green, blue));
 			}
 		}
-		//
+
 		return getColorDefault();
 	}
 
@@ -74,15 +74,15 @@ public class Resources {
 		if(color == null) {
 			color = getColorDefault();
 		}
-		//
+
 		StringBuilder builder = new StringBuilder();
-		//
+
 		builder.append(color.getRed());
 		builder.append(RGB_DELIMITER);
 		builder.append(color.getGreen());
 		builder.append(RGB_DELIMITER);
 		builder.append(color.getBlue());
-		//
+
 		return builder.toString();
 	}
 
@@ -129,7 +129,7 @@ public class Resources {
 			font = new Font(getDisplay(), name, height, style);
 			fontMap.put(key, font);
 		}
-		//
+
 		return font;
 	}
 
@@ -140,7 +140,7 @@ public class Resources {
 			textLayout = new TextLayout(getDisplay());
 			textLayoutMap.put(uuid, textLayout);
 		}
-		//
+
 		return textLayout;
 	}
 
@@ -181,7 +181,7 @@ public class Resources {
 		builder.append(height);
 		builder.append("_");
 		builder.append(style);
-		//
+
 		return builder.toString();
 	}
 

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/Legend.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/Legend.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SWTChart project.
+ * Copyright (c) 2008, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -270,7 +270,7 @@ public class Legend extends Composite implements ILegend, PaintListener {
 				if(!series.isVisibleInLegend()) {
 					continue;
 				}
-				//
+
 				if(series instanceof ICircularSeries) {
 					ICircularSeries<?> circularSeries = (ICircularSeries<?>)series;
 					String[] labels = circularSeries.getLabels();
@@ -319,7 +319,7 @@ public class Legend extends Composite implements ILegend, PaintListener {
 				if(!series.isVisibleInLegend()) {
 					continue;
 				}
-				//
+
 				if(series instanceof ICircularSeries) {
 					ICircularSeries<?> circularSeries = (ICircularSeries<?>)series;
 					String[] labels = circularSeries.getLabels();
@@ -446,7 +446,7 @@ public class Legend extends Composite implements ILegend, PaintListener {
 			if(!seriesArray[i].isVisibleInLegend()) {
 				continue;
 			}
-			//
+
 			if(seriesArray[i] instanceof ICircularSeries) {
 				ICircularSeries<?> circularSeries = (ICircularSeries<?>)seriesArray[i];
 				String[] labels = circularSeries.getLabels();
@@ -459,7 +459,7 @@ public class Legend extends Composite implements ILegend, PaintListener {
 							Node node = circularSeries.getNodeById(id);
 							String label = node.getDescription().isEmpty() ? id : node.getDescription();
 							Color color = colors[j];
-							//
+
 							if(color != null) {
 								boolean draw = node != null ? node.isVisibleInLegend() : true;
 								if(draw) {

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/PlotArea.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/PlotArea.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SWTChart project.
+ * Copyright (c) 2008, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -56,17 +56,17 @@ public class PlotArea extends Composite implements PaintListener, IPlotArea {
 	/** the custom paint listeners */
 	private List<ICustomPaintListener> paintListeners;
 	private DisposeListener disposeListener;
-	//
+
 	private Image image = null;
 	private int imagePositionX = 0;
 	private int imagePositionY = 0;
-	//
+
 	private String text = "";
 	private Font fontText = Display.getDefault().getSystemFont();
 	private Color colorText = Display.getDefault().getSystemColor(SWT.COLOR_BLACK);
 	private int textPositionX = 0;
 	private int textPositionY = 0;
-	//
+
 	private boolean buffered = false;
 
 	/**
@@ -199,7 +199,7 @@ public class PlotArea extends Composite implements PaintListener, IPlotArea {
 		 */
 		Font fontDefault = gc.getFont();
 		Color colorDefault = gc.getForeground();
-		//
+
 		gc.setFont(fontText);
 		gc.setForeground(colorText);
 		if(image != null) {
@@ -208,7 +208,7 @@ public class PlotArea extends Composite implements PaintListener, IPlotArea {
 		} else {
 			drawText(gc, sizePlotArea, text, textPositionX, textPositionY, 0);
 		}
-		//
+
 		gc.setForeground(colorDefault);
 		gc.setFont(fontDefault);
 		/*
@@ -229,13 +229,13 @@ public class PlotArea extends Composite implements PaintListener, IPlotArea {
 				((Series<?>)series).draw(gc, sizePlotArea.x, sizePlotArea.y);
 			}
 		}
-		//
+
 		for(ISeries<?> series : chart.getSeriesSet().getSeries()) {
 			if(series instanceof ILineSeries) {
 				((Series<?>)series).draw(gc, sizePlotArea.x, sizePlotArea.y);
 			}
 		}
-		//
+
 		for(ISeries<?> series : chart.getSeriesSet().getSeries()) {
 			if(series instanceof ICircularSeries) {
 				((Series<?>)series).draw(gc, sizePlotArea.x, sizePlotArea.y);
@@ -257,7 +257,7 @@ public class PlotArea extends Composite implements PaintListener, IPlotArea {
 		Point chartSize = getSize();
 		Image image = null;
 		GC gc = null;
-		//
+
 		try {
 			image = new Image(getDisplay(), new ImageData(chartSize.x, chartSize.y, 32, new PaletteData(0xFF, 0xFF00, 0xFF0000)));
 			gc = new GC(this);
@@ -277,7 +277,7 @@ public class PlotArea extends Composite implements PaintListener, IPlotArea {
 				image.dispose();
 			}
 		}
-		//
+
 		return imageData;
 	}
 
@@ -302,7 +302,7 @@ public class PlotArea extends Composite implements PaintListener, IPlotArea {
 		int x = imagePositionX;
 		int y = imagePositionY;
 		int offset = rectangle.height;
-		//
+
 		if(imagePositionX == POSITION_CENTER_X && imagePositionY == POSITION_CENTER_Y) {
 			x = (int)(sizePlotArea.x / 2.0d - rectangle.width / 2.0d);
 			y = (int)(sizePlotArea.y / 2.0d - rectangle.height / 2.0d);
@@ -324,7 +324,7 @@ public class PlotArea extends Composite implements PaintListener, IPlotArea {
 			int x = textPositionX;
 			int y = textPositionY;
 			Point sizeText = gc.textExtent(text);
-			//
+
 			if(textPositionX == POSITION_CENTER_X && textPositionY == POSITION_CENTER_Y) {
 				x = (int)(sizePlotArea.x / 2.0d - sizeText.x / 2.0d);
 				y = (int)(sizePlotArea.y / 2.0d - sizeText.y);

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/Title.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/Title.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 SWTChart project.
+ * Copyright (c) 2008, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -177,7 +177,7 @@ public class Title implements ITitle, PaintListener {
 		initializeTextLayout();
 		TextLayout textLayout = Resources.getTextLayout(textLayoutUUID);
 		textLayout.setText(text);
-		//
+
 		styleRanges = ranges;
 		if(styleRanges != null) {
 			for(StyleRange styleRange : styleRanges) {
@@ -405,7 +405,7 @@ public class Title implements ITitle, PaintListener {
 		if(useTextLayout && textLayoutUUID == null) {
 			initializeTextLayout();
 		}
-		//
+
 		return useTextLayout;
 	}
 

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/Util.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/Util.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SWTChart project.
+ * Copyright (c) 2008, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -61,7 +61,7 @@ public final class Util {
 		 */
 		image.dispose();
 		gc.dispose();
-		//
+
 		return p;
 	}
 }

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/AxisPositionMarker.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/AxisPositionMarker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Lablicate GmbH.
+ * Copyright (c) 2021, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -37,7 +37,7 @@ public class AxisPositionMarker implements PaintListener {
 	private static final int OFFSET_LINE_Y = 2;
 	private static final int ARC_WIDTH = 5;
 	private static final int ARC_HEIGHT = 3;
-	//
+
 	private Chart chart;
 	private Axis axis;
 	private Rectangle bounds;
@@ -101,17 +101,17 @@ public class AxisPositionMarker implements PaintListener {
 				gc.setForeground(e.display.getSystemColor(SWT.COLOR_WHITE));
 				gc.setBackground(e.display.getSystemColor(SWT.COLOR_DARK_GRAY));
 				Font font = gc.getFont();
-				//
+
 				AxisTick axisTick = axis.getTick();
 				Format axisFormat = axisTick.getFormat();
 				gc.setFont(axisTick.getFont());
-				//
+
 				if(axis.isHorizontalAxis()) {
 					drawPositionMarkerX(e.gc, axisFormat);
 				} else {
 					drawPositionMarkerY(e.gc, axisFormat);
 				}
-				//
+
 				gc.setForeground(foreground);
 				gc.setBackground(background);
 				gc.setFont(font);
@@ -129,7 +129,7 @@ public class AxisPositionMarker implements PaintListener {
 
 		String textValue = getTextValue(format, getValueX());
 		Point textExtend = getTextExtend(gc, textValue);
-		//
+
 		if(axis.getPosition() == Position.Primary) {
 			drawPrimaryMarkerX(gc, textValue, textExtend);
 		} else {
@@ -141,7 +141,7 @@ public class AxisPositionMarker implements PaintListener {
 
 		String textValue = getTextValue(format, getValueY());
 		Point textExtend = getTextExtend(gc, textValue);
-		//
+
 		if(axis.getPosition() == Position.Primary) {
 			drawPrimaryMarkerY(gc, textValue, textExtend);
 		} else {
@@ -154,7 +154,7 @@ public class AxisPositionMarker implements PaintListener {
 		int offsetX = textExtend.x / 2;
 		int positionX = bounds.x + x - offsetX;
 		int positionY = bounds.y + OFFSET_RECTANGLE_X;
-		//
+
 		drawTrianglePrimaryX(gc);
 		fillRoundRectangle(gc, positionX, positionY, textExtend.x, textExtend.y);
 		drawText(gc, positionX + OFFSET_TEXT_X, positionY + OFFSET_TEXT_Y, textValue);
@@ -166,7 +166,7 @@ public class AxisPositionMarker implements PaintListener {
 		int offsetY = textExtend.y / 2;
 		int positionX = bounds.x + x - offsetX;
 		int positionY = bounds.y - offsetY - OFFSET_RECTANGLE_X;
-		//
+
 		drawTriangleSecondaryX(gc);
 		fillRoundRectangle(gc, positionX, positionY - OFFSET_SPACE_Y, textExtend.x, textExtend.y);
 		drawText(gc, positionX + OFFSET_TEXT_X, positionY - OFFSET_SPACE_Y, textValue);
@@ -177,7 +177,7 @@ public class AxisPositionMarker implements PaintListener {
 		int offsetY = textExtend.y / 2;
 		int positionX = bounds.x - textExtend.x + OFFSET_RECTANGLE_X;
 		int positionY = bounds.y + y - offsetY - OFFSET_LINE_Y;
-		//
+
 		drawTrianglePrimaryY(gc);
 		fillRoundRectangle(gc, positionX - OFFSET_TEXT_Y, positionY, textExtend.x - OFFSET_TEXT_X, textExtend.y);
 		drawText(gc, positionX, positionY + OFFSET_TEXT_Y, textValue);
@@ -188,7 +188,7 @@ public class AxisPositionMarker implements PaintListener {
 		int offsetY = textExtend.y / 2;
 		int positionX = bounds.x + OFFSET_RECTANGLE_X;
 		int positionY = bounds.y + y - offsetY - OFFSET_LINE_Y;
-		//
+
 		drawTriangleSecondaryY(gc);
 		fillRoundRectangle(gc, positionX, positionY, textExtend.x + OFFSET_TEXT_X, textExtend.y);
 		drawText(gc, positionX + OFFSET_TEXT_X + TRIANGLE_DELTA, positionY + OFFSET_TEXT_Y, textValue);
@@ -204,7 +204,7 @@ public class AxisPositionMarker implements PaintListener {
 		int y2 = positionY + OFFSET_RECTANGLE_X;
 		int x3 = positionX - OFFSET_RECTANGLE_X + TRIANGLE_DELTA;
 		int y3 = positionY + OFFSET_RECTANGLE_X;
-		//
+
 		drawTriangle(gc, x1, y1, x2, y2, x3, y3);
 	}
 
@@ -218,7 +218,7 @@ public class AxisPositionMarker implements PaintListener {
 		int y2 = positionY;
 		int x3 = positionX;
 		int y3 = positionY + OFFSET_RECTANGLE_X;
-		//
+
 		drawTriangle(gc, x1, y1, x2, y2, x3, y3);
 	}
 
@@ -232,7 +232,7 @@ public class AxisPositionMarker implements PaintListener {
 		int y2 = positionY + OFFSET_RECTANGLE_X - TRIANGLE_DELTA;
 		int x3 = positionX + OFFSET_RECTANGLE_X;
 		int y3 = positionY;
-		//
+
 		drawTriangle(gc, x1, y1, x2, y2, x3, y3);
 	}
 
@@ -246,7 +246,7 @@ public class AxisPositionMarker implements PaintListener {
 		int y2 = positionY + OFFSET_RECTANGLE_X - TRIANGLE_DELTA;
 		int x3 = positionX;
 		int y3 = positionY;
-		//
+
 		drawTriangle(gc, x1, y1, x2, y2, x3, y3);
 	}
 

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/AxisTickLabels.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/AxisTickLabels.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 SWTChart project.
+ * Copyright (c) 2008, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -329,7 +329,7 @@ public class AxisTickLabels implements PaintListener {
 				if(axis.isLogScaleEnabled()) {
 					isMajorTick = isMajorTick(tickLabelValues.get(i));
 				}
-				//
+
 				try {
 					/*
 					 * Check if the value is close to the tick label, then it is a major tick
@@ -346,7 +346,7 @@ public class AxisTickLabels implements PaintListener {
 					// Label is not decimal value but string
 				}
 			}
-			//
+
 			if(hasSpaceToDraw) {
 				if(isMajorTick) {
 					previousPosition = tickLabelPositions.get(i);
@@ -379,12 +379,12 @@ public class AxisTickLabels implements PaintListener {
 		if(format == null) {
 			return new DecimalFormat(DEFAULT_DECIMAL_FORMAT).parse(label).doubleValue();
 		}
-		//
+
 		Object parsed = format.parseObject(label);
 		if(!(parsed instanceof Number)) {
 			throw new ParseException(label, 0);
 		}
-		//
+
 		return ((Number)parsed).doubleValue();
 	}
 
@@ -547,7 +547,7 @@ public class AxisTickLabels implements PaintListener {
 		if(lengthInPixels <= 0) {
 			throw new IllegalArgumentException(Messages.getString(Messages.LENGTH_MUST_BE_POSITIVE));
 		}
-		//
+
 		if(min >= max) {
 			throw new IllegalArgumentException(Messages.getString(Messages.MUST_BE_LESS_MAX));
 		}
@@ -605,7 +605,7 @@ public class AxisTickLabels implements PaintListener {
 				}
 			}
 		}
-		//
+
 		return gridStep;
 	}
 
@@ -729,7 +729,7 @@ public class AxisTickLabels implements PaintListener {
 		if(!axis.getTick().isVisible()) {
 			return;
 		}
-		//
+
 		Color oldBackground = e.gc.getBackground();
 		e.gc.setBackground(chart.getBackground());
 		Color oldForeground = e.gc.getForeground();

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/Messages.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWT Chart Project
+ * Copyright (c) 2020, 2025 SWT Chart Project
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,7 @@ public class Messages {
 
 	private static final String BUNDLE_NAME = "org.eclipse.swtchart.internal.axis.messages"; //$NON-NLS-1$
 	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
-	//
+
 	public static final String AXIS_ID_DONT_EXIST = "AXIS_ID_DONT_EXIST";
 	public static final String GIVEN_RANGE_INVALID = "GIVEN_RANGE_INVALID";
 	public static final String ILLEGAL_RANGE = "ILLEGAL_RANGE";

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/compress/Compress.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/compress/Compress.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2022 SWTChart project.
+ * Copyright (c) 2008, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -93,7 +93,7 @@ public abstract class Compress implements ICompress {
 		if(compressedXSeries == null) {
 			return new double[0];
 		}
-		//
+
 		double[] copiedSeries = new double[compressedXSeries.length];
 		System.arraycopy(compressedXSeries, 0, copiedSeries, 0, compressedXSeries.length);
 		return copiedSeries;
@@ -105,7 +105,7 @@ public abstract class Compress implements ICompress {
 		if(compressedYSeries == null) {
 			return new double[0];
 		}
-		//
+
 		double[] copiedSeries = new double[compressedYSeries.length];
 		System.arraycopy(compressedYSeries, 0, copiedSeries, 0, compressedYSeries.length);
 		return copiedSeries;
@@ -117,7 +117,7 @@ public abstract class Compress implements ICompress {
 		if(compressedIndexes == null) {
 			return new int[0];
 		}
-		//
+
 		int[] copiedSeries = new int[compressedIndexes.length];
 		System.arraycopy(compressedIndexes, 0, copiedSeries, 0, compressedIndexes.length);
 		return copiedSeries;

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/series/CircularSeries.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/series/CircularSeries.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -35,12 +35,12 @@ public abstract class CircularSeries extends Series implements ICircularSeries {
 	private Color borderColor = Display.getDefault().getSystemColor(SWT.COLOR_GRAY);
 	private int borderWidth = 1;
 	private int borderStyle = SWT.LINE_SOLID;
-	//
+
 	private Color sliceColorHighlight = Display.getDefault().getSystemColor(SWT.COLOR_RED);
 	private Color borderColorHighlight = Display.getDefault().getSystemColor(SWT.COLOR_DARK_RED);
 	private int borderWidthHighlight = 3;
 	private int borderStyleHighlight = SWT.LINE_SOLID;
-	//
+
 	private Chart chart;
 	private NodeDataModel nodeDataModel;
 	private Node rootNode;
@@ -54,7 +54,7 @@ public abstract class CircularSeries extends Series implements ICircularSeries {
 		super(chart, id);
 		this.chart = chart;
 		initialize();
-		//
+
 		nodeDataModel = new NodeDataModel(id);
 		rootNode = nodeDataModel.getRootNode();
 		rootPointer = nodeDataModel.getRootPointer();
@@ -206,7 +206,7 @@ public abstract class CircularSeries extends Series implements ICircularSeries {
 		for(int i = 1; i <= maxTreeDepth; i++) {
 			tot += nodes[i].size();
 		}
-		//
+
 		String[] labels = new String[tot];
 		for(int i = 1; i <= maxTreeDepth; i++) {
 			int len = nodes[i].size();
@@ -215,7 +215,7 @@ public abstract class CircularSeries extends Series implements ICircularSeries {
 				index++;
 			}
 		}
-		//
+
 		return labels;
 	}
 
@@ -227,7 +227,7 @@ public abstract class CircularSeries extends Series implements ICircularSeries {
 		for(int i = 1; i <= maxTreeDepth; i++) {
 			tot += nodes[i].size();
 		}
-		//
+
 		Color[] colors = new Color[tot];
 		for(int i = 1; i <= maxTreeDepth; i++) {
 			int len = nodes[i].size();
@@ -236,7 +236,7 @@ public abstract class CircularSeries extends Series implements ICircularSeries {
 				ind++;
 			}
 		}
-		//
+
 		return colors;
 	}
 
@@ -247,7 +247,7 @@ public abstract class CircularSeries extends Series implements ICircularSeries {
 		if(colors.length != length) {
 			// Throw Error
 		}
-		//
+
 		for(int i = 0; i != length; i++) {
 			if(colors[i] != null)
 				nodeDataModel.getNodeById(getLabels()[i]).setSliceColor(colors[i]);
@@ -270,11 +270,11 @@ public abstract class CircularSeries extends Series implements ICircularSeries {
 		if(values.length != length) {
 			// throw error
 		}
-		//
+
 		for(int i = 0; i != length; i++) {
 			new Node(labels[i], values[i], rootNode);
 		}
-		//
+
 		nodeDataModel.update();
 	}
 
@@ -292,18 +292,18 @@ public abstract class CircularSeries extends Series implements ICircularSeries {
 			this.highlightedNode = null;
 			return;
 		}
-		//
+
 		Node node = highlightedNode;
 		while(node != getRootPointer() && node != getRootNode()) {
 			node = node.getParent();
 		}
-		//
+
 		if(node != getRootPointer()) {
 			return;
 		}
-		//
+
 		borderColorHighlight = (borderColorHighlight == null) ? Display.getDefault().getSystemColor(SWT.COLOR_BLACK) : borderColorHighlight;
-		//
+
 		this.highlightedNode = highlightedNode;
 	}
 
@@ -320,7 +320,7 @@ public abstract class CircularSeries extends Series implements ICircularSeries {
 		gc.setForeground(sliceColor != null ? sliceColor : Display.getDefault().getSystemColor(SWT.COLOR_BLACK));
 		gc.setLineStyle(borderStyle);
 		gc.setLineWidth(borderWidth);
-		//
+
 		/*
 		 * A DFS function which draws the node after drawing it's children.
 		 */
@@ -329,7 +329,7 @@ public abstract class CircularSeries extends Series implements ICircularSeries {
 		 * highlight just the required node.
 		 */
 		if(highlightedNode != null && borderColorHighlight != null) {
-			//
+
 			gc.setForeground(borderColorHighlight);
 			gc.setLineStyle(borderStyleHighlight);
 			gc.setLineWidth(borderWidthHighlight);
@@ -340,7 +340,7 @@ public abstract class CircularSeries extends Series implements ICircularSeries {
 			int yStart = yAxis.getPixelCoordinate(level);
 			int xWidth = xAxis.getPixelCoordinate(level) - xStart;
 			int yWidth = yAxis.getPixelCoordinate(-level) - yStart;
-			//
+
 			int angleStart = highlightedNode.getAngleBounds().x;
 			int angleWidth = highlightedNode.getAngleBounds().y;
 			// drawing the inner and outer arcs of the highlighted node.
@@ -432,7 +432,7 @@ public abstract class CircularSeries extends Series implements ICircularSeries {
 				highlightedNode = null;
 			}
 		}
-		//
+
 		this.rootPointer = rootPointer;
 		nodeDataModel.setRootPointer(rootPointer);
 	}

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/series/DoughnutSeries.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/series/DoughnutSeries.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -46,11 +46,11 @@ public class DoughnutSeries extends CircularSeries {
 				drawNode(nodes, gc, xAxis, yAxis);
 			}
 		}
-		//
+
 		if(node.isVisible() == false) {
 			return;
 		}
-		//
+
 		int level = node.getLevel() - getRootPointer().getLevel() + 1;
 		/*
 		 * the center of the chart is (0,0). The x and y axis are set such that
@@ -77,7 +77,7 @@ public class DoughnutSeries extends CircularSeries {
 		double yStartCoordinate = level * Math.sin(Math.toRadians(angleStart));
 		int xStartPixelCoordinate = xAxis.getPixelCoordinate(xStartCoordinate);
 		int yStartPixelCoordinate = yAxis.getPixelCoordinate(yStartCoordinate);
-		//
+
 		if(node != getRootPointer()) {
 			gc.drawLine(xZero, yZero, xStartPixelCoordinate, yStartPixelCoordinate);
 		}
@@ -88,7 +88,7 @@ public class DoughnutSeries extends CircularSeries {
 		double yEndCoordinate = level * Math.sin(Math.toRadians(angleStart + angleWidth));
 		int xEndPixelCoordinate = xAxis.getPixelCoordinate(xEndCoordinate);
 		int yEndPixelCoordinate = yAxis.getPixelCoordinate(yEndCoordinate);
-		//
+
 		if(node != getRootPointer()) {
 			gc.drawLine(xZero, yZero, xEndPixelCoordinate, yEndPixelCoordinate);
 		}
@@ -144,7 +144,7 @@ public class DoughnutSeries extends CircularSeries {
 		if(angleOfInspection < 0.0) {
 			angleOfInspection += 2 * Math.PI;
 		}
-		//
+
 		if(level < getNodeDataModel().getNodes().length) {
 			for(Node nodeX : getNodeDataModel().getNodes()[level]) {
 				double lowerBound = (nodeX.getAngleBounds().x * Math.PI) / (double)180.0;
@@ -155,7 +155,7 @@ public class DoughnutSeries extends CircularSeries {
 				}
 			}
 		}
-		//
+
 		return node;
 	}
 }

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/series/LineSeries.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/series/LineSeries.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2024 SWTChart project.
+ * Copyright (c) 2008, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -348,15 +348,15 @@ public class LineSeries<T> extends Series<T> implements ILineSeries<T> {
 		int oldLineWidth = gc.getLineWidth();
 		gc.setAntialias(antialias);
 		gc.setLineWidth(lineWidth);
-		//
+
 		if(lineStyle != LineStyle.NONE) {
 			drawLineAndArea(gc, width, height, xAxis, yAxis);
 		}
-		//
+
 		if(symbolType != PlotSymbolType.NONE || getLabel().isVisible() || getXErrorBar().isVisible() || getYErrorBar().isVisible()) {
 			drawSymbolAndLabel(gc, width, height, xAxis, yAxis);
 		}
-		//
+
 		gc.setAntialias(oldAntialias);
 		gc.setLineWidth(oldLineWidth);
 	}
@@ -383,14 +383,14 @@ public class LineSeries<T> extends Series<T> implements ILineSeries<T> {
 		if(xseries.length == 0 || yseries.length == 0) {
 			return;
 		}
-		//
+
 		int[] indexes = compressor.getCompressedIndexes();
 		if(xAxis.isValidCategoryAxis()) {
 			for(int i = 0; i < xseries.length; i++) {
 				xseries[i] = indexes[i];
 			}
 		}
-		//
+
 		gc.setLineStyle(lineStyle.value());
 		Color oldForeground = gc.getForeground();
 		gc.setForeground(getLineColor());
@@ -415,7 +415,7 @@ public class LineSeries<T> extends Series<T> implements ILineSeries<T> {
 			int[] idx = useAreaStrict ? IntStream.range(0, x.length - 1).toArray() : null;
 			int[] p0 = useAreaStrict ? getLinePoints(x, y, idx, 0, xAxis, yAxis) : null;
 			int[] pn = useAreaStrict ? getLinePoints(x, y, idx, idx.length - 1, xAxis, yAxis) : null;
-			//
+
 			for(int i = 0; i < length; i++) {
 				int[] p = getLinePoints(xseries, yseries, indexes, i, xAxis, yAxis);
 				/*
@@ -637,7 +637,7 @@ public class LineSeries<T> extends Series<T> implements ILineSeries<T> {
 		gc.setAlpha(ALPHA);
 		Color oldBackground = gc.getBackground();
 		gc.setBackground(getLineColor());
-		//
+
 		int[] pointArray;
 		if(stepEnabled) {
 			if(isHorizontal) {
@@ -648,7 +648,7 @@ public class LineSeries<T> extends Series<T> implements ILineSeries<T> {
 		} else {
 			pointArray = new int[]{p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[0], p[1]};
 		}
-		//
+
 		gc.fillPolygon(pointArray);
 		gc.setAlpha(alpha);
 		gc.setBackground(oldBackground);

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/series/PieSeries.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/series/PieSeries.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -46,11 +46,11 @@ public class PieSeries extends CircularSeries {
 				drawNode(nodes, gc, xAxis, yAxis);
 			}
 		}
-		//
+
 		if(node.isVisible() == false) {
 			return;
 		}
-		//
+
 		int level = node.getLevel() - getRootPointer().getLevel();
 		/*
 		 * the center of the chart is (0,0). The x and y axis are set such that
@@ -77,7 +77,7 @@ public class PieSeries extends CircularSeries {
 		double yStartCoordinate = level * Math.sin(Math.toRadians(angleStart));
 		int xStartPixelCoordinate = xAxis.getPixelCoordinate(xStartCoordinate);
 		int yStartPixelCoordinate = yAxis.getPixelCoordinate(yStartCoordinate);
-		//
+
 		gc.drawLine(xZero, yZero, xStartPixelCoordinate, yStartPixelCoordinate);
 		/*
 		 * drawing the end boundary
@@ -86,7 +86,7 @@ public class PieSeries extends CircularSeries {
 		double yEndCoordinate = level * Math.sin(Math.toRadians(angleStart + angleWidth));
 		int xEndPixelCoordinate = xAxis.getPixelCoordinate(xEndCoordinate);
 		int yEndPixelCoordinate = yAxis.getPixelCoordinate(yEndCoordinate);
-		//
+
 		gc.drawLine(xZero, yZero, xEndPixelCoordinate, yEndPixelCoordinate);
 	}
 
@@ -140,7 +140,7 @@ public class PieSeries extends CircularSeries {
 		if(angleOfInspection < 0.0) {
 			angleOfInspection += 2 * Math.PI;
 		}
-		//
+
 		if(level < getNodeDataModel().getNodes().length) {
 			for(Node nodeX : getNodeDataModel().getNodes()[level]) {
 				double lowerBound = (nodeX.getAngleBounds().x * Math.PI) / (double)180.0;
@@ -151,7 +151,7 @@ public class PieSeries extends CircularSeries {
 				}
 			}
 		}
-		//
+
 		return node;
 	}
 }

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/series/SeriesSet.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/series/SeriesSet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SWTChart project.
+ * Copyright (c) 2008, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -251,7 +251,7 @@ public class SeriesSet implements ISeriesSet {
 		if(!chart.isCompressEnabled()) {
 			return;
 		}
-		//
+
 		try {
 			CompressConfig config = new CompressConfig();
 			final int PRECISION = 2;

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/model/Node.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/model/Node.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -348,7 +348,7 @@ public class Node {
 		Iterable<Node> nodes = children;
 		if(nodes == null)
 			return;
-		//
+
 		int start = angleBounds.x;
 		double diff = 0, required = 0;
 		for(Node node : nodes) {

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/model/NodeDataModel.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/model/NodeDataModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -133,7 +133,7 @@ public class NodeDataModel {
 		 */
 		int maxTreeDepth = rootPointer.getMaxSubTreeDepth() - 1;
 		setNodes(new ArrayList[maxTreeDepth + 1]);
-		//
+
 		ArrayList<Node>[] node = (ArrayList<Node>[])getNodes();
 		for(int i = 0; i <= maxTreeDepth; i++) {
 			node[i] = new ArrayList<Node>();
@@ -144,9 +144,9 @@ public class NodeDataModel {
 		 */
 		node[0].add(rootPointer);
 		getRootPointer().updateAngularBounds();
-		//
+
 		getRootPointer().setVisible(true);
-		//
+
 		compressCircularSeries.update();
 	}
 

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/support/CircularLegend.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/support/CircularLegend.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -370,7 +370,7 @@ public class CircularLegend extends Composite implements ILegend, PaintListener 
 			if(!seriesArray[i].isVisibleInLegend()) {
 				continue;
 			}
-			//
+
 			if(seriesArray[i] instanceof ICircularSeries) {
 				ICircularSeries<?> pieSeries = (ICircularSeries<?>)seriesArray[i];
 				String[] labels = pieSeries.getLabels();


### PR DESCRIPTION
This seems to be using the downstream code styles from @eclipse-chemclipse which were changed half a year ago in https://github.com/eclipse-chemclipse/chemclipse/pull/2051. This is doing a regex search and replace: `^\s*//\s*\r?\n` → `\n` on all files.