### PR TITLE
Build with Tycho 5.0.0

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>4.0.13</version>
+    <version>5.0.0</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
   -->
   <properties>
     <!-- VERSIONS -->
-    <tycho.version>4.0.13</tycho.version>
+    <tycho.version>5.0.0</tycho.version>
     <tycho.sbom.url>https://projects.eclipse.org/projects/science.swtchart</tycho.sbom.url>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-swtchart/swtchart</tycho.scmUrl>
     <!-- IDS -->


### PR DESCRIPTION
PR https://github.com/eclipse-swtchart/swtchart/pull/496 failed as it was open before https://github.com/eclipse-swtchart/swtchart/pull/499 . Doing it manually so we can move on now, dependabot should work again fine on next Tycho update as
https://github.com/eclipse-swtchart/swtchart/pull/496#issuecomment-3409700374 states it will not try to update to 5.0.0 again.