### PR TITLE
Move tests to o.e.swtchart.test package

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -24,14 +24,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Find changed Java files
         id: changed
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          CHANGED_FILES=$(git diff --name-status origin/${{ github.event.pull_request.base.ref }} | grep -E '^[AM]' | awk '{print $2}')
-          echo "java=$(echo "$CHANGED_FILES" | grep '\.java$' | tr '\n' ' ' || echo '')" >> $GITHUB_OUTPUT
+          CHANGED_FILES=$(gh pr view ${{ github.event.pull_request.number }} --json files --jq '.files[] | select(.additions > 0) | .path')
+          JAVA_FILES=$(echo "$CHANGED_FILES" | grep '\.java$' || true)
+          echo "java=$(echo "$JAVA_FILES" | tr '\n' ' ')" >> $GITHUB_OUTPUT
 
       - name: Check year in license header
         shell: bash

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/AxisSetTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/AxisSetTest.java
@@ -10,15 +10,19 @@
  * Contributors:
  * yoshitaka - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swtchart;
+package org.eclipse.swtchart.test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.IAxisSet;
+import org.eclipse.swtchart.ISeries;
+import org.eclipse.swtchart.Range;
 import org.eclipse.swtchart.ISeries.SeriesType;
-import org.eclipse.swtchart.util.ChartTestCase;
+import org.eclipse.swtchart.test.util.ChartTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/AxisTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/AxisTest.java
@@ -11,7 +11,7 @@
  * yoshitaka - initial API and implementation
  * Sebastien Darche - Arbitrary base log scale test cases
  *******************************************************************************/
-package org.eclipse.swtchart;
+package org.eclipse.swtchart.test;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -24,10 +24,13 @@ import java.util.List;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.ISeries;
+import org.eclipse.swtchart.Range;
 import org.eclipse.swtchart.IAxis.Position;
 import org.eclipse.swtchart.ISeries.SeriesType;
 import org.eclipse.swtchart.internal.axis.AxisTick;
-import org.eclipse.swtchart.util.ChartTestCase;
+import org.eclipse.swtchart.test.util.ChartTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/AxisTickTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/AxisTickTest.java
@@ -12,7 +12,7 @@
  * Christoph Läubrich - adjust for API changes
  * Philip Wenig - default font name
  *******************************************************************************/
-package org.eclipse.swtchart;
+package org.eclipse.swtchart.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -31,11 +31,15 @@ import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swtchart.IAxisTick;
+import org.eclipse.swtchart.ILineSeries;
+import org.eclipse.swtchart.Range;
+import org.eclipse.swtchart.Resources;
 import org.eclipse.swtchart.IAxis.Position;
 import org.eclipse.swtchart.ISeries.SeriesType;
 import org.eclipse.swtchart.internal.axis.AxisTick;
 import org.eclipse.swtchart.internal.axis.AxisTickLabels;
-import org.eclipse.swtchart.util.ChartTestCase;
+import org.eclipse.swtchart.test.util.ChartTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/AxisTitleTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/AxisTitleTest.java
@@ -11,7 +11,7 @@
  * yoshitaka - initial API and implementation
  * Philip Wenig - default font name
  *******************************************************************************/
-package org.eclipse.swtchart;
+package org.eclipse.swtchart.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -24,8 +24,10 @@ import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swtchart.ITitle;
+import org.eclipse.swtchart.Resources;
 import org.eclipse.swtchart.internal.Title;
-import org.eclipse.swtchart.util.ChartTestCase;
+import org.eclipse.swtchart.test.util.ChartTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/BarSeriesTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/BarSeriesTest.java
@@ -10,7 +10,7 @@
  * Contributors:
  * yoshitaka - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swtchart;
+package org.eclipse.swtchart.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -22,8 +22,13 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.IBarSeries;
+import org.eclipse.swtchart.ISeries;
+import org.eclipse.swtchart.ISeriesSet;
+import org.eclipse.swtchart.Range;
 import org.eclipse.swtchart.ISeries.SeriesType;
-import org.eclipse.swtchart.util.ChartTestCase;
+import org.eclipse.swtchart.test.util.ChartTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/ChartTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/ChartTest.java
@@ -10,7 +10,7 @@
  * Contributors:
  * yoshitaka - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swtchart;
+package org.eclipse.swtchart.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -22,8 +22,11 @@ import java.util.UUID;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swtchart.IBarSeries;
+import org.eclipse.swtchart.ILineSeries;
+import org.eclipse.swtchart.ISeries;
 import org.eclipse.swtchart.ISeries.SeriesType;
-import org.eclipse.swtchart.util.ChartTestCase;
+import org.eclipse.swtchart.test.util.ChartTestCase;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/ChartTitleTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/ChartTitleTest.java
@@ -11,7 +11,7 @@
  * yoshitaka - initial API and implementation
  * Philip Wenig - default font name
  *******************************************************************************/
-package org.eclipse.swtchart;
+package org.eclipse.swtchart.test;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,8 +25,10 @@ import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swtchart.ITitle;
+import org.eclipse.swtchart.Resources;
 import org.eclipse.swtchart.internal.Title;
-import org.eclipse.swtchart.util.ChartTestCase;
+import org.eclipse.swtchart.test.util.ChartTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/ErrorBarTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/ErrorBarTest.java
@@ -10,7 +10,7 @@
  * Contributors:
  * yoshitaka - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swtchart;
+package org.eclipse.swtchart.test;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -21,9 +21,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swtchart.IErrorBar;
+import org.eclipse.swtchart.ISeries;
+import org.eclipse.swtchart.Range;
 import org.eclipse.swtchart.IErrorBar.ErrorBarType;
 import org.eclipse.swtchart.ISeries.SeriesType;
-import org.eclipse.swtchart.util.ChartTestCase;
+import org.eclipse.swtchart.test.util.ChartTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/GridTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/GridTest.java
@@ -10,7 +10,7 @@
  * Contributors:
  * yoshitaka - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swtchart;
+package org.eclipse.swtchart.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -19,7 +19,9 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swtchart.util.ChartTestCase;
+import org.eclipse.swtchart.IGrid;
+import org.eclipse.swtchart.LineStyle;
+import org.eclipse.swtchart.test.util.ChartTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/LegendTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/LegendTest.java
@@ -11,7 +11,7 @@
  * yoshitaka - initial API and implementation
  * Philip Wenig - default font name
  *******************************************************************************/
-package org.eclipse.swtchart;
+package org.eclipse.swtchart.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -26,8 +26,11 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swtchart.ILegend;
+import org.eclipse.swtchart.ISeries;
+import org.eclipse.swtchart.Resources;
 import org.eclipse.swtchart.ISeries.SeriesType;
-import org.eclipse.swtchart.util.ChartTestCase;
+import org.eclipse.swtchart.test.util.ChartTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/LineSeriesTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/LineSeriesTest.java
@@ -10,7 +10,7 @@
  * Contributors:
  * yoshitaka - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swtchart;
+package org.eclipse.swtchart.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -21,9 +21,15 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.ILineSeries;
+import org.eclipse.swtchart.ISeries;
+import org.eclipse.swtchart.ISeriesSet;
+import org.eclipse.swtchart.LineStyle;
+import org.eclipse.swtchart.Range;
 import org.eclipse.swtchart.ILineSeries.PlotSymbolType;
 import org.eclipse.swtchart.ISeries.SeriesType;
-import org.eclipse.swtchart.util.ChartTestCase;
+import org.eclipse.swtchart.test.util.ChartTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/SeriesLabelTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/SeriesLabelTest.java
@@ -11,7 +11,7 @@
  * yoshitaka - initial API and implementation
  * Philip Wenig - default font name
  *******************************************************************************/
-package org.eclipse.swtchart;
+package org.eclipse.swtchart.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -24,8 +24,12 @@ import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swtchart.ISeries;
+import org.eclipse.swtchart.ISeriesLabel;
+import org.eclipse.swtchart.Range;
+import org.eclipse.swtchart.Resources;
 import org.eclipse.swtchart.ISeries.SeriesType;
-import org.eclipse.swtchart.util.ChartTestCase;
+import org.eclipse.swtchart.test.util.ChartTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/SeriesSetTest.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/SeriesSetTest.java
@@ -10,7 +10,7 @@
  * Contributors:
  * yoshitaka - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swtchart;
+package org.eclipse.swtchart.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -18,8 +18,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.IBarSeries;
+import org.eclipse.swtchart.ISeries;
+import org.eclipse.swtchart.ISeriesSet;
 import org.eclipse.swtchart.ISeries.SeriesType;
-import org.eclipse.swtchart.util.ChartTestCase;
+import org.eclipse.swtchart.test.util.ChartTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/testmodel/BusinessObject.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/testmodel/BusinessObject.java
@@ -8,7 +8,7 @@
  * Contributors:
  * Christoph Läubrich - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swtchart.testmodel;
+package org.eclipse.swtchart.test.testmodel;
 
 import java.util.Date;
 

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/testmodel/BusinessObject.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/testmodel/BusinessObject.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Lablicate GmbH.
+ * Copyright (c) 2019, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/testmodel/BusinessObjectModel.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/testmodel/BusinessObjectModel.java
@@ -8,7 +8,7 @@
  * Contributors:
  * Christoph Läubrich - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swtchart.testmodel;
+package org.eclipse.swtchart.test.testmodel;
 
 import java.util.Iterator;
 import java.util.function.Supplier;

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/testmodel/BusinessObjectModel.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/testmodel/BusinessObjectModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Lablicate GmbH.
+ * Copyright (c) 2019, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/testmodel/SineWave.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/testmodel/SineWave.java
@@ -8,7 +8,7 @@
  * Contributors:
  * Christoph Läubrich - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swtchart.testmodel;
+package org.eclipse.swtchart.test.testmodel;
 
 import java.util.Iterator;
 import java.util.stream.IntStream;

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/testmodel/SineWave.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/testmodel/SineWave.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Lablicate GmbH.
+ * Copyright (c) 2019, 2025 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/util/ChartTestCase.java
+++ b/org.eclipse.swtchart.test/src/org/eclipse/swtchart/test/util/ChartTestCase.java
@@ -10,7 +10,7 @@
  * Contributors:
  * yoshitaka - initial API and implementation
  *******************************************************************************/
-package org.eclipse.swtchart.util;
+package org.eclipse.swtchart.test.util;
 
 import java.io.File;
 import java.lang.reflect.Field;


### PR DESCRIPTION
Reduces "split package" issues between test fragment and bundle.