### PR TITLE
Set a more subtle default color for grid lines

### DIFF
--- a/org.eclipse.swtchart.extensions.test/src/org/eclipse/swtchart/extensions/core/PrimaryAxisSettings_1_UITest.java
+++ b/org.eclipse.swtchart.extensions.test/src/org/eclipse/swtchart/extensions/core/PrimaryAxisSettings_1_UITest.java
@@ -68,7 +68,7 @@ public class PrimaryAxisSettings_1_UITest {
 	@Test
 	public void test7() {
 
-		assertEquals(Display.getDefault().getSystemColor(SWT.COLOR_WIDGET_BORDER), settings.getGridColor());
+		assertEquals(Display.getDefault().getSystemColor(SWT.COLOR_WIDGET_DISABLED_FOREGROUND), settings.getGridColor());
 	}
 
 	@Test

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/AbstractAxisSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/AbstractAxisSettings.java
@@ -66,7 +66,7 @@ public abstract class AbstractAxisSettings implements IAxisSettings {
 		titleFont = defaultFont;
 		visible = true;
 		position = Position.Primary;
-		gridColor = Display.getDefault().getSystemColor(SWT.COLOR_WIDGET_BORDER);
+		gridColor = Display.getDefault().getSystemColor(SWT.COLOR_WIDGET_DISABLED_FOREGROUND);
 		gridLineStyle = LineStyle.DOT;
 		enableLogScale = false;
 		logScaleBase = 10.0d;


### PR DESCRIPTION
These grid lines look best with less contrast. This is a follow-up to https://github.com/eclipse-swtchart/swtchart/pull/509.