### PR TITLE
Remove debug line in Resources.getColor

### DIFF
--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/Resources.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/Resources.java
@@ -99,7 +99,6 @@ public class Resources {
 		if(color == null) {
 			color = new Color(rgb);
 			colorMap.put(rgb, color);
-			System.out.println(colorMap.size());
 		}
 		return color;
 	}


### PR DESCRIPTION
This somehow slipped the review in https://github.com/eclipse-swtchart/swtchart/pull/531/.