### PR TITLE
Drop enforcer rule usage

### DIFF
--- a/org.eclipse.swtchart.cbi/pom.xml
+++ b/org.eclipse.swtchart.cbi/pom.xml
@@ -100,26 +100,6 @@
     -->
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.6.1</version>
-        <executions>
-          <execution>
-            <id>enforce-maven</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireMavenVersion>
-                  <version>3.9</version>
-                </requireMavenVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>${tycho.groupid}</groupId>
         <artifactId>tycho-packaging-plugin</artifactId>
         <version>${tycho.version}</version>


### PR DESCRIPTION
It is used to enforce Maven 3.9 but used Tycho version itself requires 3.9.6 so this check is actually pointless and it's best to let Tycho define the requirement for Maven.