### PR TITLE
Avoid dependencies in features

### DIFF
--- a/org.eclipse.swtchart.feature/feature.xml
+++ b/org.eclipse.swtchart.feature/feature.xml
@@ -39,16 +39,4 @@
          id="org.eclipse.swtchart.vectorgraphics2d"
          version="0.0.0"/>
 
-   <plugin
-         id="org.apache.pdfbox"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.pdfbox.fontbox"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.apache.pdfbox.io"
-         version="0.0.0"/>
-
 </feature>


### PR DESCRIPTION
`org.apache.pdfbox.io` is no longer available and the others should be referenced by the plug-in that use them.