### PR TITLE
Add PDF export handler

### DIFF
--- a/org.eclipse.swtchart.export.extended/META-INF/MANIFEST.MF
+++ b/org.eclipse.swtchart.export.extended/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.swtchart;bundle-version="1.2.0",
  org.eclipse.swtchart.extensions;bundle-version="1.2.0",
- org.eclipse.swtchart.export;bundle-version="1.2.0"
+ org.eclipse.swtchart.export;bundle-version="1.2.0",
+ org.eclipse.swtchart.vectorgraphics2d;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Eclipse SWTChart

--- a/org.eclipse.swtchart.export.extended/plugin.xml
+++ b/org.eclipse.swtchart.export.extended/plugin.xml
@@ -6,5 +6,8 @@
       <MenuItemSupplier
             MenuEntry="org.eclipse.swtchart.export.extended.menu.vector.SVGExportHandler">
       </MenuItemSupplier>           
+      <MenuItemSupplier
+            MenuEntry="org.eclipse.swtchart.export.extended.menu.vector.PDFExportHandler">
+      </MenuItemSupplier>
    </extension>
 </plugin>

--- a/org.eclipse.swtchart.export.extended/src/org/eclipse/swtchart/export/extended/menu/vector/Messages.java
+++ b/org.eclipse.swtchart.export.extended/src/org/eclipse/swtchart/export/extended/menu/vector/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 SWT Chart Project
+ * Copyright (c) 2020, 2026 SWT Chart Project
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,11 @@ public class Messages {
 	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
 
 	public static final String EXPORT_TO_SVG = "EXPORT_TO_SVG";
+	public static final String EXPORT_TO_PDF = "EXPORT_TO_PDF";
+	public static final String EXPORT_TO_PDF_INTERRUPTED = "EXPORT_TO_PDF_INTERRUPTED";
+	public static final String PDF_EXPORT_ERROR = "PDF_EXPORT_ERROR";
+	public static final String SAVE_AS_PDF = "SAVE_AS_PDF";
+	public static final String PDF = "PDF";
 	public static final String SAVE_AS_SVG = "SAVE_AS_SVG";
 	public static final String SVG = "SVG";
 

--- a/org.eclipse.swtchart.export.extended/src/org/eclipse/swtchart/export/extended/menu/vector/PDFExportHandler.java
+++ b/org.eclipse.swtchart.export.extended/src/org/eclipse/swtchart/export/extended/menu/vector/PDFExportHandler.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.swtchart.export.extended.menu.vector;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.text.MessageFormat;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.dialogs.ProgressMonitorDialog;
+import org.eclipse.jface.window.Window;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.FileDialog;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swtchart.export.core.AbstractSeriesExportHandler;
+import org.eclipse.swtchart.export.core.VectorExportSettingsDialog;
+import org.eclipse.swtchart.export.extended.awt.ChartToGraphics2D;
+import org.eclipse.swtchart.extensions.core.BaseChart;
+import org.eclipse.swtchart.extensions.core.ScrollableChart;
+import org.eclipse.swtchart.vectorgraphics2d.core.Document;
+import org.eclipse.swtchart.vectorgraphics2d.core.Processor;
+import org.eclipse.swtchart.vectorgraphics2d.core.Processors;
+import org.eclipse.swtchart.vectorgraphics2d.core.VectorGraphics2D;
+import org.eclipse.swtchart.vectorgraphics2d.util.PageSize;
+
+public class PDFExportHandler extends AbstractSeriesExportHandler {
+
+	private static final String FILE_EXTENSION = "*.pdf"; //$NON-NLS-1$
+	private static final String NAME = MessageFormat.format(Messages.getString(Messages.PDF), FILE_EXTENSION);
+	private static final String TITLE = Messages.getString(Messages.SAVE_AS_PDF);
+
+	@Override
+	public String getName() {
+
+		return NAME;
+	}
+
+	@Override
+	public void execute(Shell shell, ScrollableChart scrollableChart) {
+
+		FileDialog fileDialog = new FileDialog(shell, SWT.SAVE);
+		fileDialog.setOverwrite(true);
+		fileDialog.setText(NAME);
+		fileDialog.setFilterExtensions(FILE_EXTENSION);
+		fileDialog.setFileName(scrollableChart.getFileName());
+
+		String fileName = fileDialog.open();
+		if(fileName != null) {
+			try {
+				BaseChart baseChart = scrollableChart.getBaseChart();
+				VectorExportSettingsDialog exportSettingsDialog = new VectorExportSettingsDialog(fileDialog.getParent(), baseChart);
+				exportSettingsDialog.create();
+				if(exportSettingsDialog.open() == Window.OK) {
+					int indexAxisX = exportSettingsDialog.getIndexAxisSelectionX();
+					int indexAxisY = exportSettingsDialog.getIndexAxisSelectionY();
+					if(indexAxisX >= 0 && indexAxisY >= 0) {
+						try {
+							ProgressMonitorDialog monitorDialog = new ProgressMonitorDialog(fileDialog.getParent());
+							monitorDialog.run(false, true, monitor -> {
+
+								monitor.beginTask(Messages.getString(Messages.EXPORT_TO_PDF), IProgressMonitor.UNKNOWN);
+								try (OutputStream output = new FileOutputStream(fileName)) {
+									VectorGraphics2D graphics2D = new VectorGraphics2D();
+									graphics2D = (VectorGraphics2D)new ChartToGraphics2D(baseChart, indexAxisX, indexAxisY, graphics2D).getGraphics2D();
+
+									Processor processor = Processors.get("pdf"); //$NON-NLS-1$
+									PageSize pageSize = new PageSize(0.0d, 0.0d, baseChart.getSize().x, baseChart.getSize().y);
+									Document document = processor.getDocument(graphics2D.getCommands(), pageSize);
+									document.writeTo(output);
+									MessageDialog.openInformation(fileDialog.getParent(), TITLE, MESSAGE_OK);
+								} catch(IOException e) {
+									e.printStackTrace();
+									String reason = e.getMessage() != null ? e.getMessage() : MESSAGE_ERROR;
+									MessageDialog.openError(fileDialog.getParent(), TITLE, MessageFormat.format(Messages.getString(Messages.PDF_EXPORT_ERROR), reason));
+								} finally {
+									monitor.done();
+								}
+							});
+						} catch(InterruptedException e) {
+							e.printStackTrace();
+							Thread.currentThread().interrupt();
+							MessageDialog.openInformation(fileDialog.getParent(), TITLE, Messages.getString(Messages.EXPORT_TO_PDF_INTERRUPTED));
+						}
+					}
+				}
+			} catch(InvocationTargetException e) {
+				MessageDialog.openInformation(shell, TITLE, MESSAGE_ERROR);
+				e.getCause().printStackTrace();
+			}
+		}
+	}
+}

--- a/org.eclipse.swtchart.export.extended/src/org/eclipse/swtchart/export/extended/menu/vector/messages.properties
+++ b/org.eclipse.swtchart.export.extended/src/org/eclipse/swtchart/export/extended/menu/vector/messages.properties
@@ -1,3 +1,8 @@
 EXPORT_TO_SVG  =  Exports the chart to SVG via Apache Batik (this may take a while)
 SAVE_AS_SVG = Save As Scalable Vector Graphic
 SVG = Scalable Vector Graphic [Graphics2D] ({0})
+EXPORT_TO_PDF = Exports the chart to PDF [VectorGraphics2D]
+SAVE_AS_PDF = Save As Portable Document Format
+PDF = Portable Document Format [Graphics2D] ({0})
+EXPORT_TO_PDF_INTERRUPTED = The PDF export operation has been interrupted.
+PDF_EXPORT_ERROR = PDF export failed: {0}

--- a/org.eclipse.swtchart.export.extended/src/org/eclipse/swtchart/export/extended/menu/vector/messages_de.properties
+++ b/org.eclipse.swtchart.export.extended/src/org/eclipse/swtchart/export/extended/menu/vector/messages_de.properties
@@ -1,3 +1,8 @@
 EXPORT_TO_SVG  =  Exportiere das Diagramm in ein SVG mittels Apache Batik (dauert eine Weile)
 SAVE_AS_SVG = Speichere als skalierbare Vektorgrafik
 SVG = skalierbare Vektorgrafik [Graphics2D] ({0})
+EXPORT_TO_PDF = Exportiere das Diagramm in ein PDF [VectorGraphics2D]
+SAVE_AS_PDF = Speichere als Portable Document Format
+PDF = Portable Document Format [VectorGraphics2D] ({0})
+EXPORT_TO_PDF_INTERRUPTED = Der PDF-Exportvorgang wurde unterbrochen.
+PDF_EXPORT_ERROR = PDF-Export fehlgeschlagen: {0}

--- a/org.eclipse.swtchart.export.extended/src/org/eclipse/swtchart/export/extended/menu/vector/messages_fr.properties
+++ b/org.eclipse.swtchart.export.extended/src/org/eclipse/swtchart/export/extended/menu/vector/messages_fr.properties
@@ -1,3 +1,8 @@
 EXPORT_TO_SVG = Exporter le graphe en SVG via Apache Batik (cela peut prendre du temps)
 SAVE_AS_SVG = Enregistrer en SVG
 SVG = Scalable Vector Graphic [Graphics2D] ({0})
+EXPORT_TO_PDF = Exporter le graphe en PDF [VectorGraphics2D]
+SAVE_AS_PDF = Enregistrer en PDF
+PDF = Portable Document Format [VectorGraphics2D] ({0})
+EXPORT_TO_PDF_INTERRUPTED = L'export PDF a été interrompu.
+PDF_EXPORT_ERROR = L'export PDF a échoué : {0}


### PR DESCRIPTION
The export popup had no PDF target, so users could export SVG/bitmap/text but not PDF from the same flow. This PR adds a native PDF option and wires it through the existing vector-export axis-selection workflow.

```
Processor processor = Processors.get("pdf");
PageSize pageSize = new PageSize(0.0d, 0.0d, baseChart.getSize().x,
baseChart.getSize().y);
Document document = processor.getDocument(graphics2D.getCommands(),
pageSize);
document.writeTo(output);
```