### PR TITLE
Add Dash license check run

### DIFF
--- a/.github/workflows/licensevetting.yml
+++ b/.github/workflows/licensevetting.yml
@@ -1,0 +1,24 @@
+# This workflow will check for Maven projects if the licenses of all (transitive) dependencies are vetted.
+
+name: License vetting status check
+
+on:
+  push:
+    branches: 
+      - 'develop'
+  pull_request:
+    branches: 
+     - 'develop'
+  issue_comment:
+    types: [created]
+
+jobs:
+  call-license-check:
+    uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
+    with:
+      projectId: science.swtchart
+      javaVersion: 21
+    secrets:
+      gitlabAPIToken: ${{ secrets.GITLAB_API_TOKEN }}
+    permissions:
+      pull-requests: write


### PR DESCRIPTION
This ensures that dependencies of the project are fine to be used and ship according to EF IP team. https://github.com/eclipse-dash/dash-licenses/