### PR TITLE
Move develop to version 1.2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # News & Noteworthy
 
-## Release 0.12.0 (in review)
+## Release 1.1.0
+
+  * Available on Sonatype Central now.
+
+## Release 0.12.0
 
   * Moved to version 0.12.0 to avoid confusions with existing pre-Eclipse SWTChart bundles
   * Internationalization support has been added

--- a/org.eclipse.swtchart.bom/pom.xml
+++ b/org.eclipse.swtchart.bom/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.eclipse.swtchart</groupId>
 		<artifactId>org.eclipse.swtchart.build</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 	</parent>
 	
 	<artifactId>swtchart-bom</artifactId>
@@ -19,27 +19,27 @@
 			<dependency>
 				<groupId>org.eclipse.swtchart</groupId>
 				<artifactId>org.eclipse.swtchart</artifactId>
-				<version>1.1.0-SNAPSHOT</version>
+				<version>1.2.0-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.swtchart</groupId>
 				<artifactId>org.eclipse.swtchart.customcharts</artifactId>
-				<version>1.1.0-SNAPSHOT</version>
+				<version>1.2.0-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.swtchart</groupId>
 				<artifactId>org.eclipse.swtchart.extensions</artifactId>
-				<version>1.1.0-SNAPSHOT</version>
+				<version>1.2.0-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.swtchart</groupId>
 				<artifactId>org.eclipse.swtchart.extensions.eclipse</artifactId>
-				<version>1.1.0-SNAPSHOT</version>
+				<version>1.2.0-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.swtchart</groupId>
 				<artifactId>org.eclipse.swtchart.export</artifactId>
-				<version>1.1.0-SNAPSHOT</version>
+				<version>1.2.0-SNAPSHOT</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/org.eclipse.swtchart.customcharts/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.customcharts/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SWTChart Custom Charts
 Bundle-SymbolicName: org.eclipse.swtchart.customcharts
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Eclipse SWTChart
 Require-Bundle: org.eclipse.swt,
- org.eclipse.swtchart;bundle-version="1.1.0",
- org.eclipse.swtchart.extensions;bundle-version="1.1.0"
+ org.eclipse.swtchart;bundle-version="1.2.0",
+ org.eclipse.swtchart.extensions;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.eclipse.swtchart.customcharts
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.swtchart.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.examples/META-INF/MANIFEST.MF
@@ -3,10 +3,10 @@ Automatic-Module-Name: org.eclipse.swtchart.examples
 Bundle-ManifestVersion: 2
 Bundle-Name: SWTChart Examples
 Bundle-SymbolicName: org.eclipse.swtchart.examples
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Eclipse SWTChart
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.eclipse.swtchart;bundle-version="1.1.0"
+ org.eclipse.swtchart;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.swtchart.export.extended/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.export.extended/META-INF/MANIFEST.MF
@@ -3,12 +3,12 @@ Automatic-Module-Name: org.eclipse.swtchart.export.extended
 Bundle-ManifestVersion: 2
 Bundle-Name: SWTChart Export Options (Extended)
 Bundle-SymbolicName: org.eclipse.swtchart.export.extended;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.eclipse.swtchart;bundle-version="1.1.0",
- org.eclipse.swtchart.extensions;bundle-version="1.1.0",
- org.eclipse.swtchart.export;bundle-version="1.1.0"
+ org.eclipse.swtchart;bundle-version="1.2.0",
+ org.eclipse.swtchart.extensions;bundle-version="1.2.0",
+ org.eclipse.swtchart.export;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Eclipse SWTChart

--- a/org.eclipse.swtchart.export.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.export.test/META-INF/MANIFEST.MF
@@ -3,9 +3,9 @@ Automatic-Module-Name: org.eclipse.swtchart.export.test
 Bundle-ManifestVersion: 2
 Bundle-Name: SWTChart Export Test
 Bundle-SymbolicName: org.eclipse.swtchart.export.test
-Bundle-Version: 1.1.0.qualifier
-Fragment-Host: org.eclipse.swtchart.export;bundle-version="1.1.0"
+Bundle-Version: 1.2.0.qualifier
+Fragment-Host: org.eclipse.swtchart.export;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Vendor: Eclipse SWTChart
 Require-Bundle: junit-jupiter-api;bundle-version="5.13.4",
- org.eclipse.swtchart.customcharts;bundle-version="1.1.0"
+ org.eclipse.swtchart.customcharts;bundle-version="1.2.0"

--- a/org.eclipse.swtchart.export/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.export/META-INF/MANIFEST.MF
@@ -3,12 +3,12 @@ Automatic-Module-Name: org.eclipse.swtchart.export
 Bundle-ManifestVersion: 2
 Bundle-Name: SWTChart Export Options
 Bundle-SymbolicName: org.eclipse.swtchart.export;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Require-Bundle: org.eclipse.swt,
  org.eclipse.jface,
  org.eclipse.core.runtime,
- org.eclipse.swtchart;bundle-version="1.1.0",
- org.eclipse.swtchart.extensions;bundle-version="1.1.0"
+ org.eclipse.swtchart;bundle-version="1.2.0",
+ org.eclipse.swtchart.extensions;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Eclipse SWTChart

--- a/org.eclipse.swtchart.extensions.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.extensions.examples/META-INF/MANIFEST.MF
@@ -3,16 +3,16 @@ Automatic-Module-Name: org.eclipse.swtchart.extensions.examples
 Bundle-ManifestVersion: 2
 Bundle-Name: SWTChat Extension Examples
 Bundle-SymbolicName: org.eclipse.swtchart.extensions.examples;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Activator: org.eclipse.swtchart.extensions.examples.Activator
 Bundle-Vendor: Eclipse SWTChart
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.eclipse.swtchart;bundle-version="1.1.0",
- org.eclipse.swtchart.extensions;bundle-version="1.1.0",
+ org.eclipse.swtchart;bundle-version="1.2.0",
+ org.eclipse.swtchart.extensions;bundle-version="1.2.0",
  org.eclipse.e4.ui.di;bundle-version="1.1.100",
  org.eclipse.e4.ui.model.workbench;bundle-version="1.2.0.v20160229-1459",
- org.eclipse.swtchart.customcharts;bundle-version="1.1.0",
+ org.eclipse.swtchart.customcharts;bundle-version="1.2.0",
  com.github.weisj.jsvg;bundle-version="1.7.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.swtchart.extensions.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.extensions.test/META-INF/MANIFEST.MF
@@ -3,8 +3,8 @@ Automatic-Module-Name: org.eclipse.swtchart.extensions.test
 Bundle-ManifestVersion: 2
 Bundle-Name: SWTChart Extensions Test
 Bundle-SymbolicName: org.eclipse.swtchart.extensions.test
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Eclipse SWTChart
-Fragment-Host: org.eclipse.swtchart.extensions;bundle-version="1.1.0"
+Fragment-Host: org.eclipse.swtchart.extensions;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: junit-jupiter-api;bundle-version="5.13.4"

--- a/org.eclipse.swtchart.extensions/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.extensions/META-INF/MANIFEST.MF
@@ -3,13 +3,13 @@ Automatic-Module-Name: org.eclipse.swtchart.extensions
 Bundle-ManifestVersion: 2
 Bundle-Name: SWTChart and extensions
 Bundle-SymbolicName: org.eclipse.swtchart.extensions;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Activator: org.eclipse.swtchart.extensions.Activator
 Bundle-Vendor: Eclipse SWTChart
 Require-Bundle: org.eclipse.jface,
  org.eclipse.core.runtime,
  org.eclipse.swt,
- org.eclipse.swtchart;bundle-version="1.1.0",
+ org.eclipse.swtchart;bundle-version="1.2.0",
  org.eclipse.core.databinding;bundle-version="1.6.200",
  org.eclipse.ui;bundle-version="3.207.200",
  org.eclipse.e4.ui.css.core;bundle-version="0.14.500",

--- a/org.eclipse.swtchart.feature/feature.xml
+++ b/org.eclipse.swtchart.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.swtchart.feature"
       label="Eclipse SWTChart"
-      version="1.1.0.qualifier"
+      version="1.2.0.qualifier"
       plugin="org.eclipse.swtchart"
       license-feature="org.eclipse.license"
       license-feature-version="2.0.2.qualifier">
@@ -12,7 +12,7 @@
    </description>
 
    <copyright url="https://lablicate.com">
-      Copyright (c) 2017, 2024 Lablicate GmbH.
+      Copyright (c) 2017, 2025 Lablicate GmbH.
    </copyright>
 
    <license url="%licenseURL">

--- a/org.eclipse.swtchart.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.test/META-INF/MANIFEST.MF
@@ -3,8 +3,8 @@ Automatic-Module-Name: org.eclipse.swtchart.test
 Bundle-ManifestVersion: 2
 Bundle-Name: SWTChart Test
 Bundle-SymbolicName: org.eclipse.swtchart.test
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Eclipse SWTChart
-Fragment-Host: org.eclipse.swtchart;bundle-version="1.1.0"
+Fragment-Host: org.eclipse.swtchart;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: junit-jupiter-api;bundle-version="5.13.4"

--- a/org.eclipse.swtchart.test/pom.xml
+++ b/org.eclipse.swtchart.test/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.eclipse.swtchart</groupId>
 		<artifactId>org.eclipse.swtchart.build</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.swtchart.test</artifactId>

--- a/org.eclipse.swtchart.updatesite/category.xml
+++ b/org.eclipse.swtchart.updatesite/category.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature id="org.eclipse.swtchart.feature" version="1.1.0.qualifier">
+   <feature id="org.eclipse.swtchart.feature" version="1.2.0.qualifier">
       <category name="org.eclipse.swtchart"/>
    </feature>
-   <category-def name="org.eclipse.swtchart" label="Eclipse SWTChart" />
-   <repository-reference location="https://download.eclipse.org/releases/2025-09/" enabled="true" />
+   <category-def name="org.eclipse.swtchart" label="Eclipse SWTChart"/>
+   <repository-reference location="https://download.eclipse.org/releases/2025-09/" name="" enabled="true" />
 </site>

--- a/org.eclipse.swtchart.updatesite/pom.xml
+++ b/org.eclipse.swtchart.updatesite/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
     <groupId>org.eclipse.swtchart</groupId>
     <artifactId>org.eclipse.swtchart.build</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
 	 <artifactId>org.eclipse.swtchart.updatesite</artifactId>

--- a/org.eclipse.swtchart.vectorgraphics2d.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.vectorgraphics2d.test/META-INF/MANIFEST.MF
@@ -3,8 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-Name: SWTChart Vectorgraphics2d Tests
 Bundle-SymbolicName: org.eclipse.swtchart.vectorgraphics2d.test
 Bundle-Vendor: Eclipse SWTChart
-Bundle-Version: 1.1.0.qualifier
-Fragment-Host: org.eclipse.swtchart.vectorgraphics2d;bundle-version="1.1.0"
+Bundle-Version: 1.2.0.qualifier
+Fragment-Host: org.eclipse.swtchart.vectorgraphics2d;bundle-version="1.2.0"
 Require-Bundle: junit-jupiter-api;bundle-version="5.13.4",
  junit-jupiter-params;bundle-version="5.13.4", 
  org.hamcrest;bundle-version="3.0.0",

--- a/org.eclipse.swtchart.vectorgraphics2d.test/pom.xml
+++ b/org.eclipse.swtchart.vectorgraphics2d.test/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.eclipse.swtchart</groupId>
 		<artifactId>org.eclipse.swtchart.build</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.swtchart.vectorgraphics2d.test</artifactId>

--- a/org.eclipse.swtchart.vectorgraphics2d/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.vectorgraphics2d/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: SWTChart VectorGraphics2d
 Bundle-SymbolicName: org.eclipse.swtchart.vectorgraphics2d
 Bundle-Vendor: Eclipse SWTChart
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Export-Package: org.eclipse.swtchart.vectorgraphics2d.core,
  org.eclipse.swtchart.vectorgraphics2d.eps,
  org.eclipse.swtchart.vectorgraphics2d.intermediate,

--- a/org.eclipse.swtchart/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.swtchart
 Bundle-ManifestVersion: 2
 Bundle-Name: SWTChart
 Bundle-SymbolicName: org.eclipse.swtchart
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Eclipse SWTChart
 Require-Bundle: org.eclipse.swt
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.swtchart</groupId>
   <artifactId>org.eclipse.swtchart.build</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <!--
   DESCRIPTION


### PR DESCRIPTION
Version 1.1.0 has been released, tagged and pushed to Central Sonatype today:

https://gitlab.eclipse.org/eclipsefdn/emo-team/emo/-/issues/1058
https://github.com/eclipse-swtchart/swtchart/releases/tag/REL-1.1.0
https://central.sonatype.com/artifact/org.eclipse.swtchart/org.eclipse.swtchart

Hence, update develop to the next version.