### PR TITLE
Add grid color CSS styling

### DIFF
--- a/org.eclipse.swtchart.extensions.eclipse/.gitignore
+++ b/org.eclipse.swtchart.extensions.eclipse/.gitignore
@@ -1,2 +1,3 @@
 /bin
 /target
+.polyglot.*

--- a/org.eclipse.swtchart.extensions.eclipse/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.extensions.eclipse/META-INF/MANIFEST.MF
@@ -11,6 +11,9 @@ Require-Bundle: org.eclipse.jface,
  org.eclipse.swtchart;bundle-version="1.1.0",
  org.eclipse.ui.workbench;bundle-version="3.111.0",
  org.eclipse.core.databinding;bundle-version="1.6.200",
- org.eclipse.swtchart.extensions;bundle-version="1.1.0"
+ org.eclipse.swtchart.extensions;bundle-version="1.1.0",
+ org.eclipse.e4.ui.css.core;bundle-version="0.14.500",
+ org.eclipse.e4.ui.css.swt;bundle-version="0.15.600"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
+Export-Package: org.eclipse.swtchart.extensions.eclipse.core

--- a/org.eclipse.swtchart.extensions.eclipse/plugin.xml
+++ b/org.eclipse.swtchart.extensions.eclipse/plugin.xml
@@ -8,5 +8,25 @@
             id="org.eclipse.swtchart.extensions.eclipse.preferences.preferencePage"
             name="SWTChart">
       </page>
+   </extension>
+   <extension
+         point="org.eclipse.e4.ui.css.core.propertyHandler">
+      <handler
+            adapter="org.eclipse.swtchart.extensions.eclipse.core.ScrollableChartElement"
+            composite="false"
+            handler="org.eclipse.swtchart.extensions.eclipse.core.ScrollableChartCSSPropertyHandler">
+         <property-name
+               name="grid-color">
+         </property-name>
+      </handler>
+   </extension>
+   <extension
+         point="org.eclipse.e4.ui.css.core.elementProvider">
+      <provider
+            class="org.eclipse.swtchart.extensions.eclipse.core.SWTChartElementProvider">
+         <widget
+               class="org.eclipse.swtchart.extensions.core.ScrollableChart">
+         </widget>
+      </provider>
    </extension>       
 </plugin>

--- a/org.eclipse.swtchart.extensions.eclipse/src/org/eclipse/swtchart/extensions/eclipse/core/SWTChartElementProvider.java
+++ b/org.eclipse.swtchart.extensions.eclipse/src/org/eclipse/swtchart/extensions/eclipse/core/SWTChartElementProvider.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swtchart.extensions.eclipse.core;
+
+import org.eclipse.e4.ui.css.core.dom.IElementProvider;
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
+import org.eclipse.e4.ui.css.swt.dom.SWTElementProvider;
+import org.eclipse.swtchart.extensions.core.ScrollableChart;
+import org.w3c.dom.Element;
+
+/**
+ * Returns the CSS class which is responsible for styling a SWT widget
+ *
+ * Registered via the "org.eclipse.e4.ui.css.core.elementProvider" extension
+ * point for the SWT widgets
+ *
+ *
+ *
+ * {@link IElementProvider} SWT implementation to retrieve w3c Element
+ * {@link SWTElement} linked to SWT widget.
+ *
+ */
+@SuppressWarnings("restriction")
+public class SWTChartElementProvider implements IElementProvider {
+
+	public static final IElementProvider INSTANCE = new SWTElementProvider();
+
+	@Override
+	public Element getElement(Object element, CSSEngine engine) {
+
+		if(element instanceof ScrollableChart) {
+			return new ScrollableChartElement((ScrollableChart)element, engine);
+		}
+		return null;
+	}
+}

--- a/org.eclipse.swtchart.extensions.eclipse/src/org/eclipse/swtchart/extensions/eclipse/core/ScrollableChartCSSPropertyHandler.java
+++ b/org.eclipse.swtchart.extensions.eclipse/src/org/eclipse/swtchart/extensions/eclipse/core/ScrollableChartCSSPropertyHandler.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swtchart.extensions.eclipse.core;
+
+import org.eclipse.e4.ui.css.core.dom.properties.ICSSPropertyHandler;
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
+import org.eclipse.e4.ui.css.swt.dom.WidgetElement;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.widgets.Widget;
+import org.eclipse.swtchart.extensions.core.ISecondaryAxisSettings;
+import org.eclipse.swtchart.extensions.core.ScrollableChart;
+import org.w3c.dom.css.CSSValue;
+
+@SuppressWarnings("restriction")
+public class ScrollableChartCSSPropertyHandler implements ICSSPropertyHandler {
+
+	@Override
+	public boolean applyCSSProperty(Object element, String property, CSSValue value, String pseudo, CSSEngine engine) throws Exception {
+
+		if("grid-color".equals(property)) {
+			applyCSSPropertyGridColor(element, value, pseudo, engine);
+		}
+		return false;
+	}
+
+	private void applyCSSPropertyGridColor(Object element, CSSValue value, String pseudo, CSSEngine engine) throws Exception {
+
+		Widget widget = (Widget)((WidgetElement)element).getNativeWidget();
+		if(value.getCssValueType() == CSSValue.CSS_PRIMITIVE_VALUE) {
+			Color color = (Color)engine.convert(value, Color.class, widget.getDisplay());
+			ScrollableChart scrollableChart = (ScrollableChart)widget;
+			scrollableChart.getChartSettings().getPrimaryAxisSettingsX().setGridColor(color);
+			scrollableChart.getChartSettings().getPrimaryAxisSettingsY().setGridColor(color);
+			for(ISecondaryAxisSettings secondaryAxisSettingX : scrollableChart.getChartSettings().getSecondaryAxisSettingsListX()) {
+				secondaryAxisSettingX.setGridColor(color);
+			}
+			for(ISecondaryAxisSettings secondaryAxisSettingY : scrollableChart.getChartSettings().getSecondaryAxisSettingsListY()) {
+				secondaryAxisSettingY.setGridColor(color);
+			}
+		}
+	}
+}

--- a/org.eclipse.swtchart.extensions.eclipse/src/org/eclipse/swtchart/extensions/eclipse/core/ScrollableChartElement.java
+++ b/org.eclipse.swtchart.extensions.eclipse/src/org/eclipse/swtchart/extensions/eclipse/core/ScrollableChartElement.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swtchart.extensions.eclipse.core;
+
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
+import org.eclipse.e4.ui.css.swt.dom.ControlElement;
+import org.eclipse.swtchart.extensions.core.ScrollableChart;
+
+@SuppressWarnings("restriction")
+public class ScrollableChartElement extends ControlElement {
+
+	public ScrollableChartElement(ScrollableChart scrollableChart, CSSEngine engine) {
+
+		super(scrollableChart, engine);
+	}
+
+	@Override
+	public void initialize() {
+
+		super.initialize();
+	}
+
+	@Override
+	public void dispose() {
+
+		super.dispose();
+	}
+
+	protected ScrollableChart getScrollableChart() {
+
+		return (ScrollableChart)getNativeWidget();
+	}
+}


### PR DESCRIPTION
I followed the instructions at https://www.vogella.com/tutorials/Eclipse4CSS/article.html#css-support-for-custom-widgets so you can now do
```css
.ScrollableChart {
	grid-color: #FF0000;
}
```
like you can already do `background-color`. This allows for application-wide defaults per theme.