### PR TITLE
Fix black image export on Windows

### DIFF
--- a/org.eclipse.swtchart.export.test/testData/files/export/INFO.txt
+++ b/org.eclipse.swtchart.export.test/testData/files/export/INFO.txt
@@ -1,1 +1,0 @@
-GIT needs at least one file in this directory to track it, otherwise Eclipse gives a compile error at checkout. Remove it, if not needed anymore.

--- a/org.eclipse.swtchart.extensions.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.extensions.examples/META-INF/MANIFEST.MF
@@ -13,7 +13,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.e4.ui.di;bundle-version="1.1.100",
  org.eclipse.e4.ui.model.workbench;bundle-version="1.2.0.v20160229-1459",
  org.eclipse.swtchart.customcharts;bundle-version="1.2.0",
- com.github.weisj.jsvg;bundle-version="1.7.2"
+ com.github.weisj.jsvg;bundle-version="1.7.2",
+ org.eclipse.swtchart.export;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.swtchart.extensions.examples.support

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/DemoChart.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/charts/DemoChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 SWTChart project.
+ * Copyright (c) 2020, 2026 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,6 +24,9 @@ import org.eclipse.swtchart.IAxis;
 import org.eclipse.swtchart.IAxisSet;
 import org.eclipse.swtchart.IAxisTick;
 import org.eclipse.swtchart.ITitle;
+import org.eclipse.swtchart.export.menu.bitmap.BMPExportHandler;
+import org.eclipse.swtchart.export.menu.bitmap.JPGExportHandler;
+import org.eclipse.swtchart.export.menu.bitmap.PNGExportHandler;
 import org.eclipse.swtchart.extensions.core.IChartSettings;
 import org.eclipse.swtchart.extensions.core.ISecondaryAxisSettings;
 import org.eclipse.swtchart.extensions.core.ResourceSupport;
@@ -55,6 +58,9 @@ public class DemoChart {
 		chartSettings.setBufferSelection(true);
 		addClipboardMenuEntry(chartSettings);
 		addToggleAxisLinesMenuEntry(chartSettings);
+		chartSettings.addMenuEntry(new PNGExportHandler());
+		chartSettings.addMenuEntry(new BMPExportHandler());
+		chartSettings.addMenuEntry(new JPGExportHandler());
 		scrollableChart.applySettings(chartSettings);
 
 		while(!shell.isDisposed()) {

--- a/org.eclipse.swtchart.extensions.test/testData/files/export/INFO.txt
+++ b/org.eclipse.swtchart.extensions.test/testData/files/export/INFO.txt
@@ -1,1 +1,0 @@
-GIT needs at least one file in this directory to track it, otherwise Eclipse gives a compile error at checkout. Remove it, if not needed anymore.

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/clipboard/ImageSupplier.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/clipboard/ImageSupplier.java
@@ -15,37 +15,12 @@ package org.eclipse.swtchart.extensions.clipboard;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
-import org.eclipse.swt.graphics.ImageDataProvider;
 import org.eclipse.swt.graphics.ImageLoader;
-import org.eclipse.swt.graphics.PaletteData;
-import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swtchart.Chart;
 import org.eclipse.swtchart.extensions.core.BaseChart;
 
 public class ImageSupplier {
-
-	/*
-	 * Image data provider used locally to represent chart image
-	 */
-	private class ChartImageDataProvider implements ImageDataProvider {
-
-		private ImageData imageData;
-
-		public ChartImageDataProvider(int width, int height) {
-
-			PaletteData palette = new PaletteData(0xFF, 0xFF00, 0xFF0000);
-			imageData = new ImageData(width, height, 32, palette);
-		}
-
-		@Override
-		public ImageData getImageData(int zoom) {
-
-			if(zoom != 100) {
-				return null;
-			}
-			return imageData;
-		}
-	}
 
 	/**
 	 * Save image data representation to a file with specific format (BMP, PNG or JPG)
@@ -92,14 +67,6 @@ public class ImageSupplier {
 		chart.redraw();
 		chart.update();
 		/*
-		 * Chart size
-		 */
-		Point baseChartSize = chart.getSize();
-		/*
-		 * Create the image provider
-		 */
-		ChartImageDataProvider chartImageDataProvider = new ChartImageDataProvider(baseChartSize.x, baseChartSize.y);
-		/*
 		 * Surround main stuff with try/finally to prevent memory leakage
 		 */
 		Image image = null;
@@ -108,7 +75,8 @@ public class ImageSupplier {
 			/*
 			 * Copy chart into the image
 			 */
-			image = new Image(chart.getDisplay(), chartImageDataProvider);
+			Rectangle bounds = chart.getBounds();
+			image = new Image(chart.getDisplay(), bounds.width, bounds.height);
 			gc = new GC(chart);
 			chart.print(gc);
 			gc.copyArea(image, 0, 0);


### PR DESCRIPTION
On Windows 11, the right-click menu export and the `ImageFactory_1_UITest` produced a black image. This older and more basic code path was not affected. https://github.com/eclipse-swtchart/swtchart/blob/02f39331f1ddacc261ac8ba8638ff453ef65a0e0/org.eclipse.swtchart/src/org/eclipse/swtchart/Chart.java#L411-L434 It looks like `ChartImageDataProvider` is not creating a proper image because the empty one should be white and not black. Simply removing it fixes the issue. Nulling the image data when display zoom is not 100% also looked completely bogus.