### PR TITLE
Add null to prevent NPE

### DIFF
--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ScrollableChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ScrollableChart.java
@@ -1216,46 +1216,98 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 	private void addSecondaryAxesX(IChartSettings chartSettings) {
 
 		IAxisSet axisSet = baseChart.getAxisSet();
-		for(int id : axisSet.getXAxisIds()) {
+
+		List<ISecondaryAxisSettings> newSettings = chartSettings.getSecondaryAxisSettingsListX();
+		int[] existingIds = axisSet.getXAxisIds();
+
+		// Count existing secondary axes (exclude primary)
+		int existingSecondaryCount = 0;
+		for(int id : existingIds) {
 			if(id != BaseChart.ID_PRIMARY_X_AXIS) {
-				axisSet.deleteXAxis(id);
+				existingSecondaryCount++;
 			}
 		}
-		/*
-		 * Remove all items except the primary axis settings.
-		 */
-		baseChart.removeXAxisSettings();
-		/*
-		 * Add the axis settings.
-		 */
-		for(ISecondaryAxisSettings secondaryAxisSettings : chartSettings.getSecondaryAxisSettingsListX()) {
-			int xAxisId = axisSet.createXAxis();
-			IAxis xAxisSecondary = axisSet.getXAxis(xAxisId);
-			setAxisSettings(xAxisSecondary, secondaryAxisSettings);
-			baseChart.putXAxisSettings(xAxisId, secondaryAxisSettings);
+
+		// Only recreate if the count has changed
+		if(existingSecondaryCount != newSettings.size()) {
+			// Delete all secondary axes
+			for(int id : existingIds) {
+				if(id != BaseChart.ID_PRIMARY_X_AXIS) {
+					axisSet.deleteXAxis(id);
+				}
+			}
+
+			// Remove all secondary axis settings
+			baseChart.removeXAxisSettings();
+
+			// Create new secondary axes
+			for(ISecondaryAxisSettings secondaryAxisSettings : newSettings) {
+				int xAxisId = axisSet.createXAxis();
+				IAxis xAxisSecondary = axisSet.getXAxis(xAxisId);
+				setAxisSettings(xAxisSecondary, secondaryAxisSettings);
+				baseChart.putXAxisSettings(xAxisId, secondaryAxisSettings);
+			}
+		} else {
+			// Just update existing secondary axes settings
+			int index = 0;
+			for(int id : existingIds) {
+				if(id != BaseChart.ID_PRIMARY_X_AXIS && index < newSettings.size()) {
+					IAxis xAxisSecondary = axisSet.getXAxis(id);
+					ISecondaryAxisSettings secondaryAxisSettings = newSettings.get(index);
+					setAxisSettings(xAxisSecondary, secondaryAxisSettings);
+					baseChart.putXAxisSettings(id, secondaryAxisSettings);
+					index++;
+				}
+			}
 		}
 	}
 
 	private void addSecondaryAxesY(IChartSettings chartSettings) {
 
 		IAxisSet axisSet = baseChart.getAxisSet();
-		for(int id : axisSet.getYAxisIds()) {
+
+		List<ISecondaryAxisSettings> newSettings = chartSettings.getSecondaryAxisSettingsListY();
+		int[] existingIds = axisSet.getYAxisIds();
+
+		// Count existing secondary axes (exclude primary)
+		int existingSecondaryCount = 0;
+		for(int id : existingIds) {
 			if(id != BaseChart.ID_PRIMARY_Y_AXIS) {
-				axisSet.deleteYAxis(id);
+				existingSecondaryCount++;
 			}
 		}
-		/*
-		 * Remove all items except the primary axis settings.
-		 */
-		baseChart.removeYAxisSettings();
-		/*
-		 * Add the axis settings.
-		 */
-		for(ISecondaryAxisSettings secondaryAxisSettings : chartSettings.getSecondaryAxisSettingsListY()) {
-			int yAxisId = axisSet.createYAxis();
-			IAxis yAxisSecondary = axisSet.getYAxis(yAxisId);
-			setAxisSettings(yAxisSecondary, secondaryAxisSettings);
-			baseChart.putYAxisSettings(yAxisId, secondaryAxisSettings);
+
+		// Only recreate if the count has changed
+		if(existingSecondaryCount != newSettings.size()) {
+			// Delete all secondary axes
+			for(int id : existingIds) {
+				if(id != BaseChart.ID_PRIMARY_Y_AXIS) {
+					axisSet.deleteYAxis(id);
+				}
+			}
+
+			// Remove all secondary axis settings
+			baseChart.removeYAxisSettings();
+
+			// Create new secondary axes
+			for(ISecondaryAxisSettings secondaryAxisSettings : newSettings) {
+				int yAxisId = axisSet.createYAxis();
+				IAxis yAxisSecondary = axisSet.getYAxis(yAxisId);
+				setAxisSettings(yAxisSecondary, secondaryAxisSettings);
+				baseChart.putYAxisSettings(yAxisId, secondaryAxisSettings);
+			}
+		} else {
+			// Just update existing secondary axes settings
+			int index = 0;
+			for(int id : existingIds) {
+				if(id != BaseChart.ID_PRIMARY_Y_AXIS && index < newSettings.size()) {
+					IAxis yAxisSecondary = axisSet.getYAxis(id);
+					ISecondaryAxisSettings secondaryAxisSettings = newSettings.get(index);
+					setAxisSettings(yAxisSecondary, secondaryAxisSettings);
+					baseChart.putYAxisSettings(id, secondaryAxisSettings);
+					index++;
+				}
+			}
 		}
 	}
 

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/AxisTickLabels.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/AxisTickLabels.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 SWTChart project.
+ * Copyright (c) 2008, 2026 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
  * Frank Buloup - Internationalization
  * Philip Wenig - x/y axis position marker
  * Sebastien Darche - Implement arbitrary base log scale
+ * Lorenz Gerber - Null check
  *******************************************************************************/
 package org.eclipse.swtchart.internal.axis;
 
@@ -726,6 +727,16 @@ public class AxisTickLabels implements PaintListener {
 	public void paintControl(PaintEvent e) {
 
 		if(!axis.getTick().isVisible()) {
+			return;
+		}
+
+		if(bounds == null) {
+			chart.getDisplay().asyncExec(() -> {
+				if(!chart.isDisposed()) {
+					chart.layout(true, true);
+					chart.redraw();
+				}
+			});
 			return;
 		}
 

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/AxisTickMarks.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/AxisTickMarks.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 SWTChart project.
+ * Copyright (c) 2008, 2026 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  * yoshitaka - initial API and implementation
  * Christoph Läubrich - take line width into account when calculate clippings
  * Philip Wenig - option to skip drawing the axis line
+ * Lorenz Gerber - Null check
  *******************************************************************************/
 package org.eclipse.swtchart.internal.axis;
 
@@ -173,6 +174,16 @@ public class AxisTickMarks implements PaintListener {
 
 	@Override
 	public void paintControl(PaintEvent e) {
+
+		if(bounds == null) {
+			chart.getDisplay().asyncExec(() -> {
+				if(!chart.isDisposed()) {
+					chart.layout(true, true);
+					chart.redraw();
+				}
+			});
+			return;
+		}
 
 		if(bounds.width > 0 && bounds.height > 0) {
 			ArrayList<Integer> tickLabelPositions = axis.getTick().getAxisTickLabels().getTickLabelPositions();


### PR DESCRIPTION
On OSX, this change prevents NPE's in several redraw cases. 

One such case is due to clear/create of secondary axis. As performance improvement, secondary axis should be re-used/adjusted instead of clear/recreated if possible (same number of secondary axis).