### PR TITLE
Enable JavaDoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
     - name: Build with Maven
       uses: coactions/setup-xvfb@v1
       with:
-        run: mvn -f org.eclipse.swtchart.cbi/pom.xml -T 1C verify --B -ntp -Dstyle.color=always
+        run: mvn -f org.eclipse.swtchart.cbi/pom.xml -Pjavadoc -T 1C verify --B -ntp -Dstyle.color=always

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
 				withCredentials([file(credentialsId: 'secret-subkeys.asc', variable: 'KEYRING'),string(credentialsId: 'gpg-passphrase', variable: 'MAVEN_GPG_PASSPHRASE') ]) {
 				wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
 					sh '''
-						mvn -f org.eclipse.swtchart.cbi/pom.xml -Peclipse-sign clean install -Dtycho.pgp.signer.bc.secretKeys="${KEYRING}"
+						mvn -f org.eclipse.swtchart.cbi/pom.xml -Peclipse-sign -Pjavadoc clean install -Dtycho.pgp.signer.bc.secretKeys="${KEYRING}"
 					'''
 				}
 				}

--- a/org.eclipse.swtchart.cbi/pom.xml
+++ b/org.eclipse.swtchart.cbi/pom.xml
@@ -251,19 +251,6 @@
                      </execution>
                   </executions>
                </plugin>
-               <!-- <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-javadoc-plugin</artifactId>
-                  <version>3.7.0</version>
-                  <executions>
-                     <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                           <goal>jar</goal>
-                        </goals>
-                     </execution>
-                  </executions>
-               </plugin> -->
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-shade-plugin</artifactId>
@@ -292,6 +279,32 @@
                </plugin>
             </plugins>
          </build>
+      </profile>
+      <profile>
+        <id>javadoc</id>
+          <build>
+            <plugins>
+              <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-javadoc-plugin</artifactId>
+                  <version>3.11.2</version>
+                  <executions>
+                      <execution>
+                          <id>attach-javadocs</id>
+                          <phase>package</phase>
+                          <goals>
+                              <goal>jar</goal>
+                          </goals>
+                          <configuration>
+                            <source>21</source>
+                            <failOnError>false</failOnError>
+                            <legacyMode>true</legacyMode>
+                          </configuration>
+                      </execution>
+                  </executions>
+              </plugin>
+          </plugins>
+        </build>
       </profile>
     </profiles>
     <pluginRepositories>


### PR DESCRIPTION
https://ci.eclipse.org/swtchart/job/build/job/develop/ shows no JavaDoc errors, but it is a lie. They are just not generated.