### PR TITLE
Fix jerky lasso zoom

### DIFF
--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseMoveSelectionEvent.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/events/MouseMoveSelectionEvent.java
@@ -98,7 +98,7 @@ public class MouseMoveSelectionEvent extends AbstractHandledEventProcessor imple
 			 * Rectangle is drawn here:
 			 * void paintControl(PaintEvent e)
 			 */
-			baseChart.redraw();
+			baseChart.update();
 			baseChart.resetRedrawCounter();
 		}
 	}

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/preferences/PreferenceConstants.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/preferences/PreferenceConstants.java
@@ -18,7 +18,7 @@ public class PreferenceConstants {
 	public static final int MAX_MOVE_LEGEND = 100;
 
 	public static final String P_BUFFER_SELECTION = "bufferSelection";
-	public static final boolean DEF_BUFFER_SELECTION = true;
+	public static final boolean DEF_BUFFER_SELECTION = false;
 	public static final String P_PREVENT_ACCIDENTAL_ZOOM = "preventAccidentalZoom";
 	public static final boolean DEF_PREVENT_ACCIDENTAL_ZOOM = true;
 


### PR DESCRIPTION
The same naive fix from https://github.com/eclipse-swtchart/swtchart/pull/532 but applied to the lasso zooming, which felt choppy despite rendering being pretty fast. Tested on Windows with `DemoChart` where I see significant improvements.

At the same time, I disabled the buffered selection workaround because it causes artifacts on my Windows 11, @KDE Linux with Wayland https://github.com/eclipse-swtchart/swtchart/issues/396 and macOS https://github.com/eclipse-swtchart/swtchart/issues/418.