### PR TITLE
Allow exponent to be rendered as horizontal label

### DIFF
--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/converter/MillionConverter.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/converter/MillionConverter.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swtchart.extensions.examples.converter;
+
+import org.eclipse.swtchart.extensions.core.AbstractAxisScaleConverter;
+
+public class MillionConverter extends AbstractAxisScaleConverter {
+
+	@Override
+	public double convertToSecondaryUnit(double primaryValue) {
+
+		return primaryValue / 1_000_000.0;
+	}
+
+	@Override
+	public double convertToPrimaryUnit(double secondaryValue) {
+
+		return secondaryValue * 1_000_000.0;
+	}
+}

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/converter/MillionDecimalFormat.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/converter/MillionDecimalFormat.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lablicate GmbH.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Matthias Mailänder - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.swtchart.extensions.examples.converter;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.FieldPosition;
+import java.text.ParsePosition;
+
+public class MillionDecimalFormat extends DecimalFormat {
+
+	private static final long serialVersionUID = 1L;
+
+	public MillionDecimalFormat(String pattern, DecimalFormatSymbols symbols) {
+
+		super(pattern, symbols);
+	}
+
+	@Override
+	public StringBuffer format(double number, StringBuffer toAppendTo, FieldPosition pos) {
+
+		return super.format(number / 1_000_000.0, toAppendTo, pos);
+	}
+
+	@Override
+	public Number parse(String source, ParsePosition parsePosition) {
+
+		Number result = super.parse(source, parsePosition);
+		if(result != null) {
+			return result.doubleValue() * 1_000_000.0;
+		}
+		return result;
+	}
+}

--- a/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_1a_Part.java
+++ b/org.eclipse.swtchart.extensions.examples/src/org/eclipse/swtchart/extensions/examples/parts/LineSeries_1a_Part.java
@@ -12,15 +12,19 @@
  *******************************************************************************/
 package org.eclipse.swtchart.extensions.examples.parts;
 
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swtchart.ILineSeries.PlotSymbolType;
 import org.eclipse.swtchart.customcharts.core.ChromatogramChart;
 import org.eclipse.swtchart.extensions.core.IChartSettings;
+import org.eclipse.swtchart.extensions.core.IPrimaryAxisSettings;
 import org.eclipse.swtchart.extensions.core.ISeriesData;
+import org.eclipse.swtchart.extensions.examples.converter.MillionDecimalFormat;
 import org.eclipse.swtchart.extensions.examples.support.SeriesConverter;
 import org.eclipse.swtchart.extensions.linecharts.ILineSeriesData;
 import org.eclipse.swtchart.extensions.linecharts.ILineSeriesSettings;
@@ -44,9 +48,17 @@ public class LineSeries_1a_Part extends ChromatogramChart {
 		 * Chart Settings
 		 */
 		IChartSettings chartSettings = getChartSettings();
+		chartSettings.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundChart(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
+		chartSettings.setBackgroundPlotArea(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 		chartSettings.setOrientation(SWT.HORIZONTAL);
 		chartSettings.setCreateMenu(true);
 		chartSettings.getRangeRestriction().setForceZeroMinY(true);
+		IPrimaryAxisSettings primaryAxisSettingsY = chartSettings.getPrimaryAxisSettingsY();
+		primaryAxisSettingsY.setHorizontalLabel("×10⁶");
+		primaryAxisSettingsY.setDecimalFormat(new MillionDecimalFormat("0.#", new DecimalFormatSymbols(Locale.ENGLISH)));
+		chartSettings.getSecondaryAxisSettingsListY().clear();
+
 		applySettings(chartSettings);
 		/*
 		 * Create series.

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/AbstractAxisSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/AbstractAxisSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 Lablicate GmbH.
+ * Copyright (c) 2017, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -42,6 +42,9 @@ public abstract class AbstractAxisSettings implements IAxisSettings {
 	private boolean drawPositionMarker;
 	private int extraSpaceTitle;
 	private boolean integerDataPointAxis;
+	private boolean horizontalTitle = false;
+	private boolean ticksVisible = true;
+	private String horizontalLabel = null;
 	/*
 	 * The default font is only used if no font is set.
 	 */
@@ -320,5 +323,41 @@ public abstract class AbstractAxisSettings implements IAxisSettings {
 	public void setIntegerDataPointAxis(boolean isIntegerDataPointAxis) {
 
 		this.integerDataPointAxis = isIntegerDataPointAxis;
+	}
+
+	@Override
+	public boolean isHorizontalTitle() {
+
+		return horizontalTitle;
+	}
+
+	@Override
+	public void setHorizontalTitle(boolean horizontalTitle) {
+
+		this.horizontalTitle = horizontalTitle;
+	}
+
+	@Override
+	public boolean isTicksVisible() {
+
+		return ticksVisible;
+	}
+
+	@Override
+	public void setTicksVisible(boolean ticksVisible) {
+
+		this.ticksVisible = ticksVisible;
+	}
+
+	@Override
+	public String getHorizontalLabel() {
+
+		return horizontalLabel;
+	}
+
+	@Override
+	public void setHorizontalLabel(String label) {
+
+		this.horizontalLabel = label;
 	}
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/IAxisSettings.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/IAxisSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Lablicate GmbH.
+ * Copyright (c) 2017, 2026 Lablicate GmbH.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -110,4 +110,36 @@ public interface IAxisSettings {
 	boolean isIntegerDataPointAxis();
 
 	void setIntegerDataPointAxis(boolean isIntegerDataPointAxis);
+
+	/**
+	 * Returns whether the axis title should be rendered horizontally at the top of
+	 * the axis instead of rotated along it.
+	 *
+	 * @return true to render the title horizontally
+	 */
+	boolean isHorizontalTitle();
+
+	void setHorizontalTitle(boolean horizontalTitle);
+
+	/**
+	 * Short label drawn horizontally at the top of the axis column in addition to the
+	 * regular (rotated) axis title.
+	 *
+	 * @return the horizontal label, or null if not set
+	 */
+	String getHorizontalLabel();
+
+	void setHorizontalLabel(String label);
+
+	/**
+	 * Controls tick mark and tick label visibility independently of the axis title.
+	 * Use setVisible(false) to hide everything; use setTicksVisible(false) together
+	 * with setVisible(true) to show only the axis title (e.g. "Intensity") while
+	 * suppressing the tick labels.
+	 *
+	 * @return true if tick marks and labels are visible
+	 */
+	boolean isTicksVisible();
+
+	void setTicksVisible(boolean ticksVisible);
 }

--- a/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ScrollableChart.java
+++ b/org.eclipse.swtchart.extensions/src/org/eclipse/swtchart/extensions/core/ScrollableChart.java
@@ -1406,10 +1406,12 @@ public class ScrollableChart extends Composite implements IScrollableChart, IEve
 			title.setText(axisText);
 			title.setVisible(axisSettings.isVisible() && axisSettings.isTitleVisible());
 			title.setFont(axisSettings.getTitleFont());
+			title.setHorizontalTitle(axisSettings.isHorizontalTitle());
+			title.setHorizontalLabel(axisSettings.getHorizontalLabel());
 
 			IAxisTick axisTick = axis.getTick();
 			axisTick.setFormat(axisSettings.getDecimalFormat());
-			axisTick.setVisible(axisSettings.isVisible());
+			axisTick.setVisible(axisSettings.isVisible() && axisSettings.isTicksVisible());
 
 			IGrid grid = axis.getGrid();
 			grid.setForeground(axisSettings.getGridColor());

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/ITitle.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/ITitle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 SWTChart project.
+ * Copyright (c) 2008, 2026 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -95,8 +95,35 @@ public interface ITitle {
 
 	/**
 	 * Gets the visibility state.
-	 * 
+	 *
 	 * @return true if title is visible
 	 */
 	boolean isVisible();
+
+	/**
+	 * Forces the title to be rendered horizontally regardless of axis orientation.
+	 *
+	 * @param horizontalTitle
+	 *            true to render the title horizontally
+	 */
+	void setHorizontalTitle(boolean horizontalTitle);
+
+	/**
+	 * Returns whether the title is forced to render horizontally.
+	 *
+	 * @return true if the title is forced horizontal
+	 */
+	boolean isHorizontalTitle();
+
+	/**
+	 * Sets a short label that is drawn horizontally at the top of a vertical axis
+	 * in addition to the regular (rotated) axis title. Typical use: unit annotations
+	 * like "×10⁶" above the Y-axis tick labels.
+	 *
+	 * @param label
+	 *            the horizontal label text, or null/empty to disable
+	 */
+	void setHorizontalLabel(String label);
+
+	String getHorizontalLabel();
 }

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/ChartLayout.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/ChartLayout.java
@@ -516,8 +516,9 @@ public class ChartLayout extends Layout {
 		int y = titleHeight + topAxisHeight + MARGIN + ((titleHeight == 0) ? 0 : PADDING) + (legendPosition == SWT.TOP ? legendHeight + (legendHeight == 0 ? 0 : PADDING) : 0);
 		leftAxisOffset += width;
 		int height = layoutData.titleLayoutdata.heightHint;
-		int titleY = y + (plotAreaHeight - height) / 2;
+		int titleY = layoutData.axisTitle.isHorizontalTitle() ? y : y + (plotAreaHeight - height) / 2;
 		layoutData.axisTitle.setBounds(x, titleY, width, height);
+		layoutData.axisTitle.setPlotTopY(y);
 		x += width;
 		width = layoutData.tickLabelsLayoutdata.widthHint;
 		leftAxisOffset += width;
@@ -546,8 +547,9 @@ public class ChartLayout extends Layout {
 		int y = titleHeight + topAxisHeight + MARGIN + ((titleHeight == 0) ? 0 : PADDING) + (legendPosition == SWT.TOP ? legendHeight + (legendHeight == 0 ? 0 : PADDING) : 0);
 		rightAxisOffset += width;
 		int height = layoutData.titleLayoutdata.heightHint;
-		int titleY = y + (plotAreaHeight - height) / 2;
+		int titleY = layoutData.axisTitle.isHorizontalTitle() ? y : y + (plotAreaHeight - height) / 2;
 		layoutData.axisTitle.setBounds(x, titleY, width, height);
+		layoutData.axisTitle.setPlotTopY(y);
 		width = layoutData.tickLabelsLayoutdata.widthHint;
 		x -= width;
 		rightAxisOffset += width;

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/Title.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/Title.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 SWTChart project.
+ * Copyright (c) 2008, 2026 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -50,6 +50,12 @@ public class Title implements ITitle, PaintListener {
 	private StyleRange[] styleRanges;
 	/** the visibility state of axis */
 	private boolean isVisible;
+	/** forces horizontal rendering regardless of axis orientation */
+	private boolean horizontalTitle = false;
+	/** extra label drawn horizontally at the top of a vertical axis */
+	private String horizontalLabel = null;
+	/** top Y coordinate of the plot area, set by ChartLayout; -1 = not yet laid out */
+	private int plotTopY = -1;
 	/** the default font */
 	private final Font defaultFont;
 	/** the bounds of title */
@@ -206,6 +212,37 @@ public class Title implements ITitle, PaintListener {
 	}
 
 	@Override
+	public void setHorizontalTitle(boolean horizontalTitle) {
+
+		this.horizontalTitle = horizontalTitle;
+		chart.updateLayout();
+	}
+
+	@Override
+	public boolean isHorizontalTitle() {
+
+		return horizontalTitle;
+	}
+
+	@Override
+	public void setHorizontalLabel(String label) {
+
+		this.horizontalLabel = label;
+		chart.updateLayout();
+	}
+
+	@Override
+	public String getHorizontalLabel() {
+
+		return horizontalLabel;
+	}
+
+	public void setPlotTopY(int plotTopY) {
+
+		this.plotTopY = plotTopY;
+	}
+
+	@Override
 	public boolean isVisible() {
 
 		return isVisible;
@@ -246,7 +283,12 @@ public class Title implements ITitle, PaintListener {
 		if(isHorizontal()) {
 			setLayoutData(new ChartLayoutData(width, height));
 		} else {
-			setLayoutData(new ChartLayoutData(height, width));
+			int widthHint = height; // font height for the rotated title
+			if(horizontalLabel != null && !horizontalLabel.isEmpty()) {
+				Point labelSize = Util.getExtentInGC(getFont(), horizontalLabel);
+				widthHint = Math.max(widthHint, labelSize.x);
+			}
+			setLayoutData(new ChartLayoutData(widthHint, width));
 		}
 	}
 
@@ -284,17 +326,24 @@ public class Title implements ITitle, PaintListener {
 	@Override
 	public void paintControl(PaintEvent e) {
 
-		if(text == null || text.equals("") || !isVisible) { //$NON-NLS-1$
+		if(!isVisible) {
 			return;
 		}
 		Font oldFont = e.gc.getFont();
-		Color oldForeground = getForeground();
+		Color oldForeground = e.gc.getForeground();
 		e.gc.setFont(getFont());
 		e.gc.setForeground(getForeground());
-		if(isHorizontal()) {
-			drawHorizontalTitle(e.gc);
-		} else {
-			drawVerticalTitle(e.gc);
+		if(!(text == null || text.equals(""))) { //$NON-NLS-1$
+			if(isHorizontal()) {
+				drawHorizontalTitle(e.gc);
+			} else {
+				drawVerticalTitle(e.gc);
+			}
+		}
+		if(!isHorizontal() && horizontalLabel != null && !horizontalLabel.isEmpty() && plotTopY >= 0) {
+			Font labelFont = Resources.getFont(getFont().getFontData()[0].getName(), getFont().getFontData()[0].getHeight(), SWT.NORMAL);
+			e.gc.setFont(labelFont);
+			e.gc.drawText(horizontalLabel, getBounds().x, plotTopY, true);
 		}
 		e.gc.setFont(oldFont);
 		e.gc.setForeground(oldForeground);

--- a/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/AxisTitle.java
+++ b/org.eclipse.swtchart/src/org/eclipse/swtchart/internal/axis/AxisTitle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 SWTChart project.
+ * Copyright (c) 2008, 2026 SWTChart project.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -69,6 +69,6 @@ public class AxisTitle extends Title {
 	@Override
 	protected boolean isHorizontal() {
 
-		return axis.isHorizontalAxis();
+		return isHorizontalTitle() || axis.isHorizontalAxis();
 	}
 }


### PR DESCRIPTION
Instead of 4.0E6, 3.0E6, 2.0E6, which is difficult to read, this moves the shared exponent ×10⁶ to the top of the axis:

<img width="465" height="366" alt="grafik" src="https://github.com/user-attachments/assets/963c2eca-c3da-4092-9cca-aeda4fa375c7" />

