### PR TITLE
Fix slider not updating while the mouse is moving on Windows

### DIFF
--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/support/RangeSupport.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/support/RangeSupport.java
@@ -187,7 +187,7 @@ public class RangeSupport {
 					}
 				}
 
-				baseChart.redraw();
+				baseChart.update();
 				return true;
 			}
 		}


### PR DESCRIPTION
To reproduce, start `DemoChart`, zoom in and slide back and forth. Not every movement updates the chart. If you do it fast then the scale might disalign with the chart. It feels choppy despite all the events firing and sub-millisecond paint speeds. The problem only manifests on Windows. On Linux it already updated nicely.