### PR TITLE
Fix JavaDoc warnings/errors

### DIFF
--- a/org.eclipse.swtchart.cbi/pom.xml
+++ b/org.eclipse.swtchart.cbi/pom.xml
@@ -273,7 +273,7 @@
               <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-javadoc-plugin</artifactId>
-                  <version>3.11.3</version>
+                  <version>3.11.2</version>
                   <executions>
                       <execution>
                           <id>attach-javadocs</id>

--- a/org.eclipse.swtchart.cbi/pom.xml
+++ b/org.eclipse.swtchart.cbi/pom.xml
@@ -286,6 +286,18 @@
                             <failOnError>false</failOnError>
                             <legacyMode>true</legacyMode>
                             <doclint>accessibility,html,reference,syntax</doclint>
+                            <additionalDependencies>
+                              <additionalDependency>
+                                <groupId>org.osgi</groupId>
+                                <artifactId>org.osgi.service.component.annotations</artifactId>
+                                <version>1.5.0</version>
+                              </additionalDependency>
+                              <dependency>
+                                <groupId>org.eclipse.pde</groupId>
+                                <artifactId>org.eclipse.pde.api.tools.annotations</artifactId>
+                                <version>1.2.0</version>
+                              </dependency>
+                            </additionalDependencies>
                           </configuration>
                       </execution>
                   </executions>

--- a/org.eclipse.swtchart.cbi/pom.xml
+++ b/org.eclipse.swtchart.cbi/pom.xml
@@ -285,6 +285,7 @@
                             <source>21</source>
                             <failOnError>false</failOnError>
                             <legacyMode>true</legacyMode>
+                            <doclint>accessibility,html,reference,syntax</doclint>
                           </configuration>
                       </execution>
                   </executions>

--- a/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/images/ImageFactory.java
+++ b/org.eclipse.swtchart.export/src/org/eclipse/swtchart/export/images/ImageFactory.java
@@ -29,7 +29,6 @@ public class ImageFactory<T extends ScrollableChart> {
 	 * 
 	 * @param width
 	 * @param height
-	 * @return Shell
 	 * @throws IllegalAccessException
 	 * @throws InstantiationException
 	 */
@@ -39,7 +38,7 @@ public class ImageFactory<T extends ScrollableChart> {
 			t = clazz.getDeclaredConstructor().newInstance();
 			imageSupplier = new ImageSupplier();
 
-			display = ((ScrollableChart)t).getBaseChart().getDisplay();
+			display = t.getBaseChart().getDisplay();
 			if(display != null) {
 				width = (width > display.getBounds().width) ? display.getBounds().width : width;
 				height = (height > display.getBounds().height) ? display.getBounds().height : height;

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/barcharts/IBarSeriesData.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/barcharts/IBarSeriesData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,7 +18,7 @@ public interface IBarSeriesData extends IChartSeriesData {
 
 	/**
 	 * @deprecated use {@link #getSettings()} instead
-	 * @return
+	 * @return the {@link IBarSeriesSettings}
 	 */
 	@Deprecated
 	IBarSeriesSettings getBarSeriesSettings();

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/BaseChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/BaseChart.java
@@ -214,7 +214,7 @@ public class BaseChart extends AbstractExtendedChart implements IChartDataCoordi
 	 * 
 	 * @param label
 	 * @param description
-	 * @return
+	 * @return the created {@link ICustomSeries} instance
 	 */
 	public ICustomSeries createCustomSeries(String label, String description) {
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/IChartSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/IChartSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -26,7 +26,7 @@ public interface IChartSettings {
 	 * This method returns null if the class instance is not available.
 	 * 
 	 * @param clazz
-	 * @return {@link IChartMenuEntry>
+	 * @return {@link IChartMenuEntry}
 	 */
 	IChartMenuEntry getChartMenuEntryByClass(Class<?> clazz);
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/IPointSeriesSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/IPointSeriesSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,7 +30,6 @@ public interface IPointSeriesSettings extends ISeriesSettings {
 	 * PlotSymbolType.NONE
 	 * 
 	 * @param symbolType
-	 * @return
 	 */
 	void setSymbolType(PlotSymbolType symbolType);
 

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/linecharts/ILineSeriesData.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/linecharts/ILineSeriesData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,7 +18,7 @@ public interface ILineSeriesData extends IChartSeriesData {
 
 	/**
 	 * @deprecated use {@link #getSettings()} instead
-	 * @return
+	 * @return the {@link ILineSeriesSettings}
 	 */
 	@Deprecated
 	ILineSeriesSettings getLineSeriesSettings();

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/scattercharts/IScatterSeriesData.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/scattercharts/IScatterSeriesData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Lablicate GmbH.
+ * Copyright (c) 2017, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,7 +18,7 @@ public interface IScatterSeriesData extends IChartSeriesData {
 
 	/**
 	 * @deprecated use {@link #getSettings()} instead
-	 * @return
+	 * @return the {@link IScatterSeriesSettings}
 	 */
 	@Deprecated
 	IScatterSeriesSettings getScatterSeriesSettings();

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/ICircularSeries.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/ICircularSeries.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 SWTChart project.
+ * Copyright (c) 2020, 2025 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -111,14 +111,14 @@ public interface ICircularSeries<T> extends ISeries<T> {
 	 * fetches a node with it's Id.
 	 * 
 	 * @param id
-	 * @return
+	 * @return the {@link Node} with the specified ID, or {@code null} if not found
 	 */
 	Node getNodeById(String id);
 
 	/**
 	 * gets the MultiLevelPie Series as Series.
 	 * 
-	 * @return
+	 * @return a list of {@link Node} objects representing the series
 	 */
 	List<Node> getSeries();
 
@@ -162,7 +162,8 @@ public interface ICircularSeries<T> extends ISeries<T> {
 	 * 
 	 * @param primaryValueX
 	 * @param primaryValueY
-	 * @return
+	 * @return the {@link Node} representing the pie slice at the given position,
+	 *         or {@code null} if no slice exists at that position
 	 */
 	Node getPieSliceFromPosition(double primaryValueX, double primaryValueY);
 
@@ -178,7 +179,8 @@ public interface ICircularSeries<T> extends ISeries<T> {
 	 * 
 	 * @param x
 	 * @param y
-	 * @return
+	 * @return the {@link Node} representing the pie slice at the given position,
+	 *         or {@code null} if no slice exists at that position
 	 */
 	Node getPieSliceFromPosition(int x, int y);
 }

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/series/CircularSeries.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/series/CircularSeries.java
@@ -184,7 +184,7 @@ public abstract class CircularSeries extends Series implements ICircularSeries {
 	 * This returns the original series that we provided as input.
 	 * This is added here so as to provide the functionalities of the simple pie chart
 	 * 
-	 * @return
+	 * @return a list of {@link Node} objects
 	 */
 	@Override
 	public List<Node> getSeries() {

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/model/IndexedSeriesModel.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/model/IndexedSeriesModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Lablicate GmbH.
+ * Copyright (c) 2019, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,7 +29,6 @@ public interface IndexedSeriesModel<T> extends SeriesModel<T> {
 	 * Get the item at the specified index
 	 * 
 	 * @param index
-	 * @return
 	 * @throws IndexOutOfBoundsException
 	 *             if index < 0 or >= {@link #size()}
 	 */

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/model/Node.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/model/Node.java
@@ -102,9 +102,7 @@ public class Node {
 	}
 
 	/**
-	 * the value of the node
-	 * 
-	 * @return
+	 * @return the value of the node
 	 */
 	public double getValue() {
 
@@ -112,9 +110,7 @@ public class Node {
 	}
 
 	/**
-	 * the id of the node.
-	 * 
-	 * @return
+	 * @return the id of the node.
 	 */
 	public String getId() {
 
@@ -189,9 +185,7 @@ public class Node {
 	}
 
 	/**
-	 * the distance from the rootNode is level of the node.
-	 * 
-	 * @return
+	 * @return the distance from the rootNode is level of the node.
 	 */
 	public int getLevel() {
 
@@ -238,8 +232,6 @@ public class Node {
 	 * 
 	 * @param labels
 	 * @param vals
-	 * @return the String-node map with each node having containing data
-	 *         corresponding to the variables passed
 	 */
 	public void addChildren(String[] labels, double[] vals) {
 
@@ -259,7 +251,6 @@ public class Node {
 	 * The nodes added are not the same as nodes provided in input.
 	 * 
 	 * @param nodes
-	 * @return
 	 */
 	public void addChildren(Node[] nodes) {
 
@@ -276,7 +267,7 @@ public class Node {
 	 * 
 	 * @param label
 	 * @param value
-	 * @return
+	 * @return the added {@link Node}
 	 */
 	public Node addChild(String label, double value) {
 
@@ -294,8 +285,9 @@ public class Node {
 
 		Node node = null;
 		for(Node nodes : children) {
-			if(nodes.getId() == child)
+			if(nodes.getId() == child) {
 				node = nodes;
+			}
 		}
 		if(node == null) {
 			// throw error
@@ -346,9 +338,9 @@ public class Node {
 	public void updateAngularBounds() {
 
 		Iterable<Node> nodes = children;
-		if(nodes == null)
+		if(nodes == null) {
 			return;
-
+		}
 		int start = angleBounds.x;
 		double diff = 0, required = 0;
 		for(Node node : nodes) {


### PR DESCRIPTION
and disable warnings for missing JavaDoc. I find it a bit too excessive. Not every function is worth documenting. This is a followup to https://github.com/eclipse-swtchart/swtchart/pull/491.